### PR TITLE
Adding Committee Decisionmaking proposal.

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -82,7 +82,7 @@ allows TOC members time to consider the matter further and receive community inp
 Votes held in a synchronus meeting require the meeting to have achieved quorum, and for the YES 
 vote count to have passed the majority criteria listed above.
 
-Votes held during a synchronus meeting must be documented transparently, including the specific votes 
+Votes held during a synchronous meeting must be documented transparently, including the specific votes 
 of each TOC member, after conclusion of the meeting in question. Limited exceptions to this transparency 
 requirement include situaions where there is a security or privacy reason for secrecy.
 


### PR DESCRIPTION
The prior art in this area is less specific than I would have liked, so this is an area to review carefully. Generally, I believe that TOC decisions should almost always be consensus. In situations where no consensus is possible, I believe that the voting should be transparent and asynchronous. In situations where a vote is synchronous, I believe that the meeting must have quorum AND that the vote must pass with the same number of YES votes as an async vote would have required. Further, synchronous votes should absolutely be shared in a transparent manner after the meeting occurred. Last - there does need to be a little bit of wiggle room on transparency for the limited situations where there is a security or privacy issue.

Fixes #15 