### PR TITLE
Remove link to old Knative notes

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -60,8 +60,7 @@ up for election the following year.
 The TOC’s work includes:
 
 - Regular committee meetings to discuss hot topics, resulting in a set of
-  published
-  [meeting notes](https://docs.google.com/document/d/1hR5ijJQjz65QkLrgEhWjv3Q86tWVxYj_9xdhQ6Y5D8Q/edit#).
+  published meeting notes.
 
 - Create, review, approve and publish technical project governance documents.
 


### PR DESCRIPTION
The existing URL points to what I believe are the old notes for the Knative TOC. We already have a placeholder link further down in this document where the eventual TOC can put its meeting notes, so I don't think we even need a link here at all.