### PR TITLE
Remove language referring to "subprojects"

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -355,8 +355,8 @@ Working Group meetings.
 Within this section "manager" refers to a member who is an Execution Lead, Tech
 Lead, Approver or Scribe. (this is different from a WG or Organization Member).
 
-- Initial managers are defined at the founding of the WG or Subproject as part
-  of the acceptance of that WG or Subproject.
+- Initial managers are defined at the founding of the WG as part of the
+  acceptance of that WG.
 - Managers SHOULD remain active and responsive in their Roles.
 - Managers MUST be community members to be eligible to hold a leadership role within a SIG.
 - Managers taking an extended leave of 1 or more months SHOULD coordinate with

--- a/TOC.md
+++ b/TOC.md
@@ -35,10 +35,6 @@ product and design decisions.
   - Establish and maintain the overall technical governance guidelines for the
     project.
 
-  - Decide which sub-projects are part of the Cloud Foundry project, including
-    accepting new sub-projects and pruning existing sub-projects to maintain
-    community focus
-
   - Ensure the team adheres to our
     [code of conduct](./CONTRIBUTING.md#code-of-conduct) and respects our
     [values](./VALUES.md).


### PR DESCRIPTION
The notion of a "subproject" is not clearly defined in the governance
rules, and based on the existing minimal usage in the ROLES document
seems to correspond to a Working Group. This change removes language
referring to subprojects in favor of consolidating on only Working
Groups as the governance structure below the TOC.

Sadly, this change will conflict with the excellent PR #60.