### PR TITLE
Remove attempt to auto-assign a team

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-to-be-elector-for-toc-election.md
+++ b/.github/ISSUE_TEMPLATE/request-to-be-elector-for-toc-election.md
@@ -3,7 +3,7 @@ name: Request to be elector for TOC election
 about: Requests for community members to be added as electors for a TOC election cycle.
 title: Request to be an elector for TOC election
 labels: election
-assignees: @cloudfoundry/toc
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Fixes #85 - We can't auto-assign a team in an issue template. We will be able to figure out a workflow that tracks all issues in this repo and maps them to whatever process is needed to resolve them.