### PR TITLE
Add member nominations for first TOC election

### DIFF
--- a/toc/CHANGEPLAN.md
+++ b/toc/CHANGEPLAN.md
@@ -32,7 +32,9 @@ eligibility to be nominated for the TOC during the first election will
 be defined as:
 
 * Community members who are PMC Leads, Project Leads or committers within 
-  any PMC or project.
+  any PMC or project. Additionally, each member organization of the CFF
+  will have an opportunity, if they desire, to nominate a candidate for the
+  first TOC election.
   
 ### Initial TOC Election Voter Eligibility
 

--- a/toc/CHANGEPLAN.md
+++ b/toc/CHANGEPLAN.md
@@ -32,8 +32,8 @@ eligibility to be nominated for the TOC during the first election will
 be defined as:
 
 * Community members who are PMC Leads, Project Leads or committers within 
-  any PMC or project. Additionally, each member organization of the CFF
-  will have an opportunity, if they desire, to nominate a candidate for the
+  any PMC or project. Each member organization of the CFF can also nominate 
+  one additional person not meeting these criteria as a candidate for the 
   first TOC election.
   
 ### Initial TOC Election Voter Eligibility


### PR DESCRIPTION
In discussion about our first election, it was identified that it might be useful for there to be an additional way for candidates to be added to the pool. One brainstorm was to allow all CFF member organizations to have the opportunity to nominate candidates. Again, first election only.