### PR TITLE
Fix: section typo in TOC Election READMEs

### DIFF
--- a/toc/elections/2021/README.md
+++ b/toc/elections/2021/README.md
@@ -4,7 +4,7 @@
 
 Each year, the CFF technical community holds an election for open seats on the 
 Technical Oversight Committee (TOC). The rules governing this election are set in the 
-[CFF's project charter](../../../governing-board/charter.md) (See section 9(b) and 9(e) 
+[CFF's project charter](../../../governing-board/charter.md) (See section 7(b) and 7(e)
 for the relevant details).
 
 This guide exists to serve as a guide to this year's election process.

--- a/toc/elections/_template/README.md
+++ b/toc/elections/_template/README.md
@@ -25,7 +25,7 @@ process itself.
 
 Each year, the CFF technical community holds an election for open seats on the 
 Technical Oversight Committee (TOC). The rules governing this election are set in the 
-[CFF's project charter](../../../governing-board/charter.md) (See section 9(b) and 9(e) 
+[CFF's project charter](../../../governing-board/charter.md) (See section 7(b) and 7(e)
 for the relevant details).
 
 This guide exists to serve as a guide to this year's election process.


### PR DESCRIPTION
The READMEs state that the relevant details for the election are in [section 9](https://github.com/cloudfoundry/community/blob/main/governing-board/charter.md#9subsidiaries-and-related-companies) of the charter, when in fact they appear to be in [section 7](https://github.com/cloudfoundry/community/blob/main/governing-board/charter.md#7technical-oversight-committee-toc).

This PR fixes the template and the 2021 READMEs.