### PR TITLE
Add stub template for Community Experience WG

### DIFF
--- a/toc/working-groups/community-experience.md
+++ b/toc/working-groups/community-experience.md
@@ -1,0 +1,29 @@
+# Community Experience: Working Group Charter
+
+## Mission
+
+Provides accessible, clear entrypoints for CF end users and contributors, including documentation and example resources.
+
+## Goals
+
+
+
+## Scope
+
+
+
+## Non-Goals
+
+
+
+
+## Proposed Membership
+
+- Technical Lead(s): TBD
+- Execution Lead(s): TBD
+- Approvers: TBD
+
+
+## Technical Assets
+
+Repositories for CF documentation websites.


### PR DESCRIPTION
TODO before merge:
* Identify leads for WG
* Identify initial goals and scope for WG
* List main technical assets for WG

This PR supersedes #144: the content is identical, but it pulls from the `wg-community-experience` branch on the CF-org community repo instead of the one on my personal fork so that the other TOC members can revise it.