### PR TITLE
Add Vulnerability Management WG

### DIFF
--- a/toc/elections/2021/results.md
+++ b/toc/elections/2021/results.md
@@ -43,4 +43,4 @@ Our TOC rules for a maximum of 2 TOC members from the same employer must be appl
 
 Eric and David were the top two nominees of the group, meaning that both of them will have the full two year TOC member term. Jan, Stephan and Lee will each have a one year term, and their seats on the TOC will be up for election again in 2022. Keep in mind that this difference in term lengths only applies to this first election. In 2022, those three TOC seats will be elected for the standard TOC member term of two years. Of course, Jan, Stephan and Lee will be more than welcome to run in 2022.
 
-Records of all cast ballots are available in [CSV format here](https://github.com/cloudfoundry/community/blob/main/toc/elections/2021/ballots.md).
+Records of all cast ballots are available in [CSV format here](https://github.com/cloudfoundry/community/blob/main/toc/elections/2021/ballots.csv).

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -6,8 +6,8 @@ Provides discreet management of security vulnerabilities issues relevant for act
 
 ## Goals
 
-* Provides a single point of contact for security vulnerability reporting and management
-* Provides management of security vulnerability reports through to resolution, including but not limited to triage, reporter and team coordination, embargo negotiation, CVSS scoring, CVE assignments, pre-disclosure and disclosure
+* Provide a single point of contact for security vulnerability reporting and management.
+* Provide management of security vulnerability reports through to resolution, including but not limited to triage, reporter and team coordination, embargo negotiation, CVSS scoring, CVE assignments, pre-disclosure and disclosure.
 
 ## Scope
 

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -1,0 +1,30 @@
+# Vulnerability Management: Working Group Charter
+
+## Mission
+
+Coordinates intake, processing, and disclosure of security reports and issues relevant for active CF projects.
+
+
+## Goals
+
+
+
+## Scope
+
+
+
+## Non-Goals
+
+
+
+
+## Proposed Membership
+
+- Technical Lead(s): TBD
+- Execution Lead(s): TBD
+- Approvers: TBD
+
+
+## Technical Assets
+
+Security process and broadcast channels for security disclosures.

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -11,12 +11,12 @@ Provides discreet management of security vulnerabilities issues relevant for act
 
 ## Scope
 
-* Triage incoming security vulnerability reports to [security@cloudfoundry.org](mailto:security@cloudfoundry.org)
-* Management of vulnerabilities through dedicated slack channels
-* When appropriate, negotiating suitable embargo periods with the reporter to afford component teams time to fix the issue before it becomes known publicly
-* When appropriate, assignment of CVE numbers to vulnerabilities/fixes
-* Publication of pre-disclosures to allow all CF editions time to adopt fixes for high/critical vulnerabilities before they become known publicly
-* Publication of disclosures
+* Triage incoming security vulnerability reports to [security@cloudfoundry.org](mailto:security@cloudfoundry.org).
+* Manage vulnerabilities through dedicated slack channels.
+* When appropriate, negotiate suitable embargo periods with the reporter to afford component teams time to fix the issue before it becomes known publicly.
+* When appropriate, assign CVE numbers to vulnerabilities/fixes.
+* Publish pre-disclosures to allow all CF distributions time to adopt fixes for high/critical vulnerabilities before they become known publicly.
+* Publish disclosures of reported security vulnerabilities.
 
 ## Non-Goals
 

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -20,7 +20,7 @@ Provides discreet management of security vulnerabilities issues relevant for act
 
 ## Non-Goals
 
-* Not adding security related features to Cloud Foundry
+* Add security-related features to Cloud Foundry projects.
 
 ## Technical Lead(s): 
 - Paul Warren

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -2,29 +2,39 @@
 
 ## Mission
 
-Coordinates intake, processing, and disclosure of security reports and issues relevant for active CF projects.
-
+Provides discreet management of security vulnerabilities issues relevant for active CF projects.
 
 ## Goals
 
-
+* Provides a single point of contact for security vulnerability reporting and management
+* Provides management of security vulnerability reports through to resolution, including but not limited to triage, reporter and team coordination, embargo negotiation, CVSS scoring, CVE assignments, pre-disclosure and disclosure
 
 ## Scope
 
-
+* Triage incoming security vulnerability reports to [security@cloudfoundry.org](mailto:security@cloudfoundry.org)
+* Management of vulnerabilities through dedicated slack channels
+* When appropriate, negotiating suitable embargo periods with the reporter to afford component teams time to fix the issue before it becomes known publicly
+* When appropriate, assignment of CVE numbers to vulnerabilities/fixes
+* Publication of pre-disclosures to allow all CF editions time to adopt fixes for high/critical vulnerabilities before they become known publicly
+* Publication of disclosures
 
 ## Non-Goals
 
+* Not adding security related features to Cloud Foundry
 
+## Technical Lead(s): 
+- Paul Warren
 
-
-## Proposed Membership
-
-- Technical Lead(s): TBD
-- Execution Lead(s): TBD
-- Approvers: TBD
-
+## Execution Lead(s):
+- Monty Ijzerman
+- Khushboo Soni
+- Matthias Essenpres 
+- Prateek Mehrotra
 
 ## Technical Assets
 
 Security process and broadcast channels for security disclosures.
+
+* [Security Advisories](https://www.cloudfoundry.org/foundryblog/security-advisory/)
+* [#security](https://cloudfoundry.slack.com/archives/C0DEQSW9W)
+* [cff-security-pre-disclosure@cloudfoundry.org](mailto:cff-security-pre-disclosure@cloudfoundry.org)

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -28,7 +28,7 @@ Provides discreet management of security vulnerabilities issues relevant for act
 ## Execution Lead(s):
 - Monty Ijzerman
 - Khushboo Soni
-- Matthias Essenpres 
+- Mathias Essenpreis 
 - Prateek Mehrotra
 
 ## Technical Assets

--- a/toc/working-groups/vulnerability-management.md
+++ b/toc/working-groups/vulnerability-management.md
@@ -28,7 +28,7 @@ Provides discreet management of security vulnerabilities issues relevant for act
 ## Execution Lead(s):
 - [Monty Ijzerman](https://github.com/ijzerman)
 - [Khushboo Soni](https://github.com/skhushboo-vm)
-- Mathias Essenpreis 
+- [Mathias Essenpreis](https://github.com/Essenpreis) 
 - [Prateek Mehrotra](https://github.com/mehrotra-prateek)
 
 ## Technical Assets


### PR DESCRIPTION
TODO before merge:
* Identify leads for WG
* Identify initial goals and scope for WG
* List main technical assets for WG

This PR supersedes #147: the content is identical, but it pulls from the `wg-vulnerability-management` branch on the CF-org community repo instead of the one on my personal fork so that the other TOC members can revise it.