### PR TITLE
Add stub template for Service Management WG

### DIFF
--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -1,0 +1,31 @@
+# Service Management: Working Group Charter
+
+## Mission
+
+Provides interfaces and frameworks for the management of services within application platforms.
+
+
+## Goals
+
+
+
+## Scope
+
+
+
+## Non-Goals
+
+
+
+
+## Proposed Membership
+
+- Technical Lead(s): TBD
+- Execution Lead(s): TBD
+- Approvers: TBD
+
+
+## Technical Assets
+
+Components from the Cloud Service Broker, Open Service Broker API, Service Fabrik, and Volume Services projects.
+

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -2,16 +2,19 @@
 
 ## Mission
 
-Provides interfaces and frameworks for the management of services within application platforms.
-
+Provides interfaces for service lifecycle within application platforms and adapters to common external service providers.
 
 ## Goals
 
-
+- Define the service extension API for cloud foundry brokered services
+- Provide a flexible adapater layer to common hyperscaler service providers
+- Mantain a set of reference volume service brokers and drivers for CF applications to mount stateful data
 
 ## Scope
-
-
+- Lead OSBAPI
+- Develop and maintain Cloud Service Brokers for AWS, Azure, and GCP
+- Maintain volume service adapters for NFS and SMB.
+- Develop and maintain ServiceFabrik, a generic BOSH-based and Docker-container-based service instance manager
 
 ## Non-Goals
 
@@ -20,12 +23,27 @@ Provides interfaces and frameworks for the management of services within applica
 
 ## Proposed Membership
 
-- Technical Lead(s): TBD
-- Execution Lead(s): TBD
-- Approvers: TBD
+- Technical Lead(s): Marcela Campo
+- Execution Lead(s): Marcela Campo
+
+## Approvers by Area
+### OSBAPI
+
+### Cloud Service Broker
+
+### Volume Service Adapters
+
+### ServiceFabrik
 
 
-## Technical Assets
+## Technical Assets by Area
 
 Components from the Cloud Service Broker, Open Service Broker API, Service Fabrik, and Volume Services projects.
 
+### OSBAPI
+
+### Cloud Service Broker
+
+### Volume Service Adapters
+
+### ServiceFabrik

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -41,9 +41,6 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 * [@dlresende](https://github.com/dlresende)
 * [@fejnartal](https://github.com/fejnartal)
-* [@gbandres98](https://github.com/gbandres98)
-* [@jimbo459](https://github.com/jimbo459)
-* [@tinygrasshopper](https://github.com/tinygrasshopper)
 * [@totherme](https://github.com/totherme)
 
 ### ServiceFabrik

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -68,12 +68,20 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 
 ### Volume Service Adapters
 
+* [existing-volume-broker](https://github.com/cloudfoundry/existingvolumebroker)
+* [goshims](https://github.com/cloudfoundry/goshims)
+* [mapfs](https://github.com/cloudfoundry/mapfs)
+* [mapfs-release](https://github.com/cloudfoundry/mapfs-release)
+* [migrate-mysql-to-credhub](https://github.com/cloudfoundry/migrate_mysql_to_credhub)
 * [nfsv3driver](https://github.com/cloudfoundry/nfsv3driver)
 * [nfsbroker](https://github.com/cloudfoundry/nfsbroker)
 * [nfs-volume-release](https://github.com/cloudfoundry/nfs-volume-release)
+* [perci-ci](https://github.com/cloudfoundry/persi-ci)
+* [service-broker-store](https://github.com/cloudfoundry/service-broker-store)
 * [smbdriver](https://github.com/cloudfoundry/smbdriver)
 * [smbbroker](https://github.com/cloudfoundry/smbbroker)
 * [smb-volume-release](https://github.com/cloudfoundry/smb-volume-release)
+* [volume-mount-options](https://github.com/cloudfoundry/volume-mount-options)
 
 ### ServiceFabrik
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -39,6 +39,13 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ### Volume Service Adapters
 
+* @dlresende
+* @fejnartal
+* @gbandres98
+* @jimbo459
+* @tinygrasshopper
+* @totherme
+
 ### ServiceFabrik
 
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -28,7 +28,7 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ## Approvers by Area
 ### OSBAPI
-* [@Samse](https://github.com/Samse)
+* [@Samze](https://github.com/Samze)
 * [@rsampaio](https://github.com/rsampaio)
 
 ### Cloud Service Broker

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -46,20 +46,20 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 ### Cloud Service Broker
 
 * [cloud-service-broker](https://github.com/cloudfoundry-incubator/cloud-service-broker)
-* [csb-azure-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-azure)
-* [csb-aws-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-aws)
-* [csb-gcp-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-gcp)
+* [csb-brokerpak-azure](https://github.com/cloudfoundry-incubator/csb-brokerpak-azure)
+* [csb-brokerpak-aws](https://github.com/cloudfoundry-incubator/csb-brokerpak-aws)
+* [csb-brokerpak-gcp](https://github.com/cloudfoundry-incubator/csb-brokerpak-gcp)
 
 ### Volume Service Adapters
 
 * [nfsv3driver](https://github.com/cloudfoundry/nfsv3driver)
 * [nfsbroker](https://github.com/cloudfoundry/nfsbroker)
-* [nfsboshrelease](https://github.com/cloudfoundry/nfs-volume-release)
+* [nfs-volume-release](https://github.com/cloudfoundry/nfs-volume-release)
 * [smbdriver](https://github.com/cloudfoundry/smbdriver)
 * [smbbroker](https://github.com/cloudfoundry/smbbroker)
-* [smbboshrelease](https://github.com/cloudfoundry/smb-volume-release)
+* [smb-volume-release](https://github.com/cloudfoundry/smb-volume-release)
 
 ### ServiceFabrik
 
-* [serviceFabrikBroker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
+* [service-fabrik-broker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
 * [service-fabrik-blueprint-app](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-app)

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -60,3 +60,6 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 * [smbboshrelease](https://github.com/cloudfoundry/smb-volume-release)
 
 ### ServiceFabrik
+
+* [serviceFabrikBroker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
+* [service-fabrik-blueprint-app](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-app)

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -48,6 +48,11 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ### ServiceFabrik
 
+* [@saud89](https://github.com/saud89)
+* [@anoopjb](https://github.com/anoopjb)
+* [@Pooja-08](https://github.com/Pooja-08) 
+* [@swati1102](https://github.com/swati1102)
+
 
 ## Technical Assets by Area
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -28,23 +28,23 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ## Approvers by Area
 ### OSBAPI
-* @Samse
-* @rsampaio
+* [@Samse](https://github.com/Samse)
+* [@rsampaio](https://github.com/rsampaio)
 
 ### Cloud Service Broker
-* @blgm
-* @FelisiaM
-* @pivotal-marcela-campo 
+* [@blgm](https://github.com/blgm)
+* [@FelisiaM](https://github.com/FelisiaM)
+* [@pivotal-marcela-campo](https://github.com/pivotal-marcela-campo) 
 
 
 ### Volume Service Adapters
 
-* @dlresende
-* @fejnartal
-* @gbandres98
-* @jimbo459
-* @tinygrasshopper
-* @totherme
+* [@dlresende](https://github.com/dlresende)
+* [@fejnartal](https://github.com/fejnartal)
+* [@gbandres98](https://github.com/gbandres98)
+* [@jimbo459](https://github.com/jimbo459)
+* [@tinygrasshopper](https://github.com/tinygrasshopper)
+* [@totherme](https://github.com/totherme)
 
 ### ServiceFabrik
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -82,3 +82,9 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 
 * [service-fabrik-broker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
 * [service-fabrik-blueprint-app](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-app)
+* [service-fabrik-boshrelease](cloudfoundry-incubator/service-fabrik-boshrelease)
+* [service-fabrik-backup-restore](cloudfoundry-incubator/service-fabrik-backup-restore)
+* [service-fabrik-blueprint-service](cloudfoundry-incubator/service-fabrik-blueprint-service)
+* [service-fabrik-blueprint-boshrelease](cloudfoundry-incubator/service-fabrik-blueprint-boshrelease)
+* [service-fabrik-cli-plugin](cloudfoundry-incubator/service-fabrik-cli-plugin)
+* [service-fabrik-lvm-volume-driver](cloudfoundry-incubator/service-fabrik-lvm-volume-driver)

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -28,8 +28,13 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ## Approvers by Area
 ### OSBAPI
+* @Samse
 
 ### Cloud Service Broker
+* @blgm
+* @FelisiaM
+* @pivotal-marcela-campo 
+
 
 ### Volume Service Adapters
 
@@ -42,6 +47,7 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 
 ### OSBAPI
 * [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker)
+* [osb-checker](https://github.com/openservicebrokerapi/osb-checker)
 
 ### Cloud Service Broker
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -23,8 +23,8 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ## Proposed Membership
 
-- Technical Lead(s): Marcela Campo
-- Execution Lead(s): Marcela Campo
+- Technical Lead(s): Marcela Campo (@pivotal-marcela-campo)
+- Execution Lead(s): Marcela Campo (@pivotal-marcela-campo)
 
 ## Approvers by Area
 ### OSBAPI

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -11,10 +11,10 @@ Provides interfaces for service lifecycle within application platforms and adapt
 - Maintain a set of reference volume service brokers and drivers for CF applications to mount stateful data.
 
 ## Scope
-- Lead OSBAPI
-- Develop and maintain Cloud Service Brokers for AWS, Azure, and GCP
+- Lead OSBAPI.
+- Develop and maintain Cloud Service Brokers for AWS, Azure, and GCP.
 - Maintain volume service adapters for NFS and SMB.
-- Develop and maintain ServiceFabrik, a generic BOSH-based and Docker-container-based service instance manager
+- Develop and maintain ServiceFabrik, a generic BOSH-based and Docker-container-based service instance manager.
 
 ## Non-Goals
 

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -6,9 +6,9 @@ Provides interfaces for service lifecycle within application platforms and adapt
 
 ## Goals
 
-- Define the service extension API for cloud foundry brokered services
-- Provide a flexible adapater layer to common hyperscaler service providers
-- Mantain a set of reference volume service brokers and drivers for CF applications to mount stateful data
+- Define the service extension API for Cloud Foundry brokered services.
+- Provide a flexible adapter layer to common hyperscaler service providers.
+- Maintain a set of reference volume service brokers and drivers for CF applications to mount stateful data.
 
 ## Scope
 - Lead OSBAPI

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -29,6 +29,7 @@ Provides interfaces for service lifecycle within application platforms and adapt
 ## Approvers by Area
 ### OSBAPI
 * @Samse
+* @rsampaio
 
 ### Cloud Service Broker
 * @blgm

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -41,9 +41,22 @@ Provides interfaces for service lifecycle within application platforms and adapt
 Components from the Cloud Service Broker, Open Service Broker API, Service Fabrik, and Volume Services projects.
 
 ### OSBAPI
+* [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker)
 
 ### Cloud Service Broker
 
+* [cloud-service-broker](https://github.com/cloudfoundry-incubator/cloud-service-broker)
+* [csb-azure-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-azure)
+* [csb-aws-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-aws)
+* [csb-gcp-brokerpak](https://github.com/cloudfoundry-incubator/csb-brokerpak-gcp)
+
 ### Volume Service Adapters
+
+* [nfsv3driver](https://github.com/cloudfoundry/nfsv3driver)
+* [nfsbroker](https://github.com/cloudfoundry/nfsbroker)
+* [nfsboshrelease](https://github.com/cloudfoundry/nfs-volume-release)
+* [smbdriver](https://github.com/cloudfoundry/smbdriver)
+* [smbbroker](https://github.com/cloudfoundry/smbbroker)
+* [smbboshrelease](https://github.com/cloudfoundry/smb-volume-release)
 
 ### ServiceFabrik

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -27,37 +27,30 @@ Provides interfaces for service lifecycle within application platforms and adapt
 - Execution Lead(s): Marcela Campo (@pivotal-marcela-campo)
 
 ## Approvers by Area
-### OSBAPI
-* [@Samze](https://github.com/Samze)
-* [@rsampaio](https://github.com/rsampaio)
-
 ### Cloud Service Broker
 * [@blgm](https://github.com/blgm)
 * [@FelisiaM](https://github.com/FelisiaM)
 * [@pivotal-marcela-campo](https://github.com/pivotal-marcela-campo) 
 
-
-### Volume Service Adapters
-
-* [@dlresende](https://github.com/dlresende)
-* [@fejnartal](https://github.com/fejnartal)
-* [@totherme](https://github.com/totherme)
+### OSBAPI
+* [@Samze](https://github.com/Samze)
+* [@rsampaio](https://github.com/rsampaio)
 
 ### ServiceFabrik
-
 * [@saud89](https://github.com/saud89)
 * [@anoopjb](https://github.com/anoopjb)
 * [@Pooja-08](https://github.com/Pooja-08) 
 * [@swati1102](https://github.com/swati1102)
 
+### Volume Service Adapters
+* [@dlresende](https://github.com/dlresende)
+* [@fejnartal](https://github.com/fejnartal)
+* [@totherme](https://github.com/totherme)
+
 
 ## Technical Assets by Area
 
 Components from the Cloud Service Broker, Open Service Broker API, Service Fabrik, and Volume Services projects.
-
-### OSBAPI
-* [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker)
-* [osb-checker](https://github.com/openservicebrokerapi/osb-checker)
 
 ### Cloud Service Broker
 
@@ -65,6 +58,23 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 * [csb-brokerpak-azure](https://github.com/cloudfoundry-incubator/csb-brokerpak-azure)
 * [csb-brokerpak-aws](https://github.com/cloudfoundry-incubator/csb-brokerpak-aws)
 * [csb-brokerpak-gcp](https://github.com/cloudfoundry-incubator/csb-brokerpak-gcp)
+
+
+### OSBAPI
+
+* [OSBAPI spec](https://github.com/openservicebrokerapi/servicebroker)
+* [osb-checker](https://github.com/openservicebrokerapi/osb-checker)
+
+### ServiceFabrik
+
+* [service-fabrik-broker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
+* [service-fabrik-blueprint-app](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-app)
+* [service-fabrik-boshrelease](cloudfoundry-incubator/service-fabrik-boshrelease)
+* [service-fabrik-backup-restore](cloudfoundry-incubator/service-fabrik-backup-restore)
+* [service-fabrik-blueprint-service](cloudfoundry-incubator/service-fabrik-blueprint-service)
+* [service-fabrik-blueprint-boshrelease](cloudfoundry-incubator/service-fabrik-blueprint-boshrelease)
+* [service-fabrik-cli-plugin](cloudfoundry-incubator/service-fabrik-cli-plugin)
+* [service-fabrik-lvm-volume-driver](cloudfoundry-incubator/service-fabrik-lvm-volume-driver)
 
 ### Volume Service Adapters
 
@@ -82,14 +92,3 @@ Components from the Cloud Service Broker, Open Service Broker API, Service Fabri
 * [smbbroker](https://github.com/cloudfoundry/smbbroker)
 * [smb-volume-release](https://github.com/cloudfoundry/smb-volume-release)
 * [volume-mount-options](https://github.com/cloudfoundry/volume-mount-options)
-
-### ServiceFabrik
-
-* [service-fabrik-broker](https://github.com/cloudfoundry-incubator/service-fabrik-broker)
-* [service-fabrik-blueprint-app](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-app)
-* [service-fabrik-boshrelease](cloudfoundry-incubator/service-fabrik-boshrelease)
-* [service-fabrik-backup-restore](cloudfoundry-incubator/service-fabrik-backup-restore)
-* [service-fabrik-blueprint-service](cloudfoundry-incubator/service-fabrik-blueprint-service)
-* [service-fabrik-blueprint-boshrelease](cloudfoundry-incubator/service-fabrik-blueprint-boshrelease)
-* [service-fabrik-cli-plugin](cloudfoundry-incubator/service-fabrik-cli-plugin)
-* [service-fabrik-lvm-volume-driver](cloudfoundry-incubator/service-fabrik-lvm-volume-driver)


### PR DESCRIPTION
TODO before merge:
* Identify leads for WG
* Identify initial goals and scope for WG
* List main technical assets for WG

This PR supersedes #146: the content is identical, but it pulls from the `wg-services-management` branch on the CF-org community repo instead of the one on my personal fork so that the other TOC members can revise it.