### PR TITLE
Remove responsibility from the WG Technical Lead role

### DIFF
--- a/toc/ROLES.md
+++ b/toc/ROLES.md
@@ -120,7 +120,6 @@ establish sub-working groups. Working groups delegate change approval to Approve
         <p>Triage incoming issues, set milestones, repo labels</p>
         <p>Roadmap alignment with top-level backlog</p>
         <p>Mentor new contributors, project members, and approvers</p>
-        <p>Succession - identifying next steps for members of the working group</p>
         <p>Responsible for technical health of their functional area</p>
     </td>
     <td>Sponsored by the technical oversight committee as documented


### PR DESCRIPTION
The responsibility "Succession - identifying next steps for members of the working group" isn't very clear and seems to be covered by triaging issues and roadmap alignment. I believe it makes sense to remove it from the table.

Authored-by: Angela Chin <angelac@vmware.com>