### PR TITLE
Add stub template for CF on Kubernetes WG

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -10,7 +10,7 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 - End-user developers can deploy their applications through the same convenient flows provided by their existing Cloud Foundry environments, using their existing clients and tools (like the `cf` CLI or the CF Java client), relying on the same (V3) API.
 - End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs, using their existing tools and clients (e.g. `kubectl`, `client-go`).
 - End-user developers can smoothly migrate their workloads from their existing Cloud Foundry environments to Cloud Foundry on Kubernetes.
-- End-user operators have an robust way to install Cloud Foundry on their Kubernetes clusters.
+- End-user operators have a robust way to install Cloud Foundry on their Kubernetes clusters.
 - End-user operators can reuse their existing Kubernetes infrastructure (e.g. networking, identity, observability) on Cloud Foundry by leveraging its integration points.
 - End-users can easily experiment with Cloud Foundry on Kubernetes by installing it on their Kubernetes clusters and having a good out-of-the-box experience.
 

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -27,7 +27,12 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 
 ## Proposed Membership
 
-Technical and Execution Lead: @gcapizzi
+Technical Leads:
+* @gcapizzi
+* @mnitchev
+
+Execution Lead:
+* @gcapizzi
 
 ### Approvers
 
@@ -40,7 +45,6 @@ Technical and Execution Lead: @gcapizzi
 * @gnovv
 * @kieron-dev
 * @matt-royal
-* @mnitchev
 * @tcdowney
 
 ## Technical Assets

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -29,7 +29,7 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 
 Technical Leads:
 * @gcapizzi
-* @mnitchev
+* @georgethebeatle
 
 Execution Lead:
 * @gcapizzi
@@ -41,10 +41,10 @@ Execution Lead:
 * @akrishna90
 * @danail-branekov
 * @davewalter
-* @georgethebeatle
 * @gnovv
 * @kieron-dev
 * @matt-royal
+* @mnitchev
 * @tcdowney
 
 ## Technical Assets

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -8,11 +8,11 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 ## Goals
 
 - End-user developers can deploy existing Cloud Foundry-compatible applications to Kubernetes-based environments using workflows that employ official Cloud Foundry clients (such as the `cf` CLI and the CF Java client) or (v3) Cloud Foundry API calls.
-- End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs using  existing Kubernetes tools and clients (such as `kubectl` and `client-go`).
+- End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs using existing Kubernetes tools and clients (such as `kubectl` and `client-go`).
 - End-user developers can smoothly migrate their workloads from their existing Cloud Foundry environments to Cloud Foundry environments on Kubernetes.
 - End-user operators can reuse their existing Kubernetes infrastructure and related integrations (for example, networking, identity, and observability) in their Cloud Foundry deployments.
 - End-users can easily try out and experiment with Cloud Foundry on Kubernetes on their own Kubernetes clusters, with a good out-of-the-box experience.
-- Vendors can base their own CF distributions on the core components of CF on K8s.
+- Vendors can base their own CF distributions on the core components of Cloud Foundry on Kubernetes.
 
 ## Scope
 

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -1,0 +1,52 @@
+# Cloud Foundry on Kubernetes: Working Group Charter
+
+## Mission
+
+Bring the ease and simplicity of the Cloud Foundry developer experience to Kubernetes.
+
+
+## Goals
+
+- End-user developers can deploy their applications through the same convenient flows provided by their existing Cloud Foundry environments, using their existing clients and tools (like the `cf` CLI or the CF Java client), relying on the same (V3) API.
+- End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs, using their existing tools and clients (e.g. `kubectl`, `client-go`).
+- End-user developers can smoothly migrate their workloads from their existing Cloud Foundry environments to Cloud Foundry on Kubernetes.
+- End-user operators have an robust way to install Cloud Foundry on their Kubernetes clusters.
+- End-user operators can reuse their existing Kubernetes infrastructure (e.g. networking, identity, observability) on Cloud Foundry by leveraging its integration points.
+- End-users can easily experiment with Cloud Foundry on Kubernetes by installing it on their Kubernetes clusters and having a good out-of-the-box experience.
+
+## Scope
+
+- Develop the necessary components to implement the Cloud Foundry experience on top of Kubernetes.
+- Provide default implementations for all integrations (e.g. networking, identity, workload execution, observability).
+- Develop a distribution of Cloud Foundry on Kubernetes that is easy to use, even without any Cloud Foundry-specific experience and works out-of-the-box.
+- Work with other Working Groups to make sure that the existing Cloud Foundry clients (e.g. the `cf` CLI, the CF Java client) work with Cloud Foundry on Kubernetes out-of-the-box.
+
+## Non-Goals
+
+- Provide full compatibility with the existing Cloud Foundry behaviour.
+
+## Proposed Membership
+
+Technical and Execution Lead: ?
+
+### Approvers
+
+* @Birdrock
+* @acosta11
+* @akrishna90
+* @danail-branekov
+* @davewalter
+* @gcapizzi
+* @georgethebeatle
+* @gnovv
+* @kieron-dev
+* @matt-royal
+* @mnitchev
+* @tcdowney
+
+## Technical Assets
+
+* https://github.com/cloudfoundry/cf-crd-explorations ???
+* https://github.com/cloudfoundry/cf-k8s-api
+* https://github.com/cloudfoundry/cf-k8s-controllers
+* https://github.com/cloudfoundry-incubator/eirini-controller

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -7,19 +7,19 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 
 ## Goals
 
-- End-user developers can deploy their applications through the same convenient flows provided by their existing Cloud Foundry environments, using their existing clients and tools (like the `cf` CLI or the CF Java client), relying on the same (V3) API.
-- End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs, using their existing tools and clients (e.g. `kubectl`, `client-go`).
-- End-user developers can smoothly migrate their workloads from their existing Cloud Foundry environments to Cloud Foundry on Kubernetes.
-- End-user operators have a robust way to install Cloud Foundry on their Kubernetes clusters.
-- End-user operators can reuse their existing Kubernetes infrastructure (e.g. networking, identity, observability) on Cloud Foundry by leveraging its integration points.
-- End-users can easily experiment with Cloud Foundry on Kubernetes by installing it on their Kubernetes clusters and having a good out-of-the-box experience.
+- End-user developers can deploy existing Cloud Foundry-compatible applications to Kubernetes-based environments using workflows that employ official Cloud Foundry clients (such as the `cf` CLI and the CF Java client) or (v3) Cloud Foundry API calls.
+- End-user developers can take advantage of Cloud Foundry via Kubernetes-native APIs using  existing Kubernetes tools and clients (such as `kubectl` and `client-go`).
+- End-user developers can smoothly migrate their workloads from their existing Cloud Foundry environments to Cloud Foundry environments on Kubernetes.
+- End-user operators can reuse their existing Kubernetes infrastructure and related integrations (for example, networking, identity, and observability) in their Cloud Foundry deployments.
+- End-users can easily try out and experiment with Cloud Foundry on Kubernetes on their own Kubernetes clusters, with a good out-of-the-box experience.
+- Vendors can base their own CF distributions on the core components of CF on K8s.
 
 ## Scope
 
 - Develop the necessary components to implement the Cloud Foundry experience on top of Kubernetes.
-- Provide default implementations for all integrations (e.g. networking, identity, workload execution, observability).
-- Develop a distribution of Cloud Foundry on Kubernetes that is easy to use, even without any Cloud Foundry-specific experience and works out-of-the-box.
-- Work with other Working Groups to make sure that the existing Cloud Foundry clients (e.g. the `cf` CLI, the CF Java client) work with Cloud Foundry on Kubernetes out-of-the-box.
+- Provide basic implementations by default for all Cloud Foundry subsystem integratios (for example, networking, identity, workload execution, and observability).
+- Develop a deployment of Cloud Foundry on Kubernetes that is easy to use out-of-the-box without any prior experience with Cloud Foundry.
+- Work with other Working Groups to make sure that existing Cloud Foundry clients (such as the `cf` CLI and the CF Java client) work with Cloud Foundry on Kubernetes out-of-the-box.
 
 ## Non-Goals
 
@@ -27,7 +27,7 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 
 ## Proposed Membership
 
-Technical and Execution Lead: ?
+Technical and Execution Lead: @gcapizzi
 
 ### Approvers
 
@@ -36,7 +36,6 @@ Technical and Execution Lead: ?
 * @akrishna90
 * @danail-branekov
 * @davewalter
-* @gcapizzi
 * @georgethebeatle
 * @gnovv
 * @kieron-dev
@@ -46,7 +45,7 @@ Technical and Execution Lead: ?
 
 ## Technical Assets
 
-* https://github.com/cloudfoundry/cf-crd-explorations ???
 * https://github.com/cloudfoundry/cf-k8s-api
 * https://github.com/cloudfoundry/cf-k8s-controllers
+* https://github.com/cloudfoundry/cf-crd-explorations
 * https://github.com/cloudfoundry-incubator/eirini-controller


### PR DESCRIPTION
This PR proposes a working group dedicated to providing the Cloud Foundry developer experience on top of Kubernetes and its ecosystem. 