### PR TITLE
Add @sethboyles to Runtime Interfaces CAPI approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -61,6 +61,7 @@ CAPI
 - @andy-paine 
 - @MerricdeLauney
 - @monamohebbi
+- @sethboyles
  
 CLI
 - @a-b 


### PR DESCRIPTION
@sweinstein22 pointed out that I overlooked @sethboyles when listing CAPI approvers in https://github.com/cloudfoundry/community/pull/141.