### PR TITLE
Added initial github org managment automation

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -1,0 +1,29 @@
+name: 'Sync Github Organization Settings'
+on:
+  push:
+    paths:
+      - 'org/*'
+      - '.github/workflows/org-management.yml'
+  schedule:
+    - cron: '*/30 * * * *'
+
+jobs:
+  peribolos:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: write token
+        run: echo "${GITHUB_TOKEN}" > token
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: peribolos
+        uses: docker://gcr.io/k8s-prow/peribolos
+        with:
+          entrypoint: /app/prow/cmd/peribolos/app.binary
+          args: |
+            --github-token-path token \
+            --config-path org/cloudfoundry.yml \
+            --fix-org \
+            --fix-org-members \
+            --fix-teams \
+            --fix-team-members

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 toc/elections/2021/private.csv
+/.secrets

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1,0 +1,6439 @@
+admins:
+- christopherclark
+- dsboulder
+- emalm
+- halliwilljustin
+- jpalmerLinuxFoundation
+- LeePorte
+- loewenstein
+- mjear
+- ramiyengar
+- rkoster
+- stephanme
+- thelinuxfoundation
+billing_email: ap@cloudfoundry.org
+company: ""
+default_repository_permission: none
+description: Cloud Foundry Foundation active projects
+email: cf-dev@lists.cloudfoundry.org
+has_organization_projects: true
+has_repository_projects: true
+location: Worldwide
+members:
+- a-b
+- a-peek4
+- a-shan
+- aaronshurley
+- ab-pivot
+- AbelHu
+- abg
+- ablease
+- abubakarm94
+- AccraZed
+- achasveachas
+- aclark801
+- aclement
+- acosta11
+- acrmp
+- acvwilson
+- addytripathi
+- adobley
+- aduffeck
+- aemengo
+- ahrtr
+- ajackson
+- akazantsau
+- akodali18
+- akrishna90
+- Albertoimpl
+- albertoleal
+- alejandra-lara
+- altonf4
+- amakhija
+- amartiro1979
+- ameowlia
+- aminjam
+- andreas-kupries
+- AndreasSchoesser
+- andrew-edgar
+- andrew-su
+- andrewedstrom
+- andy-paine
+- anEXPer
+- anfernee
+- angelachin
+- animatedmax
+- ankeesler
+- ansd
+- ansergit
+- APShirley
+- aqan213
+- aramprice
+- arjun024
+- asahil9009
+- ashvinmoro
+- atwoosnam
+- avade
+- awmartin
+- bbr-ci
+- bclozel
+- beckermarc
+- belinda-liu
+- Benjamintf1
+- benmoss
+- bepotts
+- berlin-ab
+- beyhan
+- bgandon
+- bhh1893
+- bikramnehra
+- bingosummer
+- Birdrock
+- bkeelapudi
+- blgm
+- bonzofenix
+- bosh-admin-bot
+- bosh-ci-push-pull
+- bosh-init-concourse
+- bosh-windows-ci
+- boyang9527
+- brannon
+- brayanhenao
+- BrianMMcClain
+- briannebrown
+- bruce-ricard
+- brunssen
+- bsnchan
+- bsoroushian
+- bwinter
+- C-Otto
+- caijj
+- camilalonart
+- carlo-colombo
+- ccemeraldeyes
+- ccjaimes
+- cdlliuy
+- cf-blobstore-eng
+- cf-bosh-ci-bot
+- cf-buildpacks-eng
+- cf-ci-push-pull
+- cf-cli-eng
+- cf-cli-pools
+- cf-commercial
+- cf-datadog
+- cf-diego
+- cf-final-release-election-bot
+- cf-frameworks
+- cf-frontend
+- cf-gitbot
+- cf-identity
+- cf-identity-service
+- cf-infra-bot
+- cf-log-cache-ci
+- cf-london
+- cf-pub-tools
+- cf-rabbit-bot
+- cf-rel-int-cf-for-k8s-pr-bot
+- cf-release-notes-bot
+- cf-services
+- cf-sprout
+- cf-toolsmiths
+- cf-uaa
+- cf-zapier
+- cfdocs-bot
+- cfryanr
+- chaomonica
+- christianang
+- christo4ferris
+- ChunyiLyu
+- ciriarte
+- ClaudeFaundry
+- claurence
+- cobyrne
+- cobyrne-pivot
+- colins
+- cornelius
+- cphi-vmw
+- cppforlife
+- crhntr
+- crsimmons
+- Cryogenics-CI
+- cshollingsworth
+- csterwa
+- ctlong
+- cunnie
+- cwang-pivotal
+- d
+- dalvarado
+- danail-branekov
+- danhigham
+- daniel-keeney
+- danielfor
+- DanielJonesEB
+- danyoung
+- davewalter
+- david-akhsakhalyan
+- davidcurrie
+- davidschachner
+- dbasner
+- dbuchko
+- dcorricelli
+- degaurab
+- DennisDenuto
+- derwei
+- devtdeng
+- dgolds
+- dhrapson
+- djac
+- djavos-bot
+- dlresende
+- dmikusa-pivotal
+- dmutreja
+- domdom82
+- dominicrobertsc
+- donacarr
+- dpb587-pivotal
+- dpdavis
+- dprotaso
+- dpruitt2
+- dpw
+- draganm
+- drich10
+- dsabeti
+- dsharp-pivotal
+- dsyer
+- dtillman
+- dtimm
+- duglin
+- dumez-k
+- edespino
+- edwardecook
+- edwardstudy
+- ekcasey
+- elenasharma
+- elsony
+- EngineerBetterCI
+- erabil
+- ericbottard
+- erjohnso
+- evanfarrar
+- Everlag
+- ewrenn8
+- f0rmiga
+- farmermel
+- fcioanca
+- fcohen26
+- fejnartal
+- FelisiaM
+- fg-j
+- fhanik
+- fifthposition
+- flawedmatrix
+- flintstonecf
+- FlorentFlament
+- FlorianNachtigall
+- FloThinksPi
+- ForestEckhardt
+- fredwangwang
+- friegger
+- frodenas
+- gab-satchi
+- galenhammond
+- gaowa0215
+- garden-gnome
+- GarfieldLinux
+- GarimaSharma
+- garrying
+- gbandres98
+- gcapizzi
+- gdankov
+- geofffranks
+- georgethebeatle
+- georgi-lozev
+- Gerg
+- gertd
+- gggevorgyan
+- git-narya
+- gmrodgers
+- gnovv
+- gossion
+- GowriRegistry
+- graeme-davison
+- greenhouse-ci
+- gsiener
+- gu-bin
+- harshah
+- haydonryan
+- hcf-bot
+- HeavyWombat
+- heidmotron
+- hemarsai
+- herrjulz
+- heycait
+- heyjcollins
+- hillrw3
+- hjcalderon10
+- hmanukyanVMw
+- hnandiwada
+- hoegaarden
+- hsinn0
+- hyakuhei
+- iaftab-alam
+- idoru
+- IgorBelyi
+- ihcsim
+- ilackarms
+- iplay88keys
+- jackfengibm
+- jacksoncvm
+- JacquesPerrault
+- james-masson
+- jamieklassen
+- jamiemonserrate
+- jandubois
+- jaristiz
+- jchenry
+- jdeppe-pivotal
+- jdgonzaleza
+- jeff-hobbs
+- JenGoldstrich
+- jerrybelmonte
+- jessepye
+- jgawor
+- jhvhs
+- jianqiu
+- jimbo459
+- jimmykarily
+- jkjell
+- jknostman3
+- jkonicki
+- jmarrero
+- jncd
+- jochenehret
+- joeeltgroth
+- joefitzgerald
+- joeldsa
+- joergdw
+- johncornish
+- jomsie
+- JordanICollier
+- josephgee
+- joshlong
+- jpalermo
+- jpatel-pivotal
+- jpmcb
+- jrussett
+- jsampson1
+- julian-hj
+- k-don
+- k1tm
+- KaiHofstetter
+- kaleo211
+- kartiklunkad26
+- kauana
+- KauzClay
+- kcboyle
+- KeepAustinWired
+- kejadlen
+- KeshavS0519
+- Kiemes
+- kieron-dev
+- kimago
+- kirederik
+- klakin-pivotal
+- KlapTrap
+- kmarkwardt-vmware
+- knm3000
+- kreinecke
+- kriscott
+- krook
+- ktchen14
+- ktollivervmw
+- ktpv
+- kushmerick
+- kvedurmu
+- langered
+- lbarncord
+- lenapivotal
+- lisamburns
+- LizClaireMorris
+- lnguyen
+- loganloganlogan
+- lterminasyan
+- lwoydziak
+- maheshkumarvs
+- malik-altaf
+- malston
+- mamachanko
+- Manifaust
+- manno
+- MarcPaquette
+- mariash
+- markstokan
+- markthemarkest
+- Markus-Ehrnsperger
+- martyspiewak
+- matt-royal
+- mattcui
+- mattmcneeney
+- mauromorales
+- maximilien
+- mcwumbly
+- menehune23
+- menicosia
+- MerricdeLauney
+- metatype
+- metric-store-ci
+- mfine30
+- mgibson1121
+- micahyoung
+- michaelklishin
+- miguelverissimo
+- mihaibuzgau
+- mike1808
+- MirahImage
+- mjgutermuth
+- mjj209
+- mkjelland
+- mklanjsek
+- mkocher
+- mkuratczyk
+- MMisoch
+- mnitchev
+- modelseer
+- moggibear
+- moleske
+- monadic
+- monamohebbi
+- mook-as
+- mrdavidlaing
+- mrosecrance
+- msmykowski
+- mvach
+- mvalliath
+- myeghiazarya
+- N00BEST
+- n4wei
+- nader-ziada
+- nand2
+- natalieparellano
+- navdeep-pama
+- nebhale
+- nedenwalker
+- neil-hickey
+- nguerette
+- nhsieh
+- nickjameswebb
+- nickstreet
+- nicregez
+- nierajsingh
+- nimakaviani
+- Nino-K
+- nkguy
+- nmaslarski
+- notrepo05
+- nouseforaname
+- nwmac
+- objectfox
+- ograves-pivotal
+- ohkyle
+- ojhughes
+- omerbensaadon
+- oppegard
+- OpusDude
+- ozbasarir
+- pabloarodas
+- pabloschuhmacher
+- paigecalvert
+- paltanmoy
+- paulcwarren
+- pcf-core-services
+- pcf-core-services-writer
+- pcfdev-bot
+- pcfrabbitmq-concourse-ci
+- perm-ci-bot
+- PeterEltgroth
+- petergtz
+- peterhaochen47
+- petersca
+- petewall
+- philippthun
+- phschon
+- piachakra
+- pianohacker
+- Pivotal-Christopher-Wong
+- pivotal-david-osullivan
+- pivotal-lyle-murphy
+- pivotal-marcela-campo
+- pivotal-maya-kenedy
+- pivotal-rd-admins
+- pivotal-so
+- pivotal-todd-ritchie
+- pivotalgeorge
+- pivotaljohn
+- piyalibanerjee
+- pkvatvmware
+- pnikonowicz
+- poconnor1
+- pradyutsarma
+- professor
+- Proplex
+- pspinrad
+- pubtools-docs-helper
+- pulkit-chandra
+- PureMunky
+- pvaramballypivot
+- pvtl-shane
+- pws-team-admin-client
+- pydctw
+- qibobo
+- qu1queee
+- rade
+- ragaskar
+- rahulkj
+- rainmaker
+- rajasekharatvmware
+- rajdeepd
+- ram-pivot
+- ramonskie
+- rboykin
+- reedr3
+- reneighbor
+- rhall-pivotal
+- rheaton
+- RiaMahoney
+- ricardo-vm
+- richard-cox
+- RichardJJG
+- rickfarmer
+- rizwanreza
+- rlewis24
+- rmorgan
+- rnandi
+- robdimsdale
+- robertjsullivan
+- robmee
+- rogerluo410
+- rohitsakala
+- rohitsharma04
+- romswo
+- rosenhouse
+- roshan-a
+- routing-ci
+- rroberts2222
+- rszumlakowski
+- runtime-ci
+- ryanmattcollins
+- ryanmoran
+- ryantang
+- s4heid
+- sampeinado
+- Samze
+- sanagaraj-pivotal
+- satiar
+- sbawaska
+- sboyajyan
+- schaefm-ibm
+- schubert
+- sclevine
+- scothis
+- scottfrederick
+- scottietremendous
+- sebGilR
+- selzoc
+- SenatorSupes
+- services-api-ci
+- sethboyles
+- shamus
+- Shanfan
+- shanks3012
+- silvestre
+- simonjjones
+- simonleung8
+- skibum55
+- smoser-ibm
+- snneji
+- Soha-Albaghdady
+- sophiewigmore
+- spaungam
+- spgreenberg
+- spikymonkey
+- squeedee
+- ssapra
+- ssisil
+- st3v
+- staylor14
+- stefanlay
+- StefanWutz
+- strehle
+- stuart-pollock
+- suhlig
+- sujeetv
+- sunjayBhatia
+- sunnytoolsmiths
+- suprajanarasimhan
+- suraiyasuliman
+- svennam92
+- svkrieger
+- swalner-pivotal
+- swati-nair
+- sweinstein22
+- sykesm
+- syslxg
+- tack-sap
+- tamaovmware
+- tanayk2610
+- tanglisha
+- tanzeeb
+- tarpinian
+- tas-runtime-bot
+- tcdowney
+- teddyking
+- Tejuvmware
+- tekul
+- test-12341234
+- thepeterstone
+- thisisnotashwin
+- thitch97
+- thomas1206
+- tinygrasshopper
+- TisVictress
+- tjvman
+- tmegan1
+- tom-collings
+- tomkennedy513
+- torsten-sap
+- totherme
+- tracker-common
+- trevormarshall
+- trisberg
+- troytop
+- tylerphelan
+- tylerschultz
+- valeriap
+- vgogate
+- videlov
+- vikafed
+- viovanov
+- voelzmo
+- wattersjames
+- wayneadams
+- WeiQuan0605
+- weymanf
+- willmadison
+- winnab
+- xiongli
+- xtreme-andrei-dinin
+- xtreme-bozhidar-lenchov
+- xtreme-conor-nosal
+- xtreme-debbie-chen
+- xtreme-jason-smith
+- xtreme-jesse-malone
+- xtreme-nitin-ravindran
+- xtreme-sameer-vohra
+- xtreme-vikram-yadav
+- xtremerui
+- yaelharel
+- yatzek
+- ystros
+- yyzjateen
+- zhang-hua
+- zhanggbj
+- zhangtbj
+- zhongyi-zhang
+- zrob
+- zyjiaobj
+- zzori-theoriginal
+members_can_create_repositories: false
+name: Cloud Foundry
+repos:
+  .github:
+    has_projects: true
+  CLAW:
+    description: The CF CLI download redirection web application
+    has_projects: true
+    has_wiki: false
+  admin-tools:
+    has_projects: true
+    private: true
+  api-docs:
+    default_branch: main
+    description: Cloud Controller API Docs
+    has_projects: true
+  app-autoscaler:
+    archived: true
+    default_branch: main
+    description: Auto Scaling for CF Applications
+    has_projects: true
+  app-autoscaler-ci:
+    description: The CI part of the app-autoscaler project
+    has_projects: true
+  app-autoscaler-cli-plugin:
+    default_branch: main
+    description: CF CLI Plugin for the App AutoScaler
+    has_projects: true
+  app-autoscaler-env-bbl-state:
+    default_branch: main
+    has_projects: true
+    private: true
+  app-autoscaler-release:
+    default_branch: main
+    has_projects: true
+  app-autoscaler-ui:
+    description: A UI project for the Cloud Foundry incubator app-autoscaler
+    has_projects: true
+  apt-buildpack:
+    has_projects: false
+    has_wiki: false
+  archive-expanding-cnb:
+    archived: true
+    has_projects: true
+  archiver:
+    allow_merge_commit: false
+    description: Utilities for extracting and compressing tgz and zip files.
+    has_issues: false
+    has_projects: true
+  auction:
+    allow_merge_commit: false
+    description: Auction encodes Diego's long-running-process distribution algorithm
+    has_issues: false
+    has_projects: true
+  auctioneer:
+    allow_merge_commit: false
+    description: Runs diego auctions
+    has_issues: false
+    has_projects: true
+  auth-proxy:
+    archived: true
+    has_projects: true
+  azure-application-insights-cnb:
+    archived: true
+    has_projects: true
+  backup-and-restore-sdk-release:
+    default_branch: main
+    has_projects: true
+  bbl-state-resource:
+    description: a concourse resource for manipulating bbl states
+    has_projects: true
+  bbs:
+    allow_merge_commit: false
+    description: Internal API to access the database for Diego.
+    has_issues: false
+    has_projects: true
+  benchmarkbbs:
+    allow_merge_commit: false
+    description: Diego BBS Benchmark
+    has_issues: false
+    has_projects: true
+  benchmarklocket:
+    has_projects: true
+    private: true
+  binary-builder:
+    default_branch: main
+    description: Builds binaries against the rootfs of your choice.
+    has_projects: true
+  binary-buildpack:
+    description: Deploy binaries to Cloud Foundry
+    has_projects: false
+    has_wiki: false
+  binary-buildpack-release:
+    description: BOSH release for Binary Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/binary-buildpack-release
+  bits-service-private-config:
+    has_projects: true
+    private: true
+  blackbox:
+    allow_merge_commit: false
+    default_branch: main
+    description: Forward logs from files on windows and linux.
+    has_projects: false
+    has_wiki: false
+  blobstore_url_signer:
+    description: Signed URLs, or your money back!
+    has_projects: true
+  bosh:
+    description: Cloud Foundry BOSH is an open source tool chain for release engineering,
+      deployment and lifecycle management of large scale distributed services.
+    has_projects: false
+    has_wiki: false
+    homepage: https://bosh.io
+  bosh-acceptance-tests:
+    description: ' BATs: BOSH Acceptance Tests'
+    has_projects: false
+    has_wiki: false
+  bosh-agent:
+    default_branch: main
+    description: BOSH Agent runs on each BOSH deployed VM
+    has_projects: true
+    has_wiki: false
+  bosh-agent-index:
+    has_projects: true
+  bosh-alicloud-light-stemcell-builder:
+    description: Builds light stemcells for Alibaba Cloud from a "full" bosh stemcell
+    has_projects: true
+  bosh-aws-cpi-release:
+    description: BOSH AWS CPI
+    has_projects: true
+    has_wiki: false
+  bosh-aws-light-stemcell-builder:
+    description: Builds light stemcells for AWS from a "full" bosh stemcell
+    has_projects: false
+    has_wiki: false
+  bosh-azure-cpi-ci:
+    description: BOSH Azure CPI configuration
+    has_projects: true
+    private: true
+  bosh-azure-cpi-release:
+    description: BOSH Azure CPI
+    has_projects: true
+    has_wiki: false
+  bosh-backup-and-restore-test-releases:
+    description: Test Releases for bosh-backup-and-restore
+    has_projects: true
+  bosh-bbl-ci-envs:
+    description: BOSH DNS release CI envs
+    has_projects: false
+    has_wiki: false
+    private: true
+  bosh-bootloader:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    default_branch: main
+    description: Command line utility for standing up a BOSH director on an IAAS of
+      your choice.
+    has_projects: false
+    has_wiki: false
+  bosh-cli:
+    default_branch: main
+    description: BOSH CLI v2+
+    has_projects: false
+    has_wiki: false
+  bosh-community-stemcell-ci-infra:
+    default_branch: main
+    has_projects: true
+  bosh-compile-action:
+    default_branch: main
+    has_projects: true
+  bosh-compiled-releases-index:
+    has_projects: false
+    has_wiki: false
+  bosh-cpi-certification:
+    has_projects: false
+    has_wiki: false
+  bosh-cpi-environments:
+    has_projects: true
+    has_wiki: false
+    private: true
+  bosh-cpi-go:
+    description: Library for developing BOSH CPIs in Go
+    has_projects: false
+    has_wiki: false
+  bosh-cpi-kb:
+    has_projects: true
+    private: true
+  bosh-cpi-ruby:
+    description: Library for developing BOSH CPIs in Ruby
+    has_projects: true
+    has_wiki: false
+  bosh-davcli:
+    description: Dav CLI for BOSH
+    has_projects: false
+    has_wiki: false
+  bosh-deployment:
+    description: Collection of BOSH manifests referenced by cloudfoundry/docs-bosh
+    has_projects: false
+    has_wiki: false
+  bosh-deployment-resource:
+    has_projects: true
+  bosh-disaster-recovery-acceptance-tests:
+    has_projects: true
+  bosh-dns-aliases-release:
+    description: Misc release to specify additional DNS aliases
+    has_projects: false
+    has_wiki: false
+  bosh-dns-release:
+    description: BOSH DNS release
+    has_projects: false
+    has_wiki: false
+  bosh-docker-cpi-release:
+    description: BOSH Docker CPI
+    has_projects: true
+    has_wiki: false
+  bosh-gcscli:
+    description: GCS for BOSH
+    has_projects: false
+    has_wiki: false
+  bosh-google-cpi-release:
+    description: BOSH Google CPI
+    has_projects: true
+  bosh-google-light-stemcell-builder:
+    description: Builds light stemcells for GCP from a "full" bosh stemcell
+    has_projects: false
+    has_wiki: false
+  bosh-linux-stemcell-builder:
+    default_branch: ubuntu-bionic/master
+    description: 'BOSH Ubuntu Linux stemcells '
+    has_projects: false
+    has_wiki: false
+  bosh-openstack-cpi-ci:
+    description: Concourse pipeline to update Let's encrypt certificate
+    has_projects: true
+    private: true
+  bosh-openstack-cpi-release:
+    description: BOSH OpenStack CPI
+    has_projects: true
+    has_wiki: false
+  bosh-openstack-cpi-shared:
+    has_issues: false
+    has_projects: true
+    private: true
+  bosh-s3cli:
+    description: Go CLI for S3
+    has_projects: false
+    has_wiki: false
+  bosh-softlayer-cpi-release:
+    description: An external BOSH CPI for the SoftLayer cloud written in Golang
+    has_projects: true
+  bosh-stemcell-resource:
+    archived: true
+    has_projects: true
+    private: true
+  bosh-stemcells-ci:
+    has_projects: true
+  bosh-system-metrics-forwarder-release:
+    allow_merge_commit: false
+    has_projects: true
+  bosh-system-metrics-server-release:
+    allow_merge_commit: false
+    has_projects: true
+  bosh-utils:
+    description: Generic packages extracted from bosh-agent and bosh-init
+    has_projects: false
+    has_wiki: false
+  bosh-virtualbox-cpi-release:
+    description: BOSH VirtualBox CPI
+    has_projects: false
+    has_wiki: false
+  bosh-vsphere-cpi-release:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    description: BOSH vSphere CPI
+    has_projects: false
+    has_wiki: false
+  bosh-warden-cpi-release:
+    description: BOSH Garden (used to be Warden) CPI
+    has_projects: false
+    has_wiki: false
+  bosh-windows-acceptance-tests:
+    has_projects: true
+  bosh-windows-stemcell-builder:
+    has_projects: true
+  bosh-workstation:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    description: Get your workstation setup to work on the bosh team
+    has_projects: false
+    has_wiki: false
+    private: true
+  bosh_rackspace_cpi_spike:
+    description: An experimental/unsupported/untested CPI for Rackspace
+    has_projects: true
+    private: true
+  bpm-release:
+    allow_merge_commit: false
+    description: isolated bosh jobs
+    has_projects: false
+    has_wiki: false
+  brats:
+    description: Buildpack Runtime Acceptance Tests
+    has_projects: false
+    has_wiki: false
+  bsdtar:
+    has_projects: true
+    has_wiki: false
+  build-system-cnb:
+    archived: true
+    has_projects: true
+  buildpack-acceptance-tests:
+    has_projects: false
+    has_wiki: false
+  buildpack-checklists:
+    archived: true
+    has_projects: true
+    has_wiki: false
+    private: true
+  buildpack-packager:
+    description: Buildpack Packager
+    has_projects: false
+    has_wiki: false
+  buildpackapplifecycle:
+    description: The bit that takes some bits, mashes them together with other bits,
+      and produces a new bit
+    has_projects: false
+    has_wiki: false
+  buildpacks-ci:
+    description: Concourse CI pipelines for the buildpacks team
+    has_projects: false
+    has_wiki: false
+    homepage: https://buildpacks.ci.cf-app.com
+  buildpacks-envs:
+    has_projects: false
+    has_wiki: false
+    private: true
+  buildpacks-feature-eng-ci:
+    has_projects: false
+    has_wiki: false
+  buildpacks-github-config:
+    default_branch: main
+    has_projects: false
+    has_wiki: false
+  buildpacks-style-guide:
+    archived: true
+    description: Cloud Foundry Buildpack Team's Style Guide
+    has_projects: true
+  buildpacks-workstation:
+    has_projects: true
+    private: true
+  bytefmt:
+    allow_merge_commit: false
+    description: Human readable byte formatter
+    has_issues: false
+    has_projects: true
+  cacheddownloader:
+    allow_merge_commit: false
+    description: A cached HTTP blob downloader
+    has_issues: false
+    has_projects: true
+  canibump:
+    archived: true
+    has_projects: true
+  capi-bara-tests:
+    default_branch: main
+    has_projects: true
+  capi-ci:
+    default_branch: main
+    has_projects: true
+  capi-ci-private:
+    default_branch: main
+    has_projects: true
+    private: true
+  capi-datadog:
+    has_projects: true
+    private: true
+  capi-dockerfiles:
+    default_branch: main
+    has_projects: true
+  capi-env-pool:
+    default_branch: main
+    has_projects: true
+    private: true
+  capi-integration-tests:
+    archived: true
+    default_branch: main
+    has_projects: true
+  capi-k8s-release:
+    default_branch: main
+    description: The CF API parts of cloudfoundry/cf-for-k8s
+    has_projects: true
+  capi-release:
+    default_branch: develop
+    description: Bosh Release for Cloud Controller and friends
+    has_projects: true
+  capi-team-checklists:
+    default_branch: main
+    description: Checklists and wiki for CAPI team
+    has_projects: true
+    private: true
+  capi-workspace:
+    default_branch: main
+    description: Machine setup for CAPI developers
+    has_projects: true
+  cc-api-v3-style-guide:
+    archived: true
+    description: Style Guide for Cloud Controller v3 API
+    has_projects: true
+  cc-uploader:
+    default_branch: main
+    description: CC Bridge component to enable Diego to upload files to Cloud Controller's
+      blobstore
+    has_projects: true
+  cert-injector:
+    has_projects: true
+  certauthority:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  certsplitter:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  cf-acceptance-tests:
+    default_branch: develop
+    description: CF Acceptance tests
+    has_projects: true
+  cf-app-utils-ruby:
+    description: Helper methods for ruby apps on Cloud Foundry
+    has_projects: true
+  cf-crd-explorations:
+    default_branch: main
+    has_projects: true
+  cf-deployment:
+    default_branch: main
+    description: The canonical open source deployment manifest for Cloud Foundry
+    has_projects: true
+  cf-deployment-concourse-tasks:
+    default_branch: main
+    has_projects: true
+  cf-drain-cli:
+    allow_merge_commit: false
+    default_branch: develop
+    description: CF CLI plugin to create syslog drains
+    has_projects: true
+  cf-for-k8s:
+    default_branch: develop
+    description: The open source deployment manifest for Cloud Foundry on Kubernetes
+    has_projects: true
+  cf-for-k8s-docs:
+    default_branch: main
+    has_projects: true
+  cf-for-k8s-metric-examples:
+    has_projects: true
+  cf-identity-acceptance-tests-release:
+    has_projects: true
+  cf-java-client:
+    default_branch: main
+    description: Java Client Library for Cloud Foundry
+    has_projects: false
+    has_wiki: false
+  cf-k8s-api:
+    archived: true
+    default_branch: main
+    has_projects: true
+  cf-k8s-ci:
+    default_branch: main
+    has_projects: true
+  cf-k8s-controllers:
+    default_branch: main
+    description: Cloud Foundry on Kubernetes
+    has_projects: true
+  cf-k8s-logging:
+    default_branch: main
+    has_projects: true
+  cf-k8s-logging-fluent:
+    default_branch: main
+    has_projects: true
+  cf-k8s-networking:
+    default_branch: develop
+    description: building a cloud foundry without gorouter....
+    has_projects: false
+    has_wiki: false
+  cf-k8s-networking-scaling:
+    has_projects: true
+  cf-k8s-prometheus:
+    default_branch: main
+    has_projects: true
+  cf-k8s-secrets:
+    default_branch: main
+    has_projects: true
+    private: true
+  cf-lite-ci:
+    has_projects: true
+    private: true
+  cf-mysql-ci:
+    description: Contains Concourse CI scripts and configuration we use to test cf-mysql-release
+    has_projects: true
+  cf-mysql-deployment:
+    default_branch: develop
+    has_projects: true
+  cf-mysql-release:
+    default_branch: develop
+    description: Cloud Foundry MySQL Release
+    has_projects: true
+  cf-networking-deployments:
+    archived: true
+    description: Private manifests and credentials for the Container Networking team
+    has_issues: false
+    has_projects: true
+    has_wiki: false
+    private: true
+  cf-networking-helpers:
+    allow_merge_commit: false
+    default_branch: main
+    description: Shared libraries for the CF Networking team
+    has_projects: false
+    has_wiki: false
+  cf-networking-onboarding:
+    default_branch: main
+    description: Onboarding materials for new contributors in the routing/networking
+      area of CF
+    has_projects: true
+  cf-networking-release:
+    allow_merge_commit: false
+    default_branch: develop
+    description: Container Networking for CloudFoundry
+    has_projects: true
+    has_wiki: false
+  cf-on-k8s-integration:
+    default_branch: main
+    has_projects: true
+  cf-relint-ci-semver:
+    default_branch: main
+    has_projects: true
+  cf-routing-test-helpers:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  cf-slackin:
+    has_projects: true
+    private: true
+  cf-smoke-tests:
+    default_branch: main
+    description: Smoke tests for CloudFoundry that are safe to run in a production
+      environment
+    has_projects: true
+  cf-smoke-tests-release:
+    default_branch: main
+    has_projects: true
+  cf-tcp-router:
+    allow_merge_commit: false
+    default_branch: main
+    description: TCP Router repository for Cloud Foundry
+    has_projects: true
+  cf-uaa-lib:
+    description: Ruby client APIs to access the Cloud Foundry User Account and Authentication
+      service
+    has_projects: true
+  cf-uaac:
+    has_projects: true
+  cf-volume-services-acceptance-tests:
+    has_projects: true
+  cf-volume-services-team:
+    has_projects: true
+    private: true
+  cfar-logging-acceptance-tests:
+    archived: true
+    has_projects: true
+  cfar-proposals:
+    description: Repository for Cloud Foundry Application Runtime Proposals
+    has_projects: true
+  cfcd-broker:
+    default_branch: main
+    description: This service broker to manage infrastructure as part of the Cloud
+      Foundry Certified Developer exam.
+    has_projects: true
+    private: true
+  cfcd-cert-items:
+    has_projects: true
+    private: true
+  cfcd-ci:
+    has_projects: true
+    private: true
+  cfcd-course-content:
+    has_projects: true
+    private: true
+  cfcd-dockerfile:
+    has_projects: true
+    private: true
+  cfcd-exam-info:
+    description: General CFCD-related materials
+    has_projects: true
+    private: true
+  cfcd-facts:
+    has_projects: true
+    private: true
+  cfcd-items:
+    has_projects: true
+    private: true
+  cfcd-mappings:
+    has_projects: true
+    private: true
+  cfcd-mindmaps:
+    has_projects: true
+    private: true
+  cfcd-parser:
+    has_projects: true
+    private: true
+  cfcd-prep:
+    has_projects: true
+  cfdot:
+    allow_merge_commit: false
+    description: A command-line tool to interact with a Cloud Foundry Diego deployment.
+    has_issues: false
+    has_projects: true
+  cfdreddbot:
+    archived: true
+    description: This application has been deprecated. It is no longer in use
+    has_projects: true
+    private: true
+  cff-platform-certification:
+    description: Cloud Foundry Platform Certification technical requirements. All
+      changes to the technical requirements document must be approved by the PMC Council,
+      but may be proposed by any member in good standing of the Cloud Foundry Foundation.
+    has_projects: true
+    private: true
+  cfhttp:
+    allow_merge_commit: false
+    description: Wrapper for official go http package
+    has_issues: false
+    has_projects: true
+  cflinuxfs2:
+    description: The official Cloud Foundry app container rootfs
+    has_projects: true
+  cflinuxfs2-release:
+    has_projects: true
+  cflinuxfs3:
+    default_branch: main
+    has_projects: true
+  cflinuxfs3-release:
+    default_branch: main
+    description: Cloud Foundry stack based on Ubuntu 18.04 LTS
+    has_projects: true
+  cli:
+    description: The official command line client for Cloud Foundry
+    has_projects: true
+    homepage: https://docs.cloudfoundry.org/cf-cli
+  cli-ci:
+    description: The CI repo for the CloudFoundry CLI.
+    has_projects: true
+  cli-docs-scripts:
+    has_projects: true
+    homepage: http://cli.cloudfoundry.org
+  cli-i18n:
+    description: Translations (i18n) for the CF CLI
+    has_projects: true
+    homepage: https://code.cloudfoundry.org/cli
+  cli-plugin-repo:
+    description: Public repository for community created CF CLI plugins.
+    has_projects: false
+    has_wiki: false
+    homepage: https://plugins.cloudfoundry.org
+  cli-pools:
+    description: POOLS!
+    has_projects: true
+    private: true
+  cli-private:
+    description: ssssssh! it's a secret!
+    has_projects: true
+    private: true
+  cli-workstation:
+    description: CF CLI Developer workstation setup/maintenance repository
+    has_projects: true
+    has_wiki: false
+  clock:
+    allow_merge_commit: false
+    default_branch: main
+    description: time provider & rich fake for Go
+    has_issues: false
+    has_projects: true
+  cloud_controller_ng:
+    default_branch: main
+    description: Cloud Foundry Cloud Controller
+    has_projects: true
+  cloudfoundry.github.com:
+    has_projects: true
+    private: true
+  cnb-tools:
+    archived: true
+    has_projects: true
+  cnb2cf:
+    has_projects: true
+  commandrunner:
+    has_projects: true
+  community:
+    default_branch: main
+    description: Governance and contact information for Cloud Foundry
+    has_projects: true
+    has_wiki: false
+  communitydashboard:
+    has_projects: true
+  compile-extensions:
+    description: Bash library which provides extra functions and overrides for Cloud
+      Foundry Buildpack compile scripts.
+    has_projects: false
+    has_wiki: false
+  config-server:
+    description: Example config server that integrates with BOSH Director
+    has_projects: false
+    has_wiki: false
+  config-server-release:
+    description: Example BOSH release for config server
+    has_projects: true
+    homepage: https://github.com/cloudfoundry/config-server
+  consuladapter:
+    allow_merge_commit: false
+    description: Consul client adapter and test cluster runner
+    has_issues: false
+    has_projects: true
+  core-deps-ci:
+    default_branch: main
+    has_projects: false
+    has_wiki: false
+  cpu-entitlement-admin-plugin:
+    has_projects: true
+  cpu-entitlement-plugin:
+    has_projects: true
+  credhub:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    default_branch: main
+    description: CredHub centralizes and secures credential generation, storage, lifecycle
+      management, and access
+    has_projects: true
+    has_wiki: false
+  credhub-acceptance-tests:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    default_branch: main
+    description: This repo provides acceptance tests for CredHub
+    has_projects: true
+    has_wiki: false
+  credhub-api-site:
+    default_branch: main
+    description: CredHub API documentation site - credhub-api.cfapps.io
+    has_projects: false
+    has_wiki: false
+  credhub-ci-locks:
+    has_projects: true
+  credhub-cli:
+    default_branch: main
+    description: CredHub CLI provides a command line interface to interact with CredHub
+      servers
+    has_projects: true
+  credhub-perf-release:
+    has_projects: true
+  dagger:
+    has_projects: true
+  debug-cnb:
+    archived: true
+    has_projects: true
+  debugserver:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  delayed_job_sequel:
+    description: Sequel backend for Delayed Job
+    has_issues: false
+    has_projects: true
+  deployments-diego:
+    allow_merge_commit: false
+    description: Configuration files for deployments owned and managed by the CF Diego
+      team.
+    has_projects: true
+    private: true
+  deployments-loggregator:
+    allow_merge_commit: false
+    archived: true
+    has_projects: true
+    private: true
+  deployments-routing:
+    archived: true
+    has_issues: false
+    has_projects: false
+    has_wiki: false
+    private: true
+  dev-cert:
+    description: CF Developer Certification Exam - Private to all that have signed
+      agreement
+    has_projects: true
+    private: true
+  dev-cert-grading:
+    description: Grading code developed by the Biarca team and to be reviewed by Item
+      Writers
+    has_projects: true
+    private: true
+  developer-training-class-apps:
+    description: Public repo making apps that are used for the developer training
+      course available to students
+    has_projects: true
+  developer-training-class-site:
+    has_projects: true
+  developer-training-course:
+    has_projects: true
+    private: true
+  developer-training-hugo-parser:
+    has_projects: true
+    private: true
+  diego-acceptance:
+    allow_merge_commit: false
+    description: Diego PM acceptance notes and tools
+    has_projects: true
+    private: true
+  diego-checkman:
+    has_projects: true
+    private: true
+  diego-ci:
+    allow_merge_commit: false
+    description: Scripts and tools to run Diego's CI builds on Concourse.
+    has_projects: true
+  diego-ci-pools:
+    allow_merge_commit: false
+    description: Lock pools for Diego CI
+    has_projects: true
+  diego-design-notes:
+    description: Diego Architectural Design Musings and Explications
+    has_projects: true
+  diego-dockerfiles:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: false
+    has_wiki: false
+  diego-logging-client:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  diego-notes:
+    allow_merge_commit: false
+    description: Diego Notes
+    has_projects: true
+  diego-perf-release:
+    description: Used to deploy multiple app-pushers and fezzik-runners for performance-testing
+      a Diego(+Runtime) deployment
+    has_projects: true
+  diego-release:
+    allow_merge_commit: false
+    default_branch: develop
+    description: BOSH Release for Diego
+    has_projects: true
+  diego-ssh:
+    allow_merge_commit: false
+    description: Access Diego containers with ssh
+    has_issues: false
+    has_projects: true
+  diego-stress-tests:
+    description: Diego Stress Tests
+    has_projects: true
+  diego-team:
+    allow_merge_commit: false
+    description: Checklists for the Diego team
+    has_projects: true
+    private: true
+  diego-upgrade-stability-tests:
+    allow_merge_commit: false
+    archived: true
+    has_issues: false
+    has_projects: true
+  diego-windows-release:
+    has_projects: true
+  diegocanaryapp:
+    description: Simple canary app to test long-running Diego deployments
+    has_projects: true
+  diff-exporter:
+    default_branch: develop
+    has_projects: true
+  disaster-recovery-acceptance-tests:
+    default_branch: main
+    description: Acceptance tests for disaster recovery of Cloud Foundry
+    has_projects: true
+  dist-zip-cnb:
+    archived: true
+    has_projects: true
+  docker_driver_integration_tests:
+    has_projects: true
+  dockerapplifecycle:
+    allow_merge_commit: false
+    description: Code that runs inside of containers, for docker-based apps
+    has_projects: true
+  dockerdriver:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  docs-bbr:
+    has_projects: true
+  docs-book-cloudfoundry:
+    description: The bookbinder repository for open source Cloud Foundry documentation
+    has_projects: true
+  docs-bosh:
+    description: The docs repo for BOSH
+    has_projects: false
+    has_wiki: false
+  docs-buildpacks:
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  docs-cf-admin:
+    description: A place to put documentation about how to operate your Cloud Foundry
+      deployment using the command line tools bosh and cf
+    has_projects: true
+  docs-cf-cli:
+    has_projects: true
+  docs-cfcr:
+    description: This repo contains the content for the CFCR documentation.
+    has_projects: true
+    homepage: https://docs.cloudfoundry.org/cfcr
+  docs-cloudfoundry-concepts:
+    description: A place for architecture and concept docs
+    has_projects: true
+  docs-credhub:
+    has_projects: true
+  docs-deploying-cf:
+    description: The docs repo for material on deploying Cloud Foundry
+    has_projects: true
+  docs-dev-guide:
+    description: Documentation for application developers who want to deploy their
+      applications to Cloud Foundry
+    has_projects: true
+  docs-dotnet-core-tutorial:
+    has_projects: true
+  docs-loggregator:
+    has_projects: true
+  docs-routing:
+    has_projects: true
+  docs-running-cf:
+    description: A place for docs related to running, monitoring, and troubleshooting
+      a Cloud Foundry deployment
+    has_projects: true
+  docs-services:
+    description: Documentation on extending Cloud Foundry
+    has_projects: true
+  docs-uaa:
+    has_projects: true
+  dontpanic:
+    description: system data collector for disaster-struck garden vms
+    has_projects: true
+  dotnet-core-buildpack:
+    description: Cloud Foundry buildpack for .NET Core on Linux
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  dotnet-core-buildpack-release:
+    description: BOSH release for .NET Core Buildpack
+    has_projects: false
+    has_wiki: false
+  dotnet-core-cnb:
+    archived: true
+    has_projects: true
+  dropsonde:
+    description: Go library to collect and emit metric and logging data from CF components.
+    has_projects: true
+  dropsonde-protocol:
+    description: Protobuf protocol for dropsonde
+    has_projects: true
+  dropsonde-protocol-js:
+    has_projects: true
+  durandal-env:
+    archived: true
+    has_projects: true
+    private: true
+  durationjson:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  ecrhelper:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  eirini-private-config:
+    has_projects: false
+    private: true
+  etcd:
+    description: A highly-available key value store for shared configuration and service
+      discovery
+    has_issues: false
+    has_projects: true
+    has_wiki: false
+    homepage: http://coreos.com/docs/etcd/
+  event-log-release:
+    has_projects: true
+  eventhub:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  example-sidecar-buildpack:
+    has_projects: true
+  executor:
+    allow_merge_commit: false
+    description: thy will be done
+    has_issues: false
+    has_projects: true
+  exemplar-backup-and-restore-release:
+    description: Example release for with backup and restore scripts for bbr
+    has_projects: true
+  exemplar-release:
+    has_projects: true
+  existingvolumebroker:
+    has_projects: true
+  filelock:
+    has_projects: true
+  fileserver:
+    allow_merge_commit: false
+    description: 'Bob Loblaw''s file server '
+    has_issues: false
+    has_projects: true
+  flintstone:
+    description: Store pipeline credentials and templates.
+    has_projects: true
+    private: true
+  fluent-plugin-syslog_rfc5424:
+    default_branch: main
+    has_projects: true
+  fluentbit-loggr-plugin:
+    archived: true
+    description: output plugin for Fluent Bit to send logs to Loggregator
+    has_projects: true
+  foundation:
+    description: Foundation Charter Documents
+    has_projects: true
+    private: true
+  galera-init:
+    description: Monit ctl script for MariaDB in cf-mysql-release
+    has_projects: true
+  garden:
+    description: Go Warden
+    has_projects: true
+  garden-ci:
+    has_projects: true
+    private: true
+  garden-ci-artifacts-release:
+    has_projects: true
+  garden-dockerfiles:
+    has_projects: true
+  garden-dotfiles:
+    has_projects: true
+  garden-dotfiles-archived:
+    has_projects: true
+    private: true
+  garden-integration-tests:
+    description: gits
+    has_projects: true
+  garden-performance-acceptance-tests:
+    has_projects: true
+  garden-runc-release:
+    default_branch: develop
+    has_projects: true
+  garden-wiki:
+    description: Wiki and checklists for the London Garden team
+    has_projects: true
+    private: true
+  garden-windows-ci:
+    has_projects: true
+  git-release-notes:
+    has_projects: true
+  go-batching:
+    description: Batching implements a generic batcher that can be specialized.
+    has_projects: true
+  go-buildpack:
+    description: Cloud Foundry buildpack for the Go Language
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  go-buildpack-release:
+    description: BOSH release for Go Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/go-buildpack-release
+  go-cf-api:
+    default_branch: main
+    has_projects: true
+  go-cf-api-release:
+    default_branch: main
+    has_projects: true
+  go-cnb:
+    archived: true
+    has_projects: true
+  go-diodes:
+    description: Diodes are ring buffers manipulated via atomics.
+    has_projects: true
+  go-envstruct:
+    description: envstruct is a simple library for populating values on structs from
+      environment variables.
+    has_projects: true
+  go-fetcher:
+    has_projects: true
+  go-git-resource:
+    has_projects: true
+  go-log-cache:
+    allow_merge_commit: false
+    has_projects: true
+  go-loggregator:
+    allow_merge_commit: false
+    description: Go Client Library for Loggregator
+    has_projects: true
+  go-metric-registry:
+    allow_merge_commit: false
+    has_projects: true
+  go-pubsub:
+    description: Tree based pubsub library for Go.
+    has_projects: true
+  go-socks5:
+    description: SOCKS5 server in Golang
+    has_issues: false
+    has_projects: true
+  gofileutils:
+    description: A collection of go packages to simplify working with files.
+    has_projects: true
+    has_wiki: false
+  google-stackdriver-cnb:
+    archived: true
+    has_projects: true
+  gorouter:
+    allow_merge_commit: false
+    default_branch: main
+    description: CF Router
+    has_projects: true
+    has_wiki: false
+  goshims:
+    description: generated real/fake os shim objects for tdd in go
+    has_projects: true
+  gosigar:
+    description: A Golang implementation of the Sigar API
+    has_projects: true
+    has_wiki: false
+  gosteno:
+    has_projects: true
+    has_wiki: false
+  grace:
+    has_projects: true
+  groot:
+    has_projects: true
+    has_wiki: false
+  groot-windows:
+    default_branch: develop
+    description: A Garden image plugin for Windows
+    has_projects: true
+    has_wiki: false
+  grootfs:
+    description: Garden root file system
+    has_projects: true
+  grootfs-ci-secrets:
+    has_projects: true
+    private: true
+  guardian:
+    description: containers4life
+    has_projects: true
+  haproxy-boshrelease:
+    description: A BOSH release for haproxy (based on cf-release's haproxy job)
+    has_projects: true
+  healthcheck:
+    allow_merge_commit: false
+    description: Common healthcheck for buildpacks and docker
+    has_issues: false
+    has_projects: true
+  homebrew-tap:
+    description: Cloud Foundry Homebrew packages
+    has_projects: true
+    has_wiki: false
+  honeycomb-ginkgo-reporter:
+    has_projects: true
+  hwc:
+    has_projects: true
+    has_wiki: false
+  hwc-buildpack:
+    description: Cloud Foundry buildpack for Hosted Web Core
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  hwc-buildpack-release:
+    has_projects: false
+    has_wiki: false
+  hydrator:
+    default_branch: develop
+    has_projects: true
+  ibm-websphere-liberty-buildpack:
+    description: IBM WebSphere Application Server Liberty Buildpack
+    has_projects: true
+  identity-ci:
+    description: where everything else lives
+    has_projects: true
+    private: true
+  identity-tools:
+    description: 'Cloud Foundry - the open platform as a service project '
+    has_projects: true
+    has_wiki: false
+  idmapper:
+    has_projects: true
+  infrastructure-ci-bbl-states:
+    has_projects: true
+    private: true
+  infrastructure-ci-deployment-locks:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    has_issues: false
+    has_projects: false
+    has_wiki: false
+    private: true
+  inigo:
+    allow_merge_commit: false
+    description: diego integration tests
+    has_issues: false
+    has_projects: true
+  istio-scaling:
+    has_projects: false
+    has_wiki: false
+  istio-scriptio:
+    has_projects: true
+  java-buildpack:
+    default_branch: main
+    description: Cloud Foundry buildpack for running Java applications
+    has_projects: true
+  java-buildpack-auto-reconfiguration:
+    default_branch: main
+    description: Auto-reconfiguration functionality for the Java Buildpack
+    has_projects: true
+    has_wiki: false
+  java-buildpack-client-certificate-mapper:
+    default_branch: main
+    has_projects: true
+  java-buildpack-container-certificate-trust-store:
+    has_projects: true
+  java-buildpack-container-customizer:
+    default_branch: main
+    has_projects: true
+  java-buildpack-dependency-builder:
+    default_branch: main
+    description: Automated building and publication of Java Buildpack dependency artifacts
+    has_projects: true
+  java-buildpack-memory-calculator:
+    default_branch: main
+    description: Cloud Foundry JVM Memory Calculator
+    has_projects: true
+  java-buildpack-metric-writer:
+    default_branch: main
+    has_projects: true
+  java-buildpack-release:
+    description: BOSH release for Java Buildpack
+    has_projects: true
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/java-buildpack-release
+  java-buildpack-security-provider:
+    default_branch: main
+    has_projects: true
+  java-buildpack-support:
+    default_branch: main
+    description: Supporting functionality for the Java Buildpack
+    has_projects: true
+  java-buildpack-system-test:
+    default_branch: main
+    description: System tests for the Java Buildpack
+    has_projects: true
+  java-cnb:
+    archived: true
+    has_projects: true
+  java-test-applications:
+    default_branch: main
+    description: Applications used for testing the Java buildpack
+    has_projects: true
+  jdbc-cnb:
+    archived: true
+    has_projects: true
+  jmx-cnb:
+    archived: true
+    has_projects: true
+  jsonry:
+    allow_merge_commit: false
+    default_branch: main
+    description: A Go library and notation for converting between a Go struct and
+      JSON
+    has_projects: false
+    has_wiki: false
+    homepage: https://pkg.go.dev/code.cloudfoundry.org/jsonry?tab=doc
+  jumpbox-deployment:
+    description: Deploy single vanilla jumpbox machine with BOSH
+    has_projects: false
+    has_wiki: false
+  jvm-application-cnb:
+    archived: true
+    has_projects: true
+  jvmkill:
+    default_branch: main
+    description: Terminate the JVM when resources are exhausted
+    has_projects: true
+    has_wiki: false
+  lager:
+    allow_merge_commit: false
+    description: An opinionated logger for Go.
+    has_projects: true
+  lamb-ci-tools:
+    has_projects: true
+    private: true
+  lds:
+    has_projects: true
+    private: true
+  leadership-election:
+    archived: true
+    has_projects: true
+  leadership-election-release:
+    archived: true
+    default_branch: develop
+    description: 'Archived: Now a part of https://github.com/cloudfoundry/system-metrics-release'
+    has_projects: true
+  leela-env:
+    archived: true
+    has_projects: true
+    private: true
+  lf-elearning:
+    default_branch: main
+    has_projects: true
+    private: true
+  libbuildpack:
+    description: A library for writing buildpacks
+    has_projects: false
+    has_wiki: false
+  libcfbuildpack:
+    archived: true
+    has_projects: true
+  localdriver:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  localip:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  locket:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  log-cache:
+    archived: true
+    description: 'Archived: Now bundled in https://github.com/cloudfoundry/log-cache-release'
+    has_projects: true
+  log-cache-acceptance-tests:
+    archived: true
+    has_projects: true
+  log-cache-acceptance-tests-release:
+    archived: true
+    has_projects: true
+  log-cache-ci:
+    archived: true
+    has_projects: true
+  log-cache-cli:
+    allow_merge_commit: false
+    default_branch: develop
+    has_projects: false
+    has_wiki: false
+  log-cache-deployments:
+    has_projects: true
+    private: true
+  log-cache-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: The BOSH release for Log Cache
+    has_projects: true
+  log-stream-cli:
+    default_branch: develop
+    description: Cloud Foundry CLI plugin to consume logs and metrics from the RLP
+    has_projects: true
+  logging-acceptance-tests:
+    archived: true
+    description: Acceptance tests for Loggregator
+    has_projects: true
+  logging-acceptance-tests-release:
+    archived: true
+    has_projects: true
+  logging-deployment:
+    has_projects: true
+    private: true
+  loggregator:
+    archived: true
+    description: 'Archived: Now bundled in https://github.com/cloudfoundry/loggregator-release'
+    has_projects: true
+  loggregator-agent:
+    archived: true
+    description: 'Archived: Now bundled in https://github.com/cloudfoundry/loggregator-agent-release'
+    has_projects: true
+  loggregator-agent-release:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  loggregator-api:
+    allow_merge_commit: false
+    has_projects: true
+  loggregator-ci:
+    archived: true
+    has_projects: true
+  loggregator-ci-old:
+    description: Concourse pipeline and scripts for loggregator
+    has_projects: true
+    private: true
+  loggregator-credentials:
+    has_projects: true
+    private: true
+  loggregator-dotfiles:
+    has_projects: true
+  loggregator-rampup:
+    description: Ramp up for new Loggregator team members
+    has_projects: true
+    private: true
+  loggregator-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: Cloud Native Logging
+    has_projects: true
+  loggregator_emitter:
+    archived: true
+    has_projects: true
+  logos:
+    description: stores CF logos
+    has_projects: true
+  machete:
+    archived: true
+    description: Cloud Foundry library for maintaining on-premises buildpacks
+    has_projects: true
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  mapfs:
+    has_projects: true
+  mapfs-release:
+    description: BOSH release with mapfs, allows uid/gid mapping at the path
+    has_projects: true
+  membrane:
+    has_projects: true
+    has_wiki: false
+  metric-proxy:
+    default_branch: main
+    description: Translates Kubelet metrics into the log-cache API
+    has_projects: true
+  metric-store-ci:
+    has_projects: true
+  metric-store-deployments:
+    has_projects: true
+    private: true
+  metric-store-dotfiles:
+    has_projects: true
+  metric-store-rampup:
+    has_projects: true
+    private: true
+  metric-store-release:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    default_branch: develop
+    description: 'Metric Store: A Cloud-Native Time Series Database for Cloud Foundry'
+    has_projects: true
+  metrics-discovery-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: BOSH Release to discovery Prometheus-formatted metric endpoints in
+      Cloud Foundry
+    has_projects: true
+  migrate_mysql_to_credhub:
+    description: A go tool to migrate broker data from mysql to credhub
+    has_projects: true
+  minimal-env:
+    has_projects: true
+    private: true
+  multierror:
+    has_projects: true
+  mysql-backup-release:
+    has_projects: true
+  mysql-monitoring-release:
+    has_projects: true
+  nats-release:
+    allow_merge_commit: false
+    default_branch: develop
+    has_projects: true
+  netplugin-shim:
+    has_projects: true
+  networking-oss-deployments:
+    allow_merge_commit: false
+    default_branch: main
+    description: bbl state store for networking oss deployments
+    has_projects: true
+    private: true
+  networking-program-checklists:
+    has_projects: true
+    private: true
+  networking-workspace:
+    description: Machine setup for Cloud Foundry Networking team
+    has_projects: true
+  nfs-volume-release:
+    has_projects: true
+  nfsbroker:
+    has_projects: true
+  nfsv3driver:
+    has_projects: true
+  nginx-buildpack:
+    description: Cloud Foundry buildpack that provides NGINX
+    has_projects: false
+    has_wiki: false
+  nginx-buildpack-release:
+    has_projects: false
+    has_wiki: false
+  nicky:
+    has_projects: true
+    private: true
+  noaa:
+    description: NOAA is a client library to consume metric and log messages from
+      Doppler.
+    has_projects: true
+  nodejs-buildpack:
+    description: Cloud Foundry buildpack for Node.js
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  nodejs-buildpack-release:
+    description: BOSH release for Node.js Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/nodejs-buildpack-release
+  nodejs-cnb:
+    archived: true
+    has_projects: true
+  nodejs-compat-cnb:
+    archived: true
+    has_projects: true
+  noisy-neighbor-nozzle:
+    allow_merge_commit: false
+    archived: true
+    description: A nozzle and CLI tool for identifying high volume log producing applications
+    has_projects: true
+  omniauth-uaa-oauth2:
+    has_projects: true
+  open-source-licenses:
+    has_projects: true
+    private: true
+  openjdk-cnb:
+    archived: true
+    has_projects: true
+  operationq:
+    allow_merge_commit: false
+    description: processes multiple queues in parallel
+    has_issues: false
+    has_projects: true
+  os-conf-release:
+    description: Additional Linux OS configuration release
+    has_projects: false
+    has_wiki: false
+  oss-s3-buckets-stack:
+    has_projects: true
+    private: true
+  oss-summit-class:
+    description: 'Lab assets for Cloud Foundry class at Open Source Summit ''18 in
+      Vancouver '
+    has_projects: true
+  overview-broker:
+    allow_merge_commit: false
+    description: A service broker that provides an overview of its service instances
+      and bindings. Conforms to the Open Service Broker API standard.
+    has_projects: true
+  persi-ci:
+    has_projects: true
+  persistence-load-tests:
+    has_projects: true
+    private: true
+  php-buildpack:
+    description: A Cloud Foundry Buildpack for PHP.
+    has_projects: false
+    has_wiki: false
+  php-buildpack-release:
+    description: BOSH release for PHP Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/php-buildpack-release
+  php-cnb:
+    archived: true
+    has_projects: true
+  php-compat-cnb:
+    archived: true
+    has_projects: true
+  pip-pop:
+    has_projects: true
+  platform-certification:
+    description: 'Tooling for eventual use in CF platform certification '
+    has_projects: true
+    private: true
+  pmc-notes:
+    description: Agendas and Notes for Cloud Foundry Project Management Committee
+      Meetings
+    has_projects: true
+  policy_client:
+    description: Policy Client allows Cloud Foundry system components to query the
+      policy server for policies
+    has_projects: true
+  postgres-ci-env:
+    has_projects: true
+    private: true
+  postgres-release:
+    default_branch: develop
+    description: BOSH release for PostgreSQL
+    has_projects: true
+  procfile-cnb:
+    archived: true
+    has_projects: true
+  public-buildpacks-ci-robots:
+    default_branch: main
+    has_projects: false
+    has_wiki: false
+  pxc-release:
+    description: 'BOSH release of Percona Xtradb Cluster '
+    has_projects: true
+  python-buildpack:
+    description: Cloud Foundry buildpack for the Python Language
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  python-buildpack-release:
+    description: BOSH release for Python Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/python-buildpack-release
+  python-cnb:
+    archived: true
+    has_projects: true
+  python-compat-cnb:
+    archived: true
+    has_projects: true
+  quarks-private:
+    description: Private repo for Quarks team secrets
+    has_projects: true
+    private: true
+  r-buildpack:
+    description: Cloud Foundry buildpack for R
+    has_projects: false
+    has_wiki: false
+  r-buildpack-release:
+    has_projects: false
+    has_wiki: false
+  rbenv-cookbook:
+    description: Installs and configures rbenv
+    has_issues: false
+    has_projects: true
+    homepage: http://community.opscode.com/cookbooks/rbenv
+  relint-ci-pools:
+    default_branch: main
+    has_projects: true
+  relint-envs:
+    default_branch: main
+    description: Release Integration team "bbl" environments
+    has_projects: true
+    private: true
+  relint-team:
+    default_branch: main
+    description: Release Integration Team
+    has_projects: true
+    homepage: https://github.com/cloudfoundry/relint-team/wiki
+    private: true
+  relogger:
+    has_projects: true
+    private: true
+  rep:
+    allow_merge_commit: false
+    description: Representative bids on tasks and schedules them on an associated
+      Executor
+    has_issues: false
+    has_projects: true
+  resolvconf-manager:
+    has_projects: true
+  resolvconf-manager-index:
+    has_projects: true
+  route-emitter:
+    allow_merge_commit: false
+    description: Registers and unregisters processes running on executors with the
+      gorouter
+    has_issues: false
+    has_projects: true
+  route-registrar:
+    allow_merge_commit: false
+    default_branch: main
+    description: A standalone executable written in golang that continuously broadcasts
+      a route using NATS to the CF router.
+    has_projects: true
+  routing-acceptance-tests:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  routing-api:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: false
+    has_wiki: false
+  routing-api-cli:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  routing-ci:
+    has_projects: true
+  routing-datadog-config:
+    has_projects: true
+    private: true
+  routing-info:
+    allow_merge_commit: false
+    default_branch: main
+    description: Routing information helpers for CF / Diego
+    has_projects: true
+  routing-perf-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: A BOSH release for routing performance tests
+    has_projects: false
+    has_wiki: false
+  routing-release:
+    allow_merge_commit: false
+    default_branch: develop
+    description: This is the BOSH release for cloud foundry routers
+    has_projects: true
+  routing-sample-apps:
+    allow_merge_commit: false
+    allow_squash_merge: false
+    has_projects: false
+    has_wiki: false
+  routing-team-checklists:
+    description: A Repository for the CF Routing Team checklists and Wiki
+    has_projects: true
+    private: true
+  ruby-buildpack:
+    description: Cloud Foundry buildpack for Ruby, Sinatra and Rails
+    has_projects: false
+    has_wiki: false
+    homepage: http://docs.cloudfoundry.org/buildpacks/
+  ruby-buildpack-release:
+    description: BOSH release for Ruby Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/ruby-buildpack-release
+  runtime-ci:
+    default_branch: main
+    has_projects: true
+  runtime-credentials:
+    has_projects: true
+    private: true
+  runtime-og-ci:
+    has_projects: true
+  runtime-og-ci-private:
+    has_projects: true
+    private: true
+  runtime-team-checklists:
+    has_projects: true
+    private: true
+  runtime1-env:
+    has_projects: true
+    private: true
+  runtimeschema:
+    description: Shared golang schema for runtime
+    has_projects: true
+  sample-http-app:
+    has_projects: true
+  sample-service-metrics-release:
+    has_projects: true
+    private: true
+  sample-windows-bosh-release:
+    has_projects: true
+    has_wiki: false
+  sapi-env-pool:
+    has_projects: true
+    private: true
+  secure-credentials-broker:
+    has_projects: true
+  security-notices:
+    has_projects: true
+    private: true
+  service-broker-store:
+    has_projects: true
+  service-logs-release:
+    archived: true
+    default_branch: develop
+    description: Bosh job to forward logs from syslog files to Loggregator
+    has_projects: true
+  service-metrics:
+    archived: true
+    description: Send Metrics to Cloud Foundry's Loggregator system
+    has_issues: false
+    has_projects: true
+    homepage: https://docs.pivotal.io/svc-sdk/service-metrics
+  service-metrics-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: 'Service Metrics BOSH Release '
+    has_projects: true
+    homepage: https://docs.pivotal.io/svc-sdk/service-metrics
+  services-api-home:
+    archived: true
+    has_projects: true
+    private: true
+  services-api-meta:
+    archived: true
+    has_projects: true
+    private: true
+  silk:
+    allow_merge_commit: false
+    default_branch: main
+    description: a network fabric for containers.  inspired by flannel, designed for
+      Cloud Foundry.
+    has_projects: true
+  silk-release:
+    allow_merge_commit: false
+    default_branch: develop
+    description: Silk - CNI plugin BOSH release for Cloud Foundry
+    has_projects: true
+  sipid:
+    has_projects: true
+  slack-interrupt-bot:
+    has_projects: false
+    has_wiki: false
+  smb-volume-release:
+    description: BOSH release with SMB driver and broker
+    has_projects: true
+  smbbroker:
+    has_projects: true
+  smbdriver:
+    has_projects: true
+  socks5-proxy:
+    default_branch: main
+    description: This is a go library for starting a socks5 proxy server via SSH
+    has_projects: true
+    homepage: https://cloudfoundry.org
+  sonde-go:
+    description: Go implementation of Cloud Foundry's Dropsonde Protocol
+    has_projects: true
+  spring-auto-reconfiguration-cnb:
+    archived: true
+    has_projects: true
+  spring-boot-cnb:
+    archived: true
+    has_projects: true
+  stack-auditor:
+    description: Stack Auditor is a cf CLI plugin that provides commands for listing
+      apps and their stacks, migrating apps to a new stack, and deleting a stack.
+    has_projects: true
+    homepage: https://docs.cloudfoundry.org/adminguide/stack-auditor.html
+  staticfile-buildpack:
+    description: Deploy static HTML/JS/CSS apps to Cloud Foundry
+    has_projects: false
+    has_wiki: false
+  staticfile-buildpack-release:
+    description: BOSH release for Staticfile Buildpack
+    has_projects: false
+    has_wiki: false
+    homepage: http://bosh.io/releases/github.com/cloudfoundry/staticfile-buildpack-release
+  statsd-injector:
+    archived: true
+    description: Companion component to Metron that receives Statsd and emits Dropsonde
+      to Metron
+    has_projects: true
+  statsd-injector-release:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  stembuild:
+    description: Binary to be used to build BOSH-compatible stemcells for Windows
+      Server 2019 on vSphere.
+    has_projects: true
+  stemcells-alicloud-index:
+    description: Alibaba Cloud Stemcell index produced by Alibaba Cloud team
+    has_projects: true
+  steno:
+    has_projects: true
+    has_wiki: false
+  stratos:
+    description: 'Stratos: Web-based Management UI for Cloud Foundry and Kubernetes'
+    has_projects: true
+  stratos-buildpack:
+    description: Custom buildpack Stratos (UI for Cloud Foundry)
+    has_projects: true
+  summit-hands-on-labs:
+    description: Hands-on Labs for CF Summit Boston '18 and beyond
+    has_projects: true
+  summit-training-classes:
+    description: 'Opensourced content for cloud foundry training classes: zero to
+      hero (beginner), bosh/operator, and microservices'
+    has_projects: true
+  switchblade:
+    default_branch: main
+    has_projects: false
+    has_wiki: false
+  sync-integration-tests:
+    has_projects: true
+  syslog-adapter-release:
+    has_projects: true
+    private: true
+  syslog-blackbox-release:
+    archived: true
+    has_projects: true
+  syslog-ci-private:
+    allow_merge_commit: false
+    archived: true
+    has_projects: true
+    private: true
+  syslog-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: BOSH release for forwarding logs (either sent to syslog or picked
+      up /var/vcap/sys/log/**/*)
+    has_projects: true
+    has_wiki: false
+  system-metrics-release:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  system-metrics-scraper-release:
+    allow_merge_commit: false
+    default_branch: main
+    has_projects: true
+  systemcerts:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  tlsconfig:
+    allow_merge_commit: false
+    description: build tls configurations
+    has_projects: false
+    has_wiki: false
+  tomcat-cnb:
+    archived: true
+    has_projects: true
+  tps:
+    description: the process status reporter
+    has_projects: true
+  training-cert-admin:
+    has_projects: true
+    private: true
+  tycho-env:
+    archived: true
+    has_projects: true
+    has_wiki: false
+    private: true
+  uaa:
+    default_branch: develop
+    description: CloudFoundry User Account and Authentication (UAA) Server
+    has_projects: true
+    has_wiki: false
+  uaa-developer-training:
+    has_projects: true
+    private: true
+  uaa-hey:
+    has_projects: true
+    private: true
+  uaa-k8s-release:
+    default_branch: main
+    has_projects: true
+  uaa-key-rotator:
+    has_projects: true
+  uaa-performance-release:
+    default_branch: develop
+    has_projects: true
+    private: true
+  uaa-release:
+    default_branch: develop
+    description: Bosh Release for the UAA
+    has_projects: true
+  uaa-singular:
+    description: Singular Login for Web Applications
+    has_projects: true
+  uaa-singular-example:
+    has_projects: true
+    private: true
+  uaa-workstation:
+    description: Setup scripts for UAA workstations
+    has_projects: true
+    private: true
+  uptimer:
+    default_branch: main
+    description: A Cloud Foundry availability measurement tool for eventful times
+    has_projects: true
+  urljoiner:
+    has_projects: true
+  usn-resource:
+    has_projects: true
+  vcap-common:
+    has_projects: true
+    has_wiki: false
+  vizzini:
+    allow_merge_commit: false
+    description: 'Vizzini: Inconceivable Tests'
+    has_issues: false
+    has_projects: true
+  volman:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  volume-mount-options:
+    has_projects: true
+  volumedriver:
+    has_projects: true
+  winc:
+    default_branch: develop
+    description: CLI tool for spawning and running containers on Windows according
+      to the OCI specification
+    has_projects: true
+    has_wiki: false
+  winc-release:
+    default_branch: develop
+    description: A BOSH release for deploying winc
+    has_projects: true
+    has_wiki: false
+  windows-regression-tests:
+    has_projects: true
+    has_wiki: false
+  windows-syslog-release:
+    allow_merge_commit: false
+    default_branch: main
+    description: BOSH release for forwarding logs from BOSH jobs on Windows VMs
+    has_projects: true
+  windows-tools-release:
+    description: Contains miscellaneous Windows packages to be BOSH-deployed
+    has_projects: true
+    has_wiki: false
+  windows-utilities-release:
+    has_projects: true
+  windows-utilities-tests:
+    has_projects: true
+  windows2016fs:
+    description: A rootfs for Windows containers in Cloud Foundry
+    has_projects: true
+    has_wiki: false
+  windows2019fs-release:
+    default_branch: develop
+    has_projects: true
+  windowsfs-online-release:
+    default_branch: develop
+    has_projects: true
+  workpool:
+    allow_merge_commit: false
+    has_issues: false
+    has_projects: true
+  yagnats:
+    description: Yet Another Go NATS client
+    has_projects: true
+  ykk:
+    description: reads zips and JAR files with additional prefixed bytes
+    has_projects: true
+  yttk8smatchers:
+    default_branch: main
+    has_projects: true
+teams:
+  Advanced Services:
+    description: ""
+    members:
+    - malston
+    - joefitzgerald
+    - rickfarmer
+    - rahulkj
+    - skibum55
+    privacy: secret
+  App Runtime Interfaces:
+    description: Approvers for the App Runtime Interfaces Working Group
+    maintainers:
+    - Gerg
+    members:
+    - philippthun
+    - Gerg
+    - sethboyles
+    - FloThinksPi
+    - monamohebbi
+    - andy-paine
+    - tjvman
+    - MarcPaquette
+    - sweinstein22
+    - JenGoldstrich
+    - MerricdeLauney
+    privacy: closed
+    teams:
+      App Runtime Interfaces CAPI:
+        description: Approvers for the App Runtime CAPI Area
+        maintainers:
+        - Gerg
+        members:
+        - philippthun
+        - sethboyles
+        - FloThinksPi
+        - monamohebbi
+        - andy-paine
+        - tjvman
+        - MarcPaquette
+        - sweinstein22
+        - JenGoldstrich
+        - MerricdeLauney
+        privacy: closed
+        repos:
+          capi-bara-tests: write
+          capi-ci: write
+          capi-dockerfiles: write
+          capi-k8s-release: write
+          capi-release: write
+          cc-uploader: write
+          cloud_controller_ng: write
+          go-cf-api: write
+          go-cf-api-release: write
+          sync-integration-tests: write
+          tps: write
+  App Runtime Platform WG:
+    description: Approvers for the App Runtime WG
+    maintainers:
+    - ameowlia
+    members:
+    - ameowlia
+    privacy: closed
+    repos:
+      archiver: write
+      auction: write
+      auctioneer: write
+      bbs: write
+      benchmarkbbs: write
+      bosh-system-metrics-forwarder-release: write
+      bytefmt: write
+      cacheddownloader: write
+      cert-injector: write
+      certsplitter: write
+      cf-networking-helpers: write
+      cf-networking-release: write
+      cf-tcp-router: write
+      cfdot: write
+      clock: write
+      consuladapter: write
+      debugserver: write
+      diego-dockerfiles: write
+      diego-logging-client: write
+      diego-release: write
+      diego-upgrade-stability-tests: write
+      diff-exporter: read
+      dockerdriver: write
+      dontpanic: write
+      durationjson: write
+      ecrhelper: write
+      eventhub: write
+      executor: write
+      fileserver: write
+      garden: write
+      garden-integration-tests: write
+      garden-runc-release: write
+      gorouter: write
+      groot-windows: write
+      grootfs: write
+      guardian: write
+      haproxy-boshrelease: write
+      healthcheck: write
+      idmapper: write
+      inigo: write
+      localdriver: write
+      localip: write
+      locket: write
+      log-cache-release: write
+      loggregator-agent-release: write
+      loggregator-release: write
+      metrics-discovery-release: write
+      nats-release: write
+      netplugin-shim: write
+      networking-oss-deployments: write
+      operationq: write
+      rep: write
+      route-emitter: write
+      route-registrar: write
+      routing-acceptance-tests: write
+      routing-api: write
+      routing-api-cli: write
+      routing-info: write
+      routing-perf-release: write
+      routing-release: write
+      silk: write
+      silk-release: write
+      statsd-injector-release: write
+      syslog-release: write
+      system-metrics-scraper-release: write
+      systemcerts: write
+      tlsconfig: write
+      vizzini: write
+      volman: write
+      winc: write
+      winc-release: write
+      workpool: write
+    teams:
+      App Runtime Platform WG leads:
+        description: ""
+        maintainers:
+        - ameowlia
+        privacy: closed
+        repos:
+          archiver: admin
+          auction: admin
+          auctioneer: admin
+          bbs: admin
+          benchmarkbbs: admin
+          bosh-system-metrics-forwarder-release: admin
+          bytefmt: admin
+          cacheddownloader: admin
+          cert-injector: admin
+          certsplitter: admin
+          cf-networking-helpers: admin
+          cf-networking-release: admin
+          cf-tcp-router: admin
+          cfdot: admin
+          clock: admin
+          consuladapter: admin
+          debugserver: admin
+          diego-dockerfiles: admin
+          diego-logging-client: admin
+          diego-release: admin
+          diego-upgrade-stability-tests: admin
+          diff-exporter: admin
+          dockerdriver: admin
+          dontpanic: admin
+          durationjson: admin
+          ecrhelper: admin
+          eventhub: admin
+          executor: admin
+          fileserver: admin
+          garden: admin
+          garden-integration-tests: admin
+          garden-runc-release: admin
+          gorouter: admin
+          groot-windows: admin
+          grootfs: admin
+          guardian: admin
+          haproxy-boshrelease: admin
+          healthcheck: admin
+          idmapper: admin
+          inigo: admin
+          localdriver: admin
+          localip: admin
+          locket: admin
+          log-cache-release: admin
+          loggregator-agent-release: admin
+          loggregator-release: admin
+          metrics-discovery-release: admin
+          nats-release: admin
+          netplugin-shim: admin
+          networking-oss-deployments: admin
+          operationq: admin
+          rep: admin
+          route-emitter: admin
+          route-registrar: admin
+          routing-acceptance-tests: admin
+          routing-api: admin
+          routing-api-cli: admin
+          routing-info: admin
+          routing-perf-release: admin
+          routing-release: admin
+          silk: admin
+          silk-release: admin
+          statsd-injector-release: admin
+          syslog-release: admin
+          system-metrics-scraper-release: admin
+          systemcerts: admin
+          tlsconfig: admin
+          vizzini: admin
+          volman: admin
+          winc: admin
+          winc-release: admin
+          workpool: admin
+  At Standup:
+    description: ""
+    maintainers:
+    - dsboulder
+    - emalm
+    members:
+    - tanzeeb
+    - matt-royal
+    - aramprice
+    - squeedee
+    - mariash
+    - mkocher
+    - nickstreet
+    - dsyer
+    - jkjell
+    - ryanmoran
+    - cppforlife
+    - tekul
+    - frodenas
+    - d
+    - avade
+    - fhanik
+    - cobyrne
+    - dsabeti
+    - cunnie
+    - pivotal-todd-ritchie
+    - BrianMMcClain
+    - xtreme-andrei-dinin
+    - st3v
+    - zrob
+    - cf-frontend
+    - syslxg
+    - draganm
+    - petewall
+    - PeterEltgroth
+    - cf-frameworks
+    - drich10
+    - cf-datadog
+    - cf-services
+    - rosenhouse
+    - bsnchan
+    - cwang-pivotal
+    - cobyrne-pivot
+    - pvtl-shane
+    - modelseer
+    - anEXPer
+    - cf-commercial
+    - ktpv
+    - teddyking
+    - cf-blobstore-eng
+    - graeme-davison
+    - rainmaker
+    - haydonryan
+    - robdimsdale
+    - edwardecook
+    - omerbensaadon
+    - pivotal-so
+    - tmegan1
+    privacy: secret
+    repos:
+      bosh_rackspace_cpi_spike: read
+      cf-mysql-release: read
+      cf-uaa-lib: read
+      cf-uaac: read
+      cflinuxfs2: read
+      cli: read
+      cloudfoundry.github.com: read
+      communitydashboard: read
+      docs-book-cloudfoundry: read
+      etcd: read
+      git-release-notes: read
+      go-buildpack: read
+      gorouter: read
+      gosigar: read
+      gosteno: read
+      identity-tools: read
+      jsonry: read
+      lamb-ci-tools: read
+      loggregator-release: read
+      loggregator_emitter: read
+      membrane: read
+      noaa: read
+      nodejs-buildpack: read
+      omniauth-uaa-oauth2: read
+      python-buildpack: read
+      rbenv-cookbook: read
+      ruby-buildpack: read
+      steno: read
+      vcap-common: read
+  BOSH Ecosystem:
+    description: Parent Team for BOSH
+    maintainers:
+    - dsboulder
+    - jpalermo
+    - ystros
+    - rkoster
+    - selzoc
+    - lnguyen
+    - cunnie
+    - mrosecrance
+    - julian-hj
+    - danielfor
+    - klakin-pivotal
+    - camilalonart
+    members:
+    - jpalermo
+    - ragaskar
+    - ystros
+    - idoru
+    - selzoc
+    - cunnie
+    - mrosecrance
+    - bgandon
+    - julian-hj
+    - danielfor
+    - klakin-pivotal
+    - nouseforaname
+    - camilalonart
+    - bosh-windows-ci
+    - suraiyasuliman
+    privacy: closed
+    repos:
+      bosh: admin
+      bosh-acceptance-tests: admin
+      bosh-agent: admin
+      bosh-agent-index: admin
+      bosh-aws-cpi-release: admin
+      bosh-aws-light-stemcell-builder: admin
+      bosh-azure-cpi-release: admin
+      bosh-bbl-ci-envs: admin
+      bosh-cli: admin
+      bosh-compiled-releases-index: admin
+      bosh-cpi-environments: admin
+      bosh-cpi-go: admin
+      bosh-cpi-kb: admin
+      bosh-cpi-ruby: admin
+      bosh-davcli: admin
+      bosh-deployment: admin
+      bosh-deployment-resource: admin
+      bosh-dns-aliases-release: admin
+      bosh-dns-release: admin
+      bosh-docker-cpi-release: admin
+      bosh-gcscli: admin
+      bosh-google-cpi-release: admin
+      bosh-google-light-stemcell-builder: admin
+      bosh-linux-stemcell-builder: admin
+      bosh-openstack-cpi-release: admin
+      bosh-s3cli: admin
+      bosh-stemcells-ci: admin
+      bosh-utils: admin
+      bosh-virtualbox-cpi-release: admin
+      bosh-warden-cpi-release: admin
+      bosh-workstation: admin
+      bpm-release: admin
+      bsdtar: admin
+      config-server: admin
+      config-server-release: admin
+      docs-bosh: admin
+      event-log-release: admin
+      gofileutils: write
+      gosigar: admin
+      homebrew-tap: admin
+      os-conf-release: admin
+      socks5-proxy: admin
+      syslog-release: write
+      usn-resource: admin
+      windows-tools-release: admin
+      windows-utilities-release: admin
+      windows-utilities-tests: admin
+      yagnats: admin
+    teams:
+      CF BOSH:
+        description: Child of BOSH Ecosystem, for backwards compatability for resources
+          that need this team name stable
+        maintainers:
+        - jpalermo
+        - ystros
+        - idoru
+        - rkoster
+        - selzoc
+        - cunnie
+        - mrosecrance
+        - julian-hj
+        - danielfor
+        - klakin-pivotal
+        - nouseforaname
+        - camilalonart
+        members:
+        - ragaskar
+        privacy: closed
+        repos:
+          bosh: read
+          bosh-acceptance-tests: read
+          bosh-agent: read
+          bosh-agent-index: read
+          bosh-aws-cpi-release: read
+          bosh-aws-light-stemcell-builder: read
+          bosh-azure-cpi-release: read
+          bosh-cli: read
+          bosh-compiled-releases-index: read
+          bosh-cpi-go: read
+          bosh-cpi-ruby: read
+          bosh-davcli: read
+          bosh-deployment: read
+          bosh-deployment-resource: read
+          bosh-dns-aliases-release: read
+          bosh-dns-release: read
+          bosh-docker-cpi-release: read
+          bosh-gcscli: read
+          bosh-google-cpi-release: read
+          bosh-google-light-stemcell-builder: read
+          bosh-linux-stemcell-builder: read
+          bosh-openstack-cpi-release: read
+          bosh-s3cli: read
+          bosh-stemcells-ci: read
+          bosh-utils: read
+          bosh-virtualbox-cpi-release: read
+          bosh-warden-cpi-release: read
+          bpm-release: read
+          bsdtar: read
+          config-server: read
+          config-server-release: read
+          docs-bosh: read
+          event-log-release: read
+          gofileutils: read
+          gosigar: read
+          homebrew-tap: read
+          os-conf-release: read
+          socks5-proxy: read
+          syslog-release: read
+          tlsconfig: write
+          usn-resource: read
+          windows-tools-release: read
+          windows-utilities-release: read
+          windows-utilities-tests: read
+          yagnats: read
+  BOSH admin bot:
+    description: ""
+    members:
+    - cf-gitbot
+    - bosh-admin-bot
+    privacy: closed
+    repos:
+      bosh: admin
+      bosh-acceptance-tests: admin
+      bosh-agent: admin
+      bosh-agent-index: admin
+      bosh-aws-cpi-release: admin
+      bosh-aws-light-stemcell-builder: admin
+      bosh-azure-cpi-release: admin
+      bosh-bbl-ci-envs: admin
+      bosh-cli: admin
+      bosh-compiled-releases-index: admin
+      bosh-cpi-environments: admin
+      bosh-cpi-go: admin
+      bosh-cpi-kb: admin
+      bosh-cpi-ruby: admin
+      bosh-davcli: admin
+      bosh-deployment: admin
+      bosh-deployment-resource: read
+      bosh-dns-aliases-release: admin
+      bosh-dns-release: admin
+      bosh-docker-cpi-release: admin
+      bosh-gcscli: admin
+      bosh-google-cpi-release: admin
+      bosh-google-light-stemcell-builder: admin
+      bosh-linux-stemcell-builder: admin
+      bosh-openstack-cpi-release: admin
+      bosh-s3cli: admin
+      bosh-stemcells-ci: admin
+      bosh-utils: admin
+      bosh-virtualbox-cpi-release: admin
+      bosh-vsphere-cpi-release: admin
+      bosh-warden-cpi-release: admin
+      bosh-workstation: admin
+      bpm-release: admin
+      bsdtar: admin
+      config-server: admin
+      config-server-release: admin
+      docs-bosh: admin
+      gofileutils: admin
+      gosigar: admin
+      homebrew-tap: write
+      os-conf-release: admin
+      socks5-proxy: admin
+      syslog-release: admin
+      usn-resource: admin
+      windows-tools-release: admin
+      yagnats: admin
+  BOSH ci push pull bot:
+    description: ""
+    members:
+    - bosh-ci-push-pull
+    privacy: closed
+    repos:
+      bosh-linux-stemcell-builder: write
+  BOSH-CI:
+    description: ""
+    members:
+    - bosh-ci-push-pull
+    privacy: secret
+    repos:
+      bosh: write
+      bosh-acceptance-tests: write
+  CF BOSH Alicloud CPI:
+    description: ""
+    maintainers:
+    - cppforlife
+    privacy: secret
+  CF BOSH Azure CPI:
+    description: ""
+    maintainers:
+    - dsboulder
+    members:
+    - cppforlife
+    - gossion
+    - bingosummer
+    - AbelHu
+    - thomas1206
+    - OpusDude
+    - zhongyi-zhang
+    privacy: secret
+  CF BOSH CORE External Contributors:
+    description: ""
+    maintainers:
+    - loewenstein
+    members:
+    - cornelius
+    - maximilien
+    - cppforlife
+    - manno
+    - mauromorales
+    - beyhan
+    - voelzmo
+    - friegger
+    privacy: closed
+  CF BOSH CPI:
+    description: ""
+    maintainers:
+    - evanfarrar
+    - dsboulder
+    - rkoster
+    - cunnie
+    - syslxg
+    - mrosecrance
+    - markstokan
+    - julian-hj
+    - moleske
+    - nouseforaname
+    members:
+    - jpalermo
+    - ragaskar
+    - ystros
+    - selzoc
+    - lnguyen
+    - danielfor
+    - klakin-pivotal
+    - camilalonart
+    privacy: closed
+    repos:
+      bosh-acceptance-tests: write
+      bosh-aws-cpi-release: write
+      bosh-aws-light-stemcell-builder: write
+      bosh-cpi-environments: write
+      bosh-cpi-kb: admin
+      bosh-cpi-ruby: write
+      bosh-davcli: admin
+      bosh-google-cpi-release: write
+      bosh-google-light-stemcell-builder: write
+      bosh-s3cli: admin
+      bosh-utils: write
+      bosh-vsphere-cpi-release: admin
+  CF BOSH Europe:
+    description: ""
+    maintainers:
+    - voelzmo
+    - KaiHofstetter
+    - friegger
+    members:
+    - mvach
+    - beyhan
+    - ramonskie
+    - bgandon
+    - joergdw
+    - FlorianNachtigall
+    - yatzek
+    - cf-bosh-ci-bot
+    privacy: closed
+    repos:
+      bosh: write
+      bosh-acceptance-tests: write
+      bosh-agent: write
+      bosh-cli: write
+      bosh-cpi-go: read
+      bosh-cpi-kb: write
+      bosh-cpi-ruby: write
+      bosh-dns-aliases-release: read
+      bosh-docker-cpi-release: read
+      bosh-linux-stemcell-builder: write
+      bosh-openstack-cpi-ci: admin
+      bosh-openstack-cpi-release: write
+      bosh-openstack-cpi-shared: admin
+      bosh-virtualbox-cpi-release: read
+      bosh-warden-cpi-release: read
+      docs-bosh: write
+  CF BOSH Google CPI:
+    description: ""
+    members:
+    - cppforlife
+    - ccemeraldeyes
+    - erjohnso
+    - mkjelland
+    privacy: secret
+  CF BOSH IBM Russia:
+    description: BOSH team members from IBM Russia
+    maintainers:
+    - cppforlife
+    members:
+    - knm3000
+    privacy: secret
+    repos:
+      bosh-cpi-kb: read
+  CF BOSH Oracle CPI:
+    description: ""
+    maintainers:
+    - cppforlife
+    members:
+    - dmutreja
+    privacy: secret
+  CF BOSH vSphere CPI:
+    description: ""
+    maintainers:
+    - cppforlife
+    members:
+    - ktchen14
+    - altonf4
+    privacy: secret
+    repos:
+      bosh-vsphere-cpi-release: write
+  CF BPM:
+    description: Working on bpm-release
+    maintainers:
+    - aramprice
+    privacy: closed
+    repos:
+      bpm-release: admin
+  CF Buildpacks:
+    description: ""
+    maintainers:
+    - sclevine
+    - TisVictress
+    members:
+    - simonjjones
+    - nebhale
+    - ryanmoran
+    - GarimaSharma
+    - arjun024
+    - dmikusa-pivotal
+    - thitch97
+    - menehune23
+    - cf-buildpacks-eng
+    - robdimsdale
+    - shanks3012
+    - AccraZed
+    - ForestEckhardt
+    - brayanhenao
+    - mgibson1121
+    - sophiewigmore
+    - fg-j
+    - pivotal-david-osullivan
+    - kvedurmu
+    - mvalliath
+    - bhh1893
+    privacy: closed
+    repos:
+      apt-buildpack: admin
+      binary-builder: admin
+      binary-buildpack: admin
+      binary-buildpack-release: admin
+      brats: admin
+      buildpack-acceptance-tests: admin
+      buildpack-checklists: admin
+      buildpack-packager: admin
+      buildpackapplifecycle: admin
+      buildpacks-ci: admin
+      buildpacks-envs: admin
+      buildpacks-feature-eng-ci: admin
+      buildpacks-github-config: admin
+      buildpacks-style-guide: admin
+      buildpacks-workstation: admin
+      cf-acceptance-tests: write
+      cflinuxfs2: admin
+      cflinuxfs2-release: admin
+      cflinuxfs3: admin
+      cflinuxfs3-release: admin
+      cnb-tools: admin
+      cnb2cf: admin
+      compile-extensions: admin
+      core-deps-ci: admin
+      dagger: admin
+      docs-buildpacks: admin
+      dotnet-core-buildpack: admin
+      dotnet-core-buildpack-release: admin
+      dotnet-core-cnb: admin
+      example-sidecar-buildpack: admin
+      garden-windows-ci: admin
+      go-buildpack: admin
+      go-buildpack-release: admin
+      go-cnb: admin
+      hwc: admin
+      hwc-buildpack: admin
+      hwc-buildpack-release: admin
+      java-buildpack-release: admin
+      libbuildpack: admin
+      libcfbuildpack: write
+      machete: admin
+      nginx-buildpack: admin
+      nginx-buildpack-release: admin
+      nodejs-buildpack: admin
+      nodejs-buildpack-release: admin
+      nodejs-cnb: admin
+      nodejs-compat-cnb: admin
+      php-buildpack: admin
+      php-buildpack-release: admin
+      php-cnb: admin
+      php-compat-cnb: admin
+      pip-pop: admin
+      public-buildpacks-ci-robots: admin
+      python-buildpack: admin
+      python-buildpack-release: admin
+      python-cnb: admin
+      python-compat-cnb: admin
+      r-buildpack: admin
+      r-buildpack-release: admin
+      ruby-buildpack: admin
+      ruby-buildpack-release: admin
+      runtime-team-checklists: admin
+      stack-auditor: admin
+      staticfile-buildpack: admin
+      staticfile-buildpack-release: admin
+      switchblade: admin
+  CF CAPI:
+    description: ""
+    maintainers:
+    - dsboulder
+    - Gerg
+    - sethboyles
+    - monamohebbi
+    - moleske
+    - tjvman
+    - sweinstein22
+    - JenGoldstrich
+    - MerricdeLauney
+    members:
+    - matt-royal
+    - tcdowney
+    - piyalibanerjee
+    privacy: closed
+    repos:
+      api-docs: admin
+      blobstore_url_signer: admin
+      bosh-stemcell-resource: admin
+      canibump: admin
+      capi-bara-tests: admin
+      capi-ci: admin
+      capi-ci-private: admin
+      capi-datadog: write
+      capi-dockerfiles: admin
+      capi-env-pool: admin
+      capi-integration-tests: admin
+      capi-k8s-release: admin
+      capi-release: admin
+      capi-team-checklists: admin
+      capi-workspace: admin
+      cc-api-v3-style-guide: write
+      cc-uploader: admin
+      cf-acceptance-tests: write
+      cf-app-utils-ruby: write
+      cf-deployment: write
+      cf-for-k8s: write
+      cf-k8s-logging: write
+      cf-smoke-tests: write
+      cf-uaa-lib: admin
+      cli: write
+      cloud_controller_ng: admin
+      delayed_job_sequel: write
+      deployments-diego: read
+      deployments-routing: read
+      docs-cf-admin: write
+      docs-cloudfoundry-concepts: write
+      docs-deploying-cf: write
+      docs-running-cf: write
+      docs-services: write
+      jsonry: write
+      overview-broker: write
+      runtime-credentials: write
+      runtime-team-checklists: write
+      runtime1-env: write
+      runtimeschema: admin
+      services-api-home: write
+      steno: write
+      sync-integration-tests: admin
+      tps: admin
+      vcap-common: write
+    teams:
+      CF API Kubernetes Evolution:
+        description: Evolving the CF API on Kubernetes
+        members:
+        - matt-royal
+        - tcdowney
+        - piyalibanerjee
+        privacy: closed
+        repos:
+          api-docs: read
+          blobstore_url_signer: read
+          canibump: read
+          capi-bara-tests: read
+          capi-ci: read
+          capi-dockerfiles: read
+          capi-integration-tests: read
+          capi-k8s-release: read
+          capi-release: read
+          capi-workspace: read
+          cc-api-v3-style-guide: read
+          cc-uploader: read
+          cf-acceptance-tests: read
+          cf-app-utils-ruby: read
+          cf-deployment: read
+          cf-for-k8s: read
+          cf-k8s-logging: read
+          cf-smoke-tests: read
+          cf-uaa-lib: read
+          cli: read
+          cloud_controller_ng: read
+          delayed_job_sequel: read
+          docs-cf-admin: read
+          docs-cloudfoundry-concepts: read
+          docs-deploying-cf: read
+          docs-running-cf: read
+          docs-services: read
+          jsonry: read
+          overview-broker: read
+          runtimeschema: read
+          steno: read
+          sync-integration-tests: read
+          tps: read
+          vcap-common: read
+  CF CI Pull:
+    description: ""
+    members:
+    - cf-ci-push-pull
+    - cf-toolsmiths
+    privacy: secret
+    repos:
+      cloud_controller_ng: read
+      gorouter: read
+      gosteno: read
+      lamb-ci-tools: read
+      loggregator-release: read
+      nodejs-buildpack: read
+      ruby-buildpack: read
+      runtime-credentials: read
+      vcap-common: read
+  CF CI Push & Pull:
+    description: ""
+    members:
+    - cf-ci-push-pull
+    privacy: secret
+    repos:
+      cf-mysql-release: write
+      cli-private: write
+      diego-release: write
+      loggregator-release: write
+  CF CLI:
+    description: ""
+    maintainers:
+    - maximilien
+    - a-b
+    - hemarsai
+    members:
+    - bepotts
+    - hjcalderon10
+    - cf-cli-eng
+    - pivotalgeorge
+    - reedr3
+    - sebGilR
+    - jdgonzaleza
+    - dominicrobertsc
+    privacy: closed
+    repos:
+      CLAW: admin
+      capi-ci: write
+      capi-env-pool: write
+      cf-acceptance-tests: write
+      cfdreddbot: read
+      cli: admin
+      cli-ci: admin
+      cli-docs-scripts: admin
+      cli-i18n: admin
+      cli-plugin-repo: admin
+      cli-pools: admin
+      cli-private: admin
+      cli-workstation: admin
+      cloud_controller_ng: write
+      gofileutils: admin
+      homebrew-tap: admin
+      jsonry: admin
+      overview-broker: write
+      relint-envs: write
+      ykk: admin
+  CF CLI Pools bot:
+    description: ""
+    members:
+    - cf-cli-pools
+    privacy: closed
+    repos:
+      cli-pools: write
+  CF Core Services:
+    description: ""
+    maintainers:
+    - abg
+    - menicosia
+    - colins
+    - APShirley
+    - mfine30
+    members:
+    - jpalermo
+    - berlin-ab
+    - rheaton
+    - jamiemonserrate
+    - abubakarm94
+    - ssapra
+    - ozbasarir
+    - kimago
+    - jpatel-pivotal
+    - cf-toolsmiths
+    - degaurab
+    - dsharp-pivotal
+    - swati-nair
+    - RiaMahoney
+    - ohkyle
+    - kmarkwardt-vmware
+    - ricardo-vm
+    privacy: closed
+    repos:
+      api-docs: write
+      capi-ci-private: write
+      cf-deployment: write
+      cf-mysql-deployment: admin
+      cf-mysql-release: write
+      deployments-diego: read
+      deployments-routing: read
+      docs-book-cloudfoundry: write
+      docs-dev-guide: write
+      docs-services: write
+      galera-init: write
+      mysql-backup-release: admin
+      mysql-monitoring-release: admin
+      omniauth-uaa-oauth2: write
+      pxc-release: admin
+  CF Credhub:
+    description: team responsible for CredHub
+    maintainers:
+    - dsboulder
+    members:
+    - tylerphelan
+    - adobley
+    - tomkennedy513
+    - bruce-ricard
+    - peterhaochen47
+    - LizClaireMorris
+    - jknostman3
+    - ccjaimes
+    - zzori-theoriginal
+    - hsinn0
+    - cphi-vmw
+    privacy: closed
+    repos:
+      cf-acceptance-tests: write
+      cf-deployment: write
+      docs-credhub: write
+      secure-credentials-broker: admin
+  CF Developer Training:
+    description: Folks helping with CF Developer Training Course
+    members:
+    - danyoung
+    - spgreenberg
+    - crsimmons
+    - dhrapson
+    - DanielJonesEB
+    - fcioanca
+    privacy: closed
+    repos:
+      developer-training-class-site: write
+      developer-training-course: write
+      developer-training-hugo-parser: write
+      uaa-developer-training: write
+  CF Diego:
+    description: Diego
+    maintainers:
+    - aminjam
+    - emalm
+    members:
+    - mariash
+    privacy: closed
+    repos:
+      archiver: admin
+      auction: admin
+      auctioneer: admin
+      bbs: admin
+      benchmarkbbs: admin
+      benchmarklocket: admin
+      buildpackapplifecycle: admin
+      bytefmt: admin
+      cacheddownloader: admin
+      certsplitter: admin
+      cf-acceptance-tests: write
+      cf-deployment: write
+      cf-networking-deployments: write
+      cf-volume-services-acceptance-tests: admin
+      cfdot: admin
+      cfdreddbot: admin
+      cfhttp: admin
+      cflinuxfs2: admin
+      clock: admin
+      cloud_controller_ng: write
+      commandrunner: admin
+      consuladapter: admin
+      debugserver: admin
+      deployments-diego: admin
+      deployments-routing: read
+      diego-acceptance: admin
+      diego-checkman: admin
+      diego-ci: admin
+      diego-ci-pools: admin
+      diego-design-notes: admin
+      diego-dockerfiles: admin
+      diego-logging-client: admin
+      diego-notes: admin
+      diego-perf-release: admin
+      diego-release: write
+      diego-ssh: admin
+      diego-stress-tests: admin
+      diego-team: admin
+      diego-upgrade-stability-tests: admin
+      diegocanaryapp: admin
+      docker_driver_integration_tests: admin
+      dockerapplifecycle: admin
+      dockerdriver: admin
+      dropsonde: admin
+      durationjson: admin
+      ecrhelper: admin
+      eventhub: admin
+      executor: admin
+      fileserver: admin
+      go-fetcher: write
+      grace: admin
+      healthcheck: admin
+      inigo: admin
+      lager: admin
+      lds: admin
+      localdriver: admin
+      localip: admin
+      locket: admin
+      networking-program-checklists: read
+      operationq: admin
+      persi-ci: admin
+      postgres-ci-env: read
+      rep: admin
+      route-emitter: admin
+      runtime-credentials: admin
+      runtimeschema: admin
+      sample-http-app: admin
+      systemcerts: admin
+      tlsconfig: admin
+      urljoiner: admin
+      vizzini: admin
+      volman: admin
+      workpool: admin
+  CF Event Producer:
+    description: ""
+    members:
+    - dtimm
+    privacy: closed
+  CF Final Release Election Bot:
+    description: ""
+    members:
+    - cf-final-release-election-bot
+    privacy: closed
+  CF Final Release Electors:
+    description: ""
+    maintainers:
+    - dsabeti
+    - emalm
+    members:
+    - evanfarrar
+    - mkocher
+    - nebhale
+    - idoru
+    - staylor14
+    - Gerg
+    - zrob
+    - sclevine
+    - mcwumbly
+    - spikymonkey
+    - valeriap
+    - angelachin
+    - aaronshurley
+    - smoser-ibm
+    privacy: closed
+  CF Flintstone:
+    description: ""
+    members:
+    - suhlig
+    - petergtz
+    - smoser-ibm
+    - flintstonecf
+    privacy: secret
+    repos:
+      bits-service-private-config: admin
+      capi-release: write
+      cloud_controller_ng: read
+      flintstone: write
+  CF Garden:
+    description: ""
+    members:
+    - gcapizzi
+    - rosenhouse
+    - danail-branekov
+    - georgethebeatle
+    - mnitchev
+    - garden-gnome
+    - kieron-dev
+    privacy: closed
+    repos:
+      commandrunner: write
+      cpu-entitlement-admin-plugin: admin
+      cpu-entitlement-plugin: admin
+      deployments-diego: read
+      diego-perf-release: write
+      dontpanic: admin
+      garden: admin
+      garden-ci: admin
+      garden-ci-artifacts-release: write
+      garden-dockerfiles: admin
+      garden-dotfiles: admin
+      garden-dotfiles-archived: admin
+      garden-integration-tests: admin
+      garden-performance-acceptance-tests: admin
+      garden-runc-release: admin
+      garden-wiki: write
+      groot: admin
+      grootfs: admin
+      grootfs-ci-secrets: admin
+      guardian: admin
+      idmapper: admin
+      netplugin-shim: admin
+      relogger: admin
+  CF Greenhouse:
+    description: Windows Support for CF
+    members:
+    - micahyoung
+    - idoru
+    - benmoss
+    - Shanfan
+    - stuart-pollock
+    - aminjam
+    - aemengo
+    - teddyking
+    - natalieparellano
+    - greenhouse-ci
+    - kartiklunkad26
+    - amakhija
+    - TisVictress
+    - mvalliath
+    - dcorricelli
+    - fejnartal
+    privacy: closed
+    repos:
+      buildpacks-envs: read
+      cert-injector: admin
+      core-deps-ci: write
+      diego-release: write
+      diego-windows-release: admin
+      diff-exporter: write
+      filelock: admin
+      garden-ci: read
+      garden-windows-ci: admin
+      groot: write
+      groot-windows: admin
+      hwc: admin
+      hwc-buildpack: admin
+      hydrator: admin
+      relint-envs: read
+      runtime-credentials: admin
+      runtime-team-checklists: admin
+      winc: admin
+      winc-release: admin
+      windows-regression-tests: admin
+      windows-tools-release: admin
+      windows2016fs: admin
+      windows2019fs-release: admin
+      windowsfs-online-release: admin
+  CF GrootFS:
+    description: Providing root filesystems for containers
+    maintainers:
+    - spikymonkey
+    members:
+    - danail-branekov
+    - georgethebeatle
+    - garden-gnome
+    privacy: closed
+    repos:
+      groot: admin
+      grootfs: read
+      grootfs-ci-secrets: read
+  CF Infrastructure:
+    description: Working on terraform and some BBL when we feel like it
+    maintainers:
+    - notrepo05
+    members:
+    - dsabeti
+    - kcboyle
+    - anEXPer
+    - cf-infra-bot
+    privacy: closed
+    repos:
+      bbl-state-resource: admin
+      bosh-bootloader: admin
+      deployments-diego: read
+      homebrew-tap: write
+      infrastructure-ci-bbl-states: admin
+      infrastructure-ci-deployment-locks: admin
+      jumpbox-deployment: admin
+      oss-s3-buckets-stack: write
+      runtime-credentials: write
+      socks5-proxy: admin
+  CF LA:
+    description: ""
+    maintainers:
+    - rosenhouse
+    members:
+    - evanfarrar
+    - davewalter
+    privacy: secret
+  CF LITE:
+    description: Team that does CF lite
+    members:
+    - cppforlife
+    - graeme-davison
+    privacy: secret
+  CF Lattice:
+    description: ""
+    members:
+    - menicosia
+    - sclevine
+    - ekcasey
+    privacy: secret
+    repos:
+      lamb-ci-tools: read
+  CF Loggregator:
+    description: Loggregator Team
+    maintainers:
+    - dtimm
+    - Benjamintf1
+    - angelachin
+    - Birdrock
+    - rainmaker
+    - paulcwarren
+    - heycait
+    privacy: closed
+    repos:
+      auth-proxy: admin
+      bosh-system-metrics-forwarder-release: admin
+      bosh-system-metrics-server-release: admin
+      capi-k8s-release: write
+      cf-acceptance-tests: write
+      cf-deployment: write
+      cf-drain-cli: admin
+      cf-for-k8s: write
+      cf-for-k8s-metric-examples: admin
+      cf-k8s-logging: admin
+      cf-k8s-logging-fluent: admin
+      cf-k8s-prometheus: admin
+      cf-smoke-tests: write
+      cfar-logging-acceptance-tests: admin
+      cli: write
+      cloud_controller_ng: write
+      deployments-diego: read
+      deployments-loggregator: admin
+      docs-loggregator: write
+      dropsonde: write
+      dropsonde-protocol: write
+      fluent-plugin-syslog_rfc5424: admin
+      fluentbit-loggr-plugin: admin
+      go-batching: admin
+      go-diodes: admin
+      go-envstruct: admin
+      go-log-cache: admin
+      go-loggregator: admin
+      go-metric-registry: admin
+      go-pubsub: admin
+      jsonry: write
+      lamb-ci-tools: write
+      leadership-election: admin
+      leadership-election-release: admin
+      log-cache: admin
+      log-cache-acceptance-tests: admin
+      log-cache-acceptance-tests-release: admin
+      log-cache-ci: admin
+      log-cache-cli: admin
+      log-cache-release: admin
+      log-stream-cli: admin
+      logging-acceptance-tests: admin
+      logging-acceptance-tests-release: admin
+      logging-deployment: write
+      loggregator: admin
+      loggregator-agent: admin
+      loggregator-agent-release: admin
+      loggregator-api: admin
+      loggregator-ci: admin
+      loggregator-ci-old: admin
+      loggregator-credentials: admin
+      loggregator-dotfiles: admin
+      loggregator-rampup: admin
+      loggregator-release: admin
+      loggregator_emitter: admin
+      metric-proxy: admin
+      metric-store-dotfiles: write
+      metric-store-rampup: admin
+      metrics-discovery-release: admin
+      noaa: write
+      noisy-neighbor-nozzle: admin
+      sample-service-metrics-release: admin
+      service-logs-release: admin
+      service-metrics: admin
+      service-metrics-release: admin
+      sonde-go: write
+      statsd-injector: admin
+      statsd-injector-release: admin
+      syslog-adapter-release: admin
+      syslog-blackbox-release: admin
+      system-metrics-release: admin
+      system-metrics-scraper-release: admin
+  CF London:
+    description: ""
+    members:
+    - albertoleal
+    - kirederik
+    - tinygrasshopper
+    - avade
+    - carlo-colombo
+    - hoegaarden
+    - st3v
+    - k-don
+    - spikymonkey
+    - cf-london
+    - teddyking
+    - mattmcneeney
+    - ablease
+    - mkuratczyk
+    - blgm
+    - kieron-dev
+    privacy: secret
+    repos:
+      garden-performance-acceptance-tests: read
+  CF Metric Store:
+    description: ""
+    members:
+    - heidmotron
+    - pianohacker
+    - rheaton
+    - colins
+    - thepeterstone
+    - robertjsullivan
+    - jpmcb
+    - gggevorgyan
+    - cf-log-cache-ci
+    - josephgee
+    - sboyajyan
+    - metric-store-ci
+    - lterminasyan
+    - david-akhsakhalyan
+    - myeghiazarya
+    - amartiro1979
+    - hmanukyanVMw
+    privacy: closed
+    repos:
+      auth-proxy: admin
+      cf-deployment: write
+      go-log-cache: admin
+      log-cache: admin
+      log-cache-acceptance-tests: admin
+      log-cache-acceptance-tests-release: admin
+      log-cache-ci: admin
+      log-cache-cli: admin
+      log-cache-deployments: admin
+      log-cache-release: admin
+      loggregator-rampup: write
+      metric-store-ci: admin
+      metric-store-deployments: admin
+      metric-store-dotfiles: admin
+      metric-store-rampup: admin
+      metric-store-release: write
+  CF Mobile Services:
+    description: ""
+    members:
+    - dprotaso
+    - xtremerui
+    - jomsie
+    - xtreme-jason-smith
+    - ryanmattcollins
+    - xtreme-vikram-yadav
+    privacy: secret
+    repos:
+      gorouter: read
+  CF Networking:
+    description: ""
+    maintainers:
+    - christianang
+    - jamiemonserrate
+    - flawedmatrix
+    - tcdowney
+    - mcwumbly
+    - mike1808
+    - rosenhouse
+    - ameowlia
+    - kauana
+    - KauzClay
+    - jrussett
+    - KeshavS0519
+    members:
+    - mike1808
+    - routing-ci
+    - kauana
+    - KauzClay
+    - KeshavS0519
+    privacy: closed
+    repos:
+      capi-k8s-release: write
+      capi-release: write
+      cf-acceptance-tests: write
+      cf-deployment: write
+      cf-for-k8s: write
+      cf-k8s-logging: write
+      cf-k8s-networking: admin
+      cf-k8s-networking-scaling: admin
+      cf-networking-deployments: admin
+      cloud_controller_ng: write
+      deployments-routing: admin
+      diego-release: read
+      docs-routing: write
+      filelock: admin
+      garden-ci: read
+      istio-scaling: admin
+      istio-scriptio: admin
+      multierror: write
+      networking-program-checklists: admin
+      networking-workspace: admin
+      policy_client: admin
+      relint-team: read
+      route-emitter: write
+      routing-ci: admin
+      routing-datadog-config: write
+      routing-sample-apps: admin
+      routing-team-checklists: write
+      sync-integration-tests: write
+    teams:
+      CF for K8s Networking:
+        description: ""
+        maintainers:
+        - mike1808
+        members:
+        - kauana
+        - KauzClay
+        - KeshavS0519
+        privacy: closed
+        repos:
+          capi-k8s-release: read
+          capi-release: read
+          cf-acceptance-tests: read
+          cf-deployment: read
+          cf-for-k8s: write
+          cf-k8s-logging: write
+          cf-k8s-networking: read
+          cf-k8s-networking-scaling: read
+          cloud_controller_ng: read
+          diego-release: read
+          docs-routing: read
+          filelock: read
+          istio-scaling: read
+          istio-scriptio: read
+          multierror: read
+          networking-oss-deployments: admin
+          networking-workspace: admin
+          policy_client: read
+          route-emitter: read
+          routing-ci: read
+          routing-sample-apps: read
+          sync-integration-tests: read
+  CF PivNet:
+    description: ""
+    members:
+    - garrying
+    - rszumlakowski
+    - bsoroushian
+    - xtreme-debbie-chen
+    - joeeltgroth
+    - N00BEST
+    - nedenwalker
+    - pivotal-so
+    - ashvinmoro
+    - git-narya
+    - rajasekharatvmware
+    - GowriRegistry
+    - Tejuvmware
+    - pkvatvmware
+    privacy: secret
+  CF Release Integration:
+    description: ""
+    maintainers:
+    - matt-royal
+    - davewalter
+    - PureMunky
+    - Shanfan
+    - tcdowney
+    - emalm
+    - Birdrock
+    - julian-hj
+    - acosta11
+    - gnovv
+    - akrishna90
+    members:
+    - ctlong
+    - JenGoldstrich
+    privacy: closed
+    repos:
+      bosh-bootloader: admin
+      canibump: write
+      capi-k8s-release: admin
+      cf-acceptance-tests: admin
+      cf-crd-explorations: admin
+      cf-deployment: admin
+      cf-deployment-concourse-tasks: admin
+      cf-for-k8s: admin
+      cf-for-k8s-docs: admin
+      cf-k8s-logging: admin
+      cf-k8s-networking: admin
+      cf-relint-ci-semver: admin
+      cf-smoke-tests: admin
+      cf-smoke-tests-release: admin
+      deployments-diego: read
+      deployments-routing: read
+      fluent-plugin-syslog_rfc5424: admin
+      honeycomb-ginkgo-reporter: admin
+      identity-ci: read
+      jumpbox-deployment: admin
+      metric-proxy: admin
+      minimal-env: write
+      oss-s3-buckets-stack: write
+      relint-ci-pools: admin
+      relint-envs: admin
+      relint-team: admin
+      runtime-ci: admin
+      runtime-credentials: write
+      uaa-k8s-release: admin
+      uptimer: admin
+      vcap-common: write
+      yttk8smatchers: admin
+  CF Routing Robots:
+    description: ""
+    members:
+    - routing-ci
+    privacy: secret
+    repos:
+      diego-ci: admin
+      diego-design-notes: admin
+  CF Runtime:
+    description: ""
+    members:
+    - zrob
+    - sykesm
+    privacy: secret
+    repos:
+      api-docs: write
+      brats: write
+      cfdreddbot: write
+      cflinuxfs2: write
+      cloud_controller_ng: write
+      delayed_job_sequel: write
+      deployments-routing: read
+      gofileutils: write
+      gorouter: write
+      lamb-ci-tools: write
+      route-registrar: write
+      runtime-credentials: write
+      runtime-team-checklists: write
+      vcap-common: write
+  CF Runtime PM:
+    description: Repo for the Runtime PM resources
+    privacy: secret
+  CF Runtime non-humans (push & pull):
+    description: This team is defunct, users should use individual keys
+    members:
+    - runtime-ci
+    privacy: secret
+  CF Syslog:
+    description: Maintainers of the syslog-release
+    maintainers:
+    - rheaton
+    - dtimm
+    - Benjamintf1
+    - anEXPer
+    - farmermel
+    privacy: closed
+    repos:
+      blackbox: admin
+      cf-deployment: write
+      durandal-env: admin
+      leela-env: admin
+      syslog-ci-private: admin
+      syslog-release: admin
+      tycho-env: admin
+      windows-syslog-release: admin
+  CF UAA Maintainers:
+    description: ""
+    maintainers:
+    - strehle
+    - peterhaochen47
+    - tack-sap
+    - torsten-sap
+    members:
+    - cphi-vmw
+    privacy: closed
+    repos:
+      uaa: admin
+      uaa-release: admin
+  CF Volume Services:
+    description: ""
+    members:
+    - tinygrasshopper
+    - paulcwarren
+    - julian-hj
+    - lisamburns
+    privacy: closed
+    repos:
+      archiver: write
+      auction: write
+      auctioneer: write
+      bbs: write
+      benchmarkbbs: write
+      buildpackapplifecycle: write
+      bytefmt: write
+      cacheddownloader: write
+      cf-volume-services-acceptance-tests: admin
+      cf-volume-services-team: admin
+      cfdot: write
+      cfhttp: write
+      clock: write
+      consuladapter: write
+      debugserver: write
+      diego-ci: write
+      diego-ci-pools: write
+      diego-design-notes: write
+      diego-dockerfiles: write
+      diego-notes: write
+      diego-perf-release: write
+      diego-release: write
+      diego-ssh: write
+      diego-stress-tests: write
+      diego-team: read
+      diego-upgrade-stability-tests: write
+      docker_driver_integration_tests: admin
+      dockerapplifecycle: write
+      dockerdriver: admin
+      docs-services: write
+      eventhub: write
+      executor: write
+      existingvolumebroker: admin
+      fileserver: write
+      go-git-resource: admin
+      goshims: admin
+      healthcheck: write
+      inigo: write
+      lager: write
+      localdriver: admin
+      localip: write
+      locket: write
+      mapfs: admin
+      mapfs-release: admin
+      migrate_mysql_to_credhub: admin
+      nfs-volume-release: admin
+      nfsbroker: admin
+      nfsv3driver: admin
+      operationq: write
+      persi-ci: admin
+      persistence-load-tests: admin
+      rep: write
+      route-emitter: write
+      runtimeschema: write
+      service-broker-store: admin
+      smb-volume-release: admin
+      smbbroker: admin
+      smbdriver: admin
+      vizzini: write
+      volman: admin
+      volume-mount-options: admin
+      volumedriver: admin
+  CF for VMs Networking:
+    description: '#cf-for-vms-networking team'
+    maintainers:
+    - aminjam
+    - ameowlia
+    - jrussett
+    members:
+    - routing-ci
+    privacy: closed
+    repos:
+      cf-networking-helpers: admin
+      cf-networking-release: admin
+      cf-routing-test-helpers: admin
+      cf-tcp-router: admin
+      gorouter: admin
+      nats-release: admin
+      networking-program-checklists: admin
+      networking-workspace: admin
+      route-registrar: admin
+      routing-acceptance-tests: admin
+      routing-api: admin
+      routing-api-cli: admin
+      routing-info: admin
+      routing-perf-release: admin
+      routing-release: admin
+      silk: admin
+      silk-release: admin
+  Community Engineering wiki:
+    description: ""
+    members:
+    - scottfrederick
+    privacy: secret
+  Concourse:
+    description: ""
+    members:
+    - tanzeeb
+    - navdeep-pama
+    - nader-ziada
+    - jamieklassen
+    privacy: secret
+    repos:
+      bosh-deployment-resource: admin
+      cli-private: write
+      homebrew-tap: write
+  Contributors:
+    description: ""
+    members:
+    - danhigham
+    - dpw
+    - monadic
+    - rmorgan
+    - joshlong
+    - scottfrederick
+    - nebhale
+    - trisberg
+    - oppegard
+    - bclozel
+    - rade
+    - scothis
+    - ericbottard
+    - joeldsa
+    - sujeetv
+    - vgogate
+    - cunnie
+    - rajdeepd
+    - jacksoncvm
+    - rickfarmer
+    - devtdeng
+    - tamaovmware
+    - dtillman
+    - tracker-common
+    - bkeelapudi
+    - lbarncord
+    - maheshkumarvs
+    - haydonryan
+    privacy: secret
+    repos:
+      cf-mysql-release: read
+      cloudfoundry.github.com: read
+  Core Dependencies:
+    description: ""
+    maintainers:
+    - sclevine
+    - martyspiewak
+    members:
+    - simonjjones
+    - brayanhenao
+    privacy: closed
+    repos:
+      binary-builder: admin
+      buildpacks-ci: admin
+      buildpacks-envs: admin
+      buildpacks-workstation: admin
+      cflinuxfs2: admin
+      cflinuxfs2-release: admin
+      cflinuxfs3: admin
+      cflinuxfs3-release: admin
+      core-deps-ci: admin
+      public-buildpacks-ci-robots: admin
+  Core Services Bot:
+    description: Core Services Read-only bot
+    members:
+    - pcf-core-services
+    privacy: secret
+  Core Services Writer Bot:
+    description: Bot with write access
+    members:
+    - pcf-core-services-writer
+    privacy: secret
+    repos:
+      cf-mysql-release: write
+  Data Visualization:
+    description: ""
+    members:
+    - mklanjsek
+    privacy: closed
+  Directors-PMs-Anchors:
+    description: ""
+    maintainers:
+    - dsboulder
+    - emalm
+    - mjear
+    members:
+    - evanfarrar
+    - schubert
+    - aramprice
+    - ajackson
+    - rmorgan
+    - mariash
+    - mkocher
+    - nebhale
+    - ragaskar
+    - ryanmoran
+    - wattersjames
+    - benmoss
+    - avade
+    - fhanik
+    - selzoc
+    - Gerg
+    - rnandi
+    - zrob
+    - sclevine
+    - tcdowney
+    - bsnchan
+    - animatedmax
+    - anEXPer
+    - paulcwarren
+    - elenasharma
+    - pivotal-lyle-murphy
+    - cf-pub-tools
+    - pulkit-chandra
+    - dpdavis
+    - pubtools-docs-helper
+    - ssisil
+    privacy: secret
+    repos:
+      CLAW: admin
+      api-docs: admin
+      binary-builder: admin
+      binary-buildpack: admin
+      bosh-cpi-environments: admin
+      bosh_rackspace_cpi_spike: admin
+      brats: admin
+      buildpack-checklists: admin
+      buildpack-packager: admin
+      buildpacks-ci: admin
+      canibump: write
+      capi-team-checklists: admin
+      cc-api-v3-style-guide: admin
+      cf-app-utils-ruby: admin
+      cf-java-client: admin
+      cf-lite-ci: admin
+      cf-mysql-release: admin
+      cf-slackin: admin
+      cf-uaa-lib: admin
+      cf-uaac: admin
+      cfdreddbot: admin
+      cflinuxfs2: admin
+      cli: admin
+      cli-plugin-repo: admin
+      cli-private: admin
+      cloud_controller_ng: admin
+      cloudfoundry.github.com: admin
+      commandrunner: admin
+      communitydashboard: admin
+      compile-extensions: admin
+      delayed_job_sequel: admin
+      deployments-diego: admin
+      deployments-routing: admin
+      diego-checkman: admin
+      diego-ci: admin
+      diego-ci-pools: admin
+      diego-design-notes: admin
+      diego-dockerfiles: admin
+      diego-notes: admin
+      diego-perf-release: admin
+      diego-release: admin
+      diego-stress-tests: admin
+      diego-team: admin
+      diego-windows-release: read
+      docs-bbr: admin
+      docs-book-cloudfoundry: admin
+      docs-bosh: admin
+      docs-buildpacks: admin
+      docs-cf-admin: admin
+      docs-cf-cli: admin
+      docs-cfcr: admin
+      docs-cloudfoundry-concepts: admin
+      docs-credhub: admin
+      docs-deploying-cf: admin
+      docs-dev-guide: admin
+      docs-dotnet-core-tutorial: admin
+      docs-loggregator: admin
+      docs-routing: admin
+      docs-running-cf: admin
+      docs-services: admin
+      docs-uaa: admin
+      dontpanic: admin
+      dropsonde: admin
+      dropsonde-protocol: admin
+      etcd: admin
+      foundation: admin
+      galera-init: admin
+      garden: admin
+      garden-ci: admin
+      garden-ci-artifacts-release: admin
+      garden-dockerfiles: admin
+      garden-integration-tests: admin
+      garden-runc-release: admin
+      git-release-notes: admin
+      go-buildpack: admin
+      gofileutils: admin
+      gorouter: admin
+      gosigar: admin
+      gosteno: admin
+      guardian: admin
+      ibm-websphere-liberty-buildpack: admin
+      identity-tools: admin
+      java-buildpack: admin
+      java-buildpack-auto-reconfiguration: admin
+      java-buildpack-client-certificate-mapper: admin
+      java-buildpack-container-certificate-trust-store: admin
+      java-buildpack-container-customizer: admin
+      java-buildpack-dependency-builder: admin
+      java-buildpack-memory-calculator: admin
+      java-buildpack-metric-writer: admin
+      java-buildpack-security-provider: admin
+      java-buildpack-support: admin
+      java-buildpack-system-test: admin
+      java-test-applications: admin
+      jsonry: admin
+      lamb-ci-tools: admin
+      loggregator-release: admin
+      loggregator_emitter: admin
+      machete: admin
+      membrane: admin
+      noaa: admin
+      nodejs-buildpack: admin
+      omniauth-uaa-oauth2: admin
+      php-buildpack: admin
+      python-buildpack: admin
+      rbenv-cookbook: admin
+      relogger: admin
+      routing-team-checklists: admin
+      ruby-buildpack: admin
+      runtime-credentials: admin
+      runtime-team-checklists: admin
+      slack-interrupt-bot: write
+      sonde-go: admin
+      staticfile-buildpack: admin
+      statsd-injector: admin
+      steno: admin
+      uaa-release: admin
+      vcap-common: admin
+  Docs:
+    description: ""
+    maintainers:
+    - animatedmax
+    members:
+    - danhigham
+    - scottfrederick
+    - fifthposition
+    - cppforlife
+    - djac
+    - cunnie
+    - jacksoncvm
+    - st3v
+    - cf-services
+    - modelseer
+    - cf-gitbot
+    - cfdocs-bot
+    - bosh-ci-push-pull
+    - pspinrad
+    - jncd
+    - mjgutermuth
+    - vikafed
+    privacy: secret
+    repos:
+      cloudfoundry.github.com: write
+      docs-book-cloudfoundry: admin
+      docs-bosh: write
+      docs-buildpacks: write
+      docs-cf-admin: write
+      docs-cf-cli: write
+      docs-cloudfoundry-concepts: write
+      docs-deploying-cf: write
+      docs-dev-guide: write
+      docs-loggregator: write
+      docs-running-cf: write
+      docs-services: write
+  DotNET DevX:
+    description: ""
+    maintainers:
+    - kartiklunkad26
+    members:
+    - atwoosnam
+    - zzori-theoriginal
+    privacy: closed
+  Exploratory Tester:
+    description: ""
+    members:
+    - aemengo
+    - anEXPer
+    privacy: closed
+  Foundational Infrastructure WG:
+    description: Approvers for the Foundational Infrastructure WG
+    maintainers:
+    - rkoster
+    - beyhan
+    - christopherclark
+    members:
+    - jpalermo
+    - beyhan
+    - lnguyen
+    - ramonskie
+    - bgandon
+    - KaiHofstetter
+    - friegger
+    - cf-rabbit-bot
+    privacy: closed
+    repos:
+      backup-and-restore-sdk-release: write
+      bosh: write
+      bosh-acceptance-tests: write
+      bosh-agent: write
+      bosh-agent-index: write
+      bosh-alicloud-light-stemcell-builder: write
+      bosh-aws-cpi-release: write
+      bosh-aws-light-stemcell-builder: write
+      bosh-azure-cpi-release: write
+      bosh-backup-and-restore-test-releases: write
+      bosh-bbl-ci-envs: write
+      bosh-cli: write
+      bosh-community-stemcell-ci-infra: write
+      bosh-compiled-releases-index: write
+      bosh-cpi-certification: write
+      bosh-cpi-environments: write
+      bosh-cpi-go: write
+      bosh-cpi-kb: write
+      bosh-cpi-ruby: write
+      bosh-davcli: write
+      bosh-deployment: write
+      bosh-deployment-resource: write
+      bosh-disaster-recovery-acceptance-tests: write
+      bosh-dns-aliases-release: write
+      bosh-dns-release: write
+      bosh-docker-cpi-release: write
+      bosh-gcscli: write
+      bosh-google-cpi-release: write
+      bosh-google-light-stemcell-builder: write
+      bosh-linux-stemcell-builder: write
+      bosh-openstack-cpi-release: write
+      bosh-s3cli: write
+      bosh-softlayer-cpi-release: write
+      bosh-stemcells-ci: write
+      bosh-utils: write
+      bosh-virtualbox-cpi-release: write
+      bosh-vsphere-cpi-release: write
+      bosh-warden-cpi-release: write
+      bosh-windows-acceptance-tests: write
+      bosh-windows-stemcell-builder: write
+      bosh-workstation: write
+      bpm-release: write
+      bsdtar: write
+      cf-mysql-ci: write
+      cf-mysql-deployment: write
+      cf-mysql-release: write
+      cf-uaa-lib: write
+      cf-uaac: write
+      config-server: write
+      config-server-release: write
+      credhub: write
+      credhub-acceptance-tests: write
+      credhub-api-site: write
+      credhub-ci-locks: write
+      credhub-cli: write
+      credhub-perf-release: write
+      disaster-recovery-acceptance-tests: write
+      docs-bbr: write
+      docs-bosh: write
+      docs-credhub: write
+      event-log-release: write
+      exemplar-backup-and-restore-release: write
+      galera-init: write
+      gofileutils: write
+      gosigar: write
+      mysql-backup-release: write
+      mysql-monitoring-release: write
+      omniauth-uaa-oauth2: write
+      os-conf-release: write
+      postgres-release: write
+      pxc-release: write
+      resolvconf-manager: write
+      resolvconf-manager-index: write
+      sample-windows-bosh-release: write
+      secure-credentials-broker: write
+      socks5-proxy: write
+      stembuild: write
+      stemcells-alicloud-index: write
+      syslog-release: write
+      tlsconfig: write
+      uaa: write
+      uaa-key-rotator: write
+      uaa-release: write
+      uaa-singular: write
+      usn-resource: write
+      windows-syslog-release: write
+      windows-tools-release: write
+      windows-utilities-release: write
+      windows-utilities-tests: write
+      yagnats: write
+    teams:
+      Foundational Infrastructure WG leads:
+        description: Technical and Execution Leads for the Foundational Infrastructure
+          WG
+        maintainers:
+        - rkoster
+        - christopherclark
+        members:
+        - beyhan
+        - cf-rabbit-bot
+        privacy: closed
+        repos:
+          backup-and-restore-sdk-release: admin
+          bosh: admin
+          bosh-acceptance-tests: admin
+          bosh-agent: admin
+          bosh-agent-index: admin
+          bosh-alicloud-light-stemcell-builder: admin
+          bosh-aws-cpi-release: admin
+          bosh-aws-light-stemcell-builder: admin
+          bosh-azure-cpi-release: admin
+          bosh-backup-and-restore-test-releases: admin
+          bosh-bbl-ci-envs: admin
+          bosh-cli: admin
+          bosh-community-stemcell-ci-infra: admin
+          bosh-compiled-releases-index: admin
+          bosh-cpi-certification: admin
+          bosh-cpi-environments: admin
+          bosh-cpi-go: admin
+          bosh-cpi-kb: admin
+          bosh-cpi-ruby: admin
+          bosh-davcli: admin
+          bosh-deployment: admin
+          bosh-deployment-resource: admin
+          bosh-disaster-recovery-acceptance-tests: admin
+          bosh-dns-aliases-release: admin
+          bosh-dns-release: admin
+          bosh-docker-cpi-release: admin
+          bosh-gcscli: admin
+          bosh-google-cpi-release: admin
+          bosh-google-light-stemcell-builder: admin
+          bosh-linux-stemcell-builder: admin
+          bosh-openstack-cpi-release: admin
+          bosh-s3cli: admin
+          bosh-softlayer-cpi-release: admin
+          bosh-stemcells-ci: admin
+          bosh-utils: admin
+          bosh-virtualbox-cpi-release: admin
+          bosh-vsphere-cpi-release: admin
+          bosh-warden-cpi-release: admin
+          bosh-windows-acceptance-tests: admin
+          bosh-windows-stemcell-builder: admin
+          bosh-workstation: admin
+          bpm-release: admin
+          bsdtar: admin
+          cf-mysql-ci: admin
+          cf-mysql-deployment: admin
+          cf-mysql-release: admin
+          cf-uaa-lib: admin
+          cf-uaac: admin
+          config-server: admin
+          config-server-release: admin
+          credhub: admin
+          credhub-acceptance-tests: admin
+          credhub-api-site: admin
+          credhub-ci-locks: admin
+          credhub-cli: admin
+          credhub-perf-release: admin
+          disaster-recovery-acceptance-tests: admin
+          docs-bbr: admin
+          docs-bosh: admin
+          docs-credhub: admin
+          event-log-release: admin
+          exemplar-backup-and-restore-release: admin
+          galera-init: admin
+          gofileutils: admin
+          gosigar: admin
+          mysql-backup-release: admin
+          mysql-monitoring-release: admin
+          omniauth-uaa-oauth2: admin
+          os-conf-release: admin
+          postgres-release: admin
+          pxc-release: admin
+          resolvconf-manager: admin
+          resolvconf-manager-index: admin
+          sample-windows-bosh-release: admin
+          secure-credentials-broker: admin
+          socks5-proxy: admin
+          stembuild: admin
+          stemcells-alicloud-index: admin
+          syslog-release: admin
+          tlsconfig: admin
+          uaa: admin
+          uaa-key-rotator: admin
+          uaa-release: admin
+          uaa-singular: admin
+          usn-resource: admin
+          windows-syslog-release: admin
+          windows-tools-release: admin
+          windows-utilities-release: admin
+          windows-utilities-tests: admin
+          yagnats: admin
+  General Contributors:
+    description: Branching access for key CF components
+    maintainers:
+    - sethboyles
+    - ctlong
+    members:
+    - mkocher
+    - Gerg
+    - weymanf
+    - ameowlia
+    - monamohebbi
+    - belinda-liu
+    - moleske
+    - ram-pivot
+    privacy: closed
+    repos:
+      capi-release: write
+      cloud_controller_ng: write
+      gorouter: write
+      routing-perf-release: write
+      routing-release: write
+  Ginkgo Gomega contributors:
+    description: ""
+    members:
+    - kirederik
+    - gcapizzi
+    - edwardecook
+    - blgm
+    - MirahImage
+    privacy: closed
+  IBM Buildpacks:
+    description: ""
+    members:
+    - jgawor
+    privacy: closed
+  Java Experience:
+    description: Developers working on projects related to the Java Experience
+    maintainers:
+    - ekcasey
+    - dmikusa-pivotal
+    members:
+    - scottfrederick
+    - nebhale
+    - jkonicki
+    - nierajsingh
+    - pivotal-david-osullivan
+    privacy: secret
+    repos:
+      archive-expanding-cnb: admin
+      azure-application-insights-cnb: admin
+      build-system-cnb: admin
+      cf-java-client: write
+      debug-cnb: admin
+      dist-zip-cnb: admin
+      google-stackdriver-cnb: admin
+      java-buildpack: admin
+      java-buildpack-auto-reconfiguration: write
+      java-buildpack-client-certificate-mapper: write
+      java-buildpack-container-certificate-trust-store: write
+      java-buildpack-container-customizer: write
+      java-buildpack-dependency-builder: write
+      java-buildpack-memory-calculator: write
+      java-buildpack-metric-writer: write
+      java-buildpack-security-provider: write
+      java-buildpack-support: write
+      java-buildpack-system-test: write
+      java-cnb: admin
+      java-test-applications: write
+      jdbc-cnb: admin
+      jmx-cnb: admin
+      jvm-application-cnb: admin
+      jvmkill: write
+      libcfbuildpack: admin
+      openjdk-cnb: admin
+      procfile-cnb: admin
+      spring-auto-reconfiguration-cnb: admin
+      spring-boot-cnb: admin
+      tomcat-cnb: admin
+  License Finder:
+    description: ""
+    maintainers:
+    - mjear
+    privacy: secret
+  OSS Review:
+    description: ""
+    members:
+    - schubert
+    - aclement
+    - davidschachner
+    privacy: closed
+    repos:
+      metric-store-release: read
+  OSS-PMS-SECURITY:
+    description: Open Source PMs +anchors that should have access to security issues
+    maintainers:
+    - emalm
+    members:
+    - cppforlife
+    - menicosia
+    - mfine30
+    - dsabeti
+    privacy: closed
+    repos:
+      security-notices: read
+  PCF Apps Manager:
+    description: ""
+    maintainers:
+    - elenasharma
+    members:
+    - a-b
+    - weymanf
+    - reedr3
+    - sweinstein22
+    - jdgonzaleza
+    - dominicrobertsc
+    privacy: secret
+  PCF BAM:
+    description: ""
+    members:
+    - drich10
+    - bwinter
+    - anEXPer
+    privacy: secret
+  PCF CloudOps:
+    description: Cloud Foundry Cloud Ops Team
+    members:
+    - xtreme-conor-nosal
+    - bsoroushian
+    - suprajanarasimhan
+    - xtreme-bozhidar-lenchov
+    - bwinter
+    - anEXPer
+    - haydonryan
+    - pws-team-admin-client
+    - degaurab
+    - nedenwalker
+    - rajasekharatvmware
+    - GowriRegistry
+    - Tejuvmware
+    - pkvatvmware
+    privacy: secret
+    repos:
+      deployments-routing: read
+      runtime-credentials: write
+  PCF Docs:
+    description: ""
+    maintainers:
+    - animatedmax
+    members:
+    - Pivotal-Christopher-Wong
+    - pspinrad
+    - nkguy
+    - cf-pub-tools
+    - paigecalvert
+    - jncd
+    - mjgutermuth
+    - pubtools-docs-helper
+    - vikafed
+    - cshollingsworth
+    - snneji
+    - ograves-pivotal
+    - RichardJJG
+    - a-peek4
+    - erabil
+    privacy: secret
+    repos:
+      cfdreddbot: write
+      docs-bbr: admin
+      docs-book-cloudfoundry: admin
+      docs-buildpacks: admin
+      docs-cf-admin: admin
+      docs-cf-cli: admin
+      docs-cfcr: admin
+      docs-cloudfoundry-concepts: admin
+      docs-credhub: admin
+      docs-deploying-cf: admin
+      docs-dev-guide: admin
+      docs-dotnet-core-tutorial: admin
+      docs-loggregator: admin
+      docs-routing: admin
+      docs-running-cf: admin
+      docs-services: admin
+      docs-uaa: admin
+  PCF Gemfire:
+    description: ""
+    members:
+    - pulkit-chandra
+    privacy: closed
+  PCF Healthwatch:
+    description: ""
+    members:
+    - colins
+    - kcboyle
+    - robertjsullivan
+    - iplay88keys
+    - jessepye
+    - hillrw3
+    - markthemarkest
+    - dpruitt2
+    - fredwangwang
+    - jpmcb
+    - jerrybelmonte
+    - johncornish
+    - farmermel
+    - mklanjsek
+    - akodali18
+    - akazantsau
+    - ktollivervmw
+    privacy: closed
+    repos:
+      bosh-system-metrics-forwarder-release: admin
+      bosh-system-metrics-server-release: admin
+      loggregator-release: write
+  PCF Metrics:
+    description: ""
+    members:
+    - rheaton
+    - pivotal-maya-kenedy
+    - Benjamintf1
+    - anEXPer
+    - farmermel
+    privacy: secret
+    repos:
+      dropsonde-protocol-js: admin
+  PCF Open Source License Tooling:
+    description: ""
+    members:
+    - Manifaust
+    - pivotal-so
+    - chaomonica
+    privacy: closed
+  PCF Pub Tools:
+    description: ""
+    maintainers:
+    - animatedmax
+    members:
+    - kejadlen
+    - cf-pub-tools
+    - ClaudeFaundry
+    - pubtools-docs-helper
+    privacy: secret
+    repos:
+      cli-docs-scripts: admin
+      docs-cf-cli: admin
+      docs-dev-guide: admin
+  PCF Release Engineering:
+    description: ""
+    members:
+    - ciriarte
+    - matt-royal
+    - rizwanreza
+    - jpalermo
+    - dtimm
+    - nhsieh
+    - notrepo05
+    - syslxg
+    - DennisDenuto
+    - markstokan
+    - angelachin
+    - crhntr
+    - julian-hj
+    - pivotaljohn
+    - moleske
+    - ctlong
+    - wayneadams
+    - MarcPaquette
+    - pabloarodas
+    - ansergit
+    - sebGilR
+    - JenGoldstrich
+    - jaristiz
+    - pydctw
+    - ram-pivot
+    - pvaramballypivot
+    - piachakra
+    - alejandra-lara
+    - asahil9009
+    privacy: secret
+    repos:
+      runtime-credentials: write
+  PCF Security PCI:
+    description: ""
+    members:
+    - jncd
+    privacy: closed
+  PCF Security Triage:
+    description: ""
+    members:
+    - ajackson
+    - robdimsdale
+    - achasveachas
+    - jknostman3
+    - jsampson1
+    privacy: closed
+  PCF Security Triage Bot:
+    description: ""
+    members:
+    - djavos-bot
+    privacy: closed
+    repos:
+      bosh: read
+      bosh-aws-cpi-release: read
+      bosh-azure-cpi-release: read
+      bosh-cli: read
+      bosh-google-cpi-release: read
+      bosh-openstack-cpi-release: read
+      bosh-vsphere-cpi-release: read
+      capi-release: read
+      cf-mysql-release: read
+      cf-networking-helpers: read
+      cf-networking-release: read
+      cf-routing-test-helpers: read
+      cf-tcp-router: read
+      cflinuxfs2: read
+      cflinuxfs3: read
+      diego-release: read
+      dontpanic: read
+      garden-runc-release: read
+      gorouter: read
+      java-buildpack: read
+      log-cache-release: read
+      loggregator-release: read
+      nats-release: read
+      networking-oss-deployments: read
+      php-buildpack: read
+      route-registrar: read
+      routing-acceptance-tests: read
+      routing-api: read
+      routing-api-cli: read
+      routing-info: read
+      routing-perf-release: read
+      routing-release: read
+      ruby-buildpack: read
+      silk: read
+      silk-release: read
+      staticfile-buildpack: read
+      uaa-release: read
+  PCF Toolsmiths:
+    description: ""
+    maintainers:
+    - sunnytoolsmiths
+    members:
+    - tinygrasshopper
+    - cf-toolsmiths
+    privacy: closed
+    repos:
+      cf-slackin: admin
+      cfdreddbot: admin
+      cli-private: write
+      docs-book-cloudfoundry: write
+      go-fetcher: admin
+      homebrew-tap: write
+  PHD service:
+    description: ""
+    maintainers:
+    - dsboulder
+    members:
+    - rnandi
+    - rainmaker
+    privacy: secret
+  PMC Leads:
+    description: ""
+    maintainers:
+    - maximilien
+    - emalm
+    - mattmcneeney
+    members:
+    - cppforlife
+    - troytop
+    privacy: secret
+    repos:
+      pmc-notes: admin
+  PMC Notes Contributors:
+    description: Contributors to the PMC Notes
+    maintainers:
+    - maximilien
+    - voelzmo
+    - emalm
+    members:
+    - jandubois
+    - menicosia
+    - gcapizzi
+    - stefanlay
+    - staylor14
+    - shamus
+    - a-b
+    - mfine30
+    - sethboyles
+    - domdom82
+    - aminjam
+    - Benjamintf1
+    - valeriap
+    - Birdrock
+    - ameowlia
+    - julian-hj
+    - smoser-ibm
+    - kartiklunkad26
+    - mnitchev
+    - JenGoldstrich
+    - Soha-Albaghdady
+    - pvaramballypivot
+    privacy: secret
+    repos:
+      cfar-proposals: write
+      pmc-notes: write
+  Pivotal-only Greenhouse:
+    description: Pivots only - Windows Garden
+    maintainers:
+    - benmoss
+    members:
+    - micahyoung
+    - idoru
+    - Shanfan
+    - stuart-pollock
+    - aminjam
+    - aemengo
+    - natalieparellano
+    - amakhija
+    - mvalliath
+    privacy: secret
+    repos:
+      deployments-diego: write
+  Postgres Release:
+    description: ""
+    members:
+    - suhlig
+    - valeriap
+    privacy: closed
+    repos:
+      postgres-ci-env: admin
+      postgres-release: admin
+  Production:
+    description: ""
+    maintainers:
+    - dsboulder
+    - emalm
+    members:
+    - matt-royal
+    - aramprice
+    - ajackson
+    - jpalermo
+    - rmorgan
+    - mariash
+    - cppforlife
+    - frodenas
+    - d
+    - fhanik
+    - dsabeti
+    - jhvhs
+    - kcboyle
+    - zrob
+    - syslxg
+    - GarimaSharma
+    - drich10
+    - pvtl-shane
+    - anEXPer
+    - robdimsdale
+    - degaurab
+    privacy: secret
+  Quarks:
+    description: ""
+    maintainers:
+    - viovanov
+    members:
+    - jandubois
+    - aduffeck
+    - manno
+    - jeff-hobbs
+    - andreas-kupries
+    - HeavyWombat
+    - f0rmiga
+    - edwardstudy
+    - bikramnehra
+    - mook-as
+    - qu1queee
+    - rohitsakala
+    - zhangtbj
+    privacy: closed
+    repos:
+      quarks-private: write
+  RabbitMQ:
+    description: ""
+    members:
+    - michaelklishin
+    - monadic
+    - rade
+    - james-masson
+    - mkuratczyk
+    - blgm
+    - pcfrabbitmq-concourse-ci
+    privacy: secret
+    repos:
+      bosh-deployment: read
+      loggregator: read
+      service-metrics: read
+      service-metrics-release: read
+  Runtime Bot:
+    description: ""
+    members:
+    - runtime-ci
+    privacy: secret
+    repos:
+      api-docs: write
+      brats: write
+      cf-smoke-tests: write
+      cflinuxfs2: write
+      cloud_controller_ng: write
+      delayed_job_sequel: write
+      gofileutils: write
+      gorouter: write
+      lamb-ci-tools: write
+      runtime-credentials: write
+      runtime-team-checklists: write
+      vcap-common: write
+  Security Disclosure Policy:
+    description: ""
+    privacy: closed
+    repos:
+      .github: admin
+  Service Community Writers:
+    description: ""
+    maintainers:
+    - rkoster
+    members:
+    - bonzofenix
+    - kushmerick
+    - nand2
+    - cf-services
+    privacy: secret
+  Spinnaker:
+    description: ""
+    members:
+    - tanzeeb
+    - xtreme-sameer-vohra
+    - briannebrown
+    privacy: closed
+  Tracker:
+    description: A team for the Pivotal Tracker folks to get read only access to key
+      repos
+    members:
+    - oppegard
+    - tracker-common
+    privacy: secret
+    repos:
+      lamb-ci-tools: read
+  V3 Acceleration Team (VAT):
+    description: Accelerating and Converging the v3 API & v7 CLI
+    maintainers:
+    - reneighbor
+    - a-b
+    - Gerg
+    - zrob
+    - monamohebbi
+    - tjvman
+    - sweinstein22
+    - MerricdeLauney
+    members:
+    - selzoc
+    - cunnie
+    - sethboyles
+    - bepotts
+    - weymanf
+    - belinda-liu
+    - piyalibanerjee
+    - MarcPaquette
+    - JenGoldstrich
+    - hnandiwada
+    - ewrenn8
+    privacy: closed
+    repos:
+      CLAW: write
+      canibump: admin
+      capi-bara-tests: write
+      capi-ci: admin
+      capi-ci-private: write
+      capi-dockerfiles: admin
+      capi-env-pool: write
+      capi-release: read
+      capi-team-checklists: admin
+      capi-workspace: admin
+      cc-api-v3-style-guide: write
+      cf-acceptance-tests: write
+      cf-deployment: write
+      cli: admin
+      cli-ci: admin
+      cli-pools: write
+      cli-private: write
+      cli-workstation: admin
+      cloud_controller_ng: write
+      jsonry: admin
+  VMware Licensing:
+    description: ""
+    members:
+    - GarfieldLinux
+    - rogerluo410
+    - davidschachner
+    privacy: secret
+    repos:
+      cf-app-utils-ruby: read
+      cf-java-client: read
+      cf-mysql-release: read
+      docs-dev-guide: read
+      docs-services: read
+      gorouter: read
+      gosigar: read
+      ibm-websphere-liberty-buildpack: read
+      identity-tools: read
+      lamb-ci-tools: read
+      loggregator-release: read
+      loggregator_emitter: read
+      membrane: read
+      nodejs-buildpack: read
+      omniauth-uaa-oauth2: read
+      rbenv-cookbook: read
+      ruby-buildpack: read
+      vcap-common: read
+  Working Group leads:
+    description: ""
+    maintainers:
+    - rkoster
+    members:
+    - gcapizzi
+    - beyhan
+    - ameowlia
+    - georgethebeatle
+    privacy: closed
+    repos:
+      community: write
+  bosh-backup-and-restore-team:
+    description: Team for BOSH Backup and Restore project
+    members:
+    - maximilien
+    - kirederik
+    - tinygrasshopper
+    - totherme
+    - mamachanko
+    - winnab
+    - neil-hickey
+    - MirahImage
+    - jimbo459
+    - gbandres98
+    - bbr-ci
+    - fejnartal
+    - sanagaraj-pivotal
+    privacy: closed
+    repos:
+      capi-ci: write
+      capi-ci-private: write
+      capi-k8s-release: write
+      docs-bbr: read
+      homebrew-tap: write
+  bosh-ci bot:
+    description: ""
+    members:
+    - bosh-ci-push-pull
+    privacy: closed
+    repos:
+      bosh-cli: admin
+  bosh-init-concourse:
+    description: Machine users that do things like tag repos from a pipeline
+    members:
+    - bosh-init-concourse
+    privacy: secret
+  bosh-lite:
+    description: Team that writes bosh-lite
+    members:
+    - cppforlife
+    privacy: secret
+  bosh-softlayer:
+    description: Team of BOSH SL developers
+    maintainers:
+    - maximilien
+    members:
+    - cppforlife
+    - mattcui
+    - zhanggbj
+    - jianqiu
+    - gu-bin
+    privacy: closed
+    repos:
+      bosh-softlayer-cpi-release: read
+  bosh-stemcell:
+    description: ""
+    maintainers:
+    - dsboulder
+    - rkoster
+    - KaiHofstetter
+    - friegger
+    - christopherclark
+    members:
+    - mvach
+    - ramonskie
+    - mrosecrance
+    - bgandon
+    - joergdw
+    - StefanWutz
+    - FlorianNachtigall
+    - yatzek
+    - cf-bosh-ci-bot
+    privacy: closed
+    repos:
+      bosh-community-stemcell-ci-infra: write
+      bosh-linux-stemcell-builder: admin
+  bosh-website-admins:
+    description: ""
+    members:
+    - frodenas
+    privacy: secret
+  bots (pull only):
+    description: ""
+    members:
+    - cf-zapier
+    - routing-ci
+    privacy: secret
+    repos:
+      cflinuxfs2: read
+      cloud_controller_ng: read
+      deployments-routing: read
+      gorouter: read
+      gosteno: read
+      nodejs-buildpack: read
+      ruby-buildpack: read
+      vcap-common: read
+  bots (push & pull):
+    description: ""
+    members:
+    - cf-sprout
+    privacy: secret
+    repos:
+      cf-app-utils-ruby: write
+      cf-java-client: write
+      gofileutils: write
+      java-buildpack-auto-reconfiguration: write
+      uaa: write
+  c4ke:
+    description: ""
+    members:
+    - matt-royal
+    - tcdowney
+    - angelachin
+    - heycait
+    - piyalibanerjee
+    privacy: closed
+    repos:
+      capi-ci: write
+      capi-ci-private: write
+      capi-k8s-release: admin
+      cf-for-k8s-metric-examples: write
+      cf-k8s-prometheus: write
+      cloud_controller_ng: write
+      log-cache-release: write
+      metric-proxy: write
+  cf-autoscaler:
+    description: CF Application Autoscaler core dev team
+    maintainers:
+    - silvestre
+    members:
+    - bonzofenix
+    - donacarr
+    privacy: closed
+    repos:
+      app-autoscaler: admin
+      app-autoscaler-ci: admin
+      app-autoscaler-cli-plugin: admin
+      app-autoscaler-env-bbl-state: admin
+      app-autoscaler-release: admin
+      app-autoscaler-ui: write
+      bosh-compile-action: admin
+      runtime-og-ci-private: write
+  cf-frontend bot:
+    description: ""
+    members:
+    - cf-frontend
+    privacy: secret
+  cf-k8s:
+    description: ""
+    maintainers:
+    - matt-royal
+    - davewalter
+    - gcapizzi
+    - PureMunky
+    - Shanfan
+    - tcdowney
+    - danail-branekov
+    - emalm
+    - Birdrock
+    - julian-hj
+    - georgethebeatle
+    - mnitchev
+    - kieron-dev
+    - acosta11
+    - gnovv
+    - akrishna90
+    privacy: closed
+    repos:
+      cf-k8s-api: admin
+      cf-k8s-ci: admin
+      cf-k8s-controllers: admin
+      cf-k8s-secrets: admin
+      cf-on-k8s-integration: write
+  cf-release-notes-bot:
+    description: Team for bot that creates release notes on cf-release repo
+    members:
+    - cf-release-notes-bot
+    privacy: secret
+  cf-uaa:
+    description: Cloud Foundry User Account and Authentication Development Team
+    maintainers:
+    - bruce-ricard
+    - cf-identity
+    - peterhaochen47
+    - ccjaimes
+    - hsinn0
+    members:
+    - cf-uaa
+    - cphi-vmw
+    privacy: secret
+    repos:
+      cf-identity-acceptance-tests-release: admin
+      cf-uaa-lib: admin
+      cf-uaac: admin
+      identity-ci: admin
+      identity-tools: write
+      nicky: admin
+      uaa: admin
+      uaa-hey: admin
+      uaa-key-rotator: admin
+      uaa-performance-release: admin
+      uaa-release: admin
+      uaa-singular: admin
+      uaa-singular-example: admin
+      uaa-workstation: admin
+  cfcd-training:
+    description: ""
+    members:
+    - spgreenberg
+    - dhrapson
+    - DanielJonesEB
+    - EngineerBetterCI
+    privacy: secret
+    repos:
+      cfcd-cert-items: write
+      cfcd-ci: write
+      cfcd-course-content: write
+      cfcd-dockerfile: write
+      cfcd-facts: write
+      cfcd-mappings: write
+      cfcd-mindmaps: write
+      cfcd-parser: write
+  cforg-admin:
+    description: ""
+    members:
+    - djac
+    - JacquesPerrault
+    - jgawor
+    - jacksoncvm
+    - krook
+    - duglin
+    - christo4ferris
+    - sykesm
+    - brunssen
+    - rboykin
+    - petersca
+    - jackfengibm
+    - tarpinian
+    - cf-toolsmiths
+    privacy: secret
+    repos:
+      ibm-websphere-liberty-buildpack: admin
+  cloudops-ci:
+    description: ""
+    members:
+    - pws-team-admin-client
+    privacy: secret
+  cryogenics:
+    description: specialists in transitioning from highly agile software development
+      to highly sustainable software maintenance and support
+    maintainers:
+    - kirederik
+    - tinygrasshopper
+    - totherme
+    - dlresende
+    - neil-hickey
+    - jimbo459
+    - gbandres98
+    - fejnartal
+    members:
+    - cf-gitbot
+    - Cryogenics-CI
+    privacy: closed
+    repos:
+      backup-and-restore-sdk-release: write
+      bosh-bootloader: admin
+      cf-volume-services-acceptance-tests: admin
+      cf-volume-services-team: admin
+      disaster-recovery-acceptance-tests: write
+      docker_driver_integration_tests: admin
+      dockerdriver: admin
+      existingvolumebroker: admin
+      go-git-resource: admin
+      goshims: admin
+      mapfs: admin
+      mapfs-release: admin
+      migrate_mysql_to_credhub: admin
+      nfs-volume-release: admin
+      nfsbroker: admin
+      nfsv3driver: admin
+      persi-ci: admin
+      service-broker-store: admin
+      smb-volume-release: admin
+      smbbroker: admin
+      smbdriver: admin
+      volume-mount-options: admin
+      volumedriver: admin
+  dea-maint:
+    description: Team to maintain DEA architecture
+    members:
+    - sykesm
+    privacy: closed
+    repos:
+      runtime-og-ci: write
+      runtime-og-ci-private: admin
+  dev-cert:
+    description: Team for working on Cloud Foundry expert certification exams.
+    members:
+    - C-Otto
+    - spgreenberg
+    - nicregez
+    - simonleung8
+    - romswo
+    - tom-collings
+    privacy: secret
+    repos:
+      dev-cert: write
+      dev-cert-grading: read
+  eclipse-admin:
+    description: ""
+    members:
+    - trevormarshall
+    - nierajsingh
+    privacy: secret
+  eclipse-push:
+    description: ""
+    members:
+    - elsony
+    privacy: secret
+  eirini:
+    description: ""
+    maintainers:
+    - gcapizzi
+    - danail-branekov
+    - georgethebeatle
+    - mnitchev
+    - kieron-dev
+    privacy: closed
+    repos:
+      capi-k8s-release: write
+      cf-crd-explorations: admin
+      cf-for-k8s: write
+      cf-k8s-logging: write
+      eirini-private-config: admin
+  friends-of-runtime-deployments:
+    description: ""
+    members:
+    - danhigham
+    - zrob
+    privacy: secret
+  go-cf-api:
+    description: Write access to go-cf-api POC repositories
+    maintainers:
+    - stephanme
+    members:
+    - philippthun
+    - FloThinksPi
+    - jochenehret
+    - andy-paine
+    - svkrieger
+    - MMisoch
+    - WeiQuan0605
+    - iaftab-alam
+    privacy: closed
+    repos:
+      go-cf-api: write
+      go-cf-api-release: write
+  ibm-read:
+    description: ""
+    members:
+    - rmorgan
+    - nebhale
+    privacy: secret
+    repos:
+      ibm-websphere-liberty-buildpack: read
+  other-uaa-committers:
+    description: Other comitters to the UAA project
+    maintainers:
+    - aramprice
+    - staylor14
+    - peterhaochen47
+    - cfryanr
+    members:
+    - shamus
+    - strehle
+    - tack-sap
+    - phschon
+    privacy: closed
+    repos:
+      cf-identity-acceptance-tests-release: write
+      cf-uaa-lib: write
+      cf-uaac: write
+      nicky: write
+      uaa: write
+      uaa-hey: write
+      uaa-key-rotator: write
+      uaa-performance-release: write
+      uaa-release: write
+      uaa-singular: write
+      uaa-singular-example: write
+  pivotal-practices:
+    description: non-CF Pivotal team doing customer installs
+    members:
+    - joefitzgerald
+    - rickfarmer
+    - skibum55
+    privacy: secret
+  pivotal-security-internal:
+    description: Security reporters from Pivotal
+    members:
+    - aramprice
+    - ajackson
+    - squeedee
+    - mkocher
+    - aemengo
+    privacy: secret
+    repos:
+      security-notices: read
+  pivotal_analytics:
+    description: ""
+    members:
+    - xiongli
+    privacy: secret
+  pks-bosh-lifecycle:
+    description: ""
+    members:
+    - professor
+    - benmoss
+    - SenatorSupes
+    - briannebrown
+    - ahrtr
+    - swalner-pivotal
+    - daniel-keeney
+    privacy: closed
+    repos:
+      docs-cfcr: admin
+  postgres-ci:
+    description: ""
+    maintainers:
+    - valeriap
+    members:
+    - suhlig
+    privacy: closed
+    repos:
+      postgres-release: admin
+  release program:
+    description: ""
+    maintainers:
+    - ciriarte
+    - rizwanreza
+    - jpalermo
+    - nhsieh
+    - notrepo05
+    - syslxg
+    - DennisDenuto
+    - markstokan
+    - angelachin
+    - anEXPer
+    - julian-hj
+    - moleske
+    - ctlong
+    - wayneadams
+    - ram-pivot
+    - pvaramballypivot
+    privacy: closed
+    repos:
+      relint-team: write
+      uptimer: admin
+      yttk8smatchers: write
+  runtime:
+    description: CF Journey Runtime team
+    maintainers:
+    - dsboulder
+    - mariash
+    - reneighbor
+    - acrmp
+    - selzoc
+    - aminjam
+    - Benjamintf1
+    - ameowlia
+    - geofffranks
+    - ctlong
+    - pivotalgeorge
+    - MarcPaquette
+    - rroberts2222
+    - jrussett
+    - cphi-vmw
+    members:
+    - mkocher
+    - cf-gitbot
+    - routing-ci
+    - tas-runtime-bot
+    privacy: closed
+    repos:
+      archiver: admin
+      auction: admin
+      auctioneer: admin
+      bbs: admin
+      benchmarkbbs: admin
+      blackbox: admin
+      bosh-system-metrics-forwarder-release: admin
+      bosh-system-metrics-server-release: admin
+      bytefmt: admin
+      cacheddownloader: admin
+      certauthority: admin
+      certsplitter: admin
+      cf-drain-cli: admin
+      cf-networking-helpers: admin
+      cf-networking-onboarding: admin
+      cf-networking-release: admin
+      cf-routing-test-helpers: admin
+      cf-tcp-router: admin
+      cfdot: admin
+      cfhttp: admin
+      clock: admin
+      consuladapter: admin
+      debugserver: admin
+      deployments-diego: admin
+      deployments-loggregator: admin
+      diego-acceptance: admin
+      diego-ci: admin
+      diego-ci-pools: admin
+      diego-dockerfiles: admin
+      diego-logging-client: admin
+      diego-notes: admin
+      diego-release: admin
+      diego-ssh: admin
+      diego-team: admin
+      diego-upgrade-stability-tests: admin
+      dockerapplifecycle: admin
+      dockerdriver: admin
+      dontpanic: admin
+      durationjson: admin
+      ecrhelper: admin
+      eventhub: admin
+      executor: admin
+      fileserver: admin
+      garden: admin
+      garden-ci: admin
+      garden-integration-tests: admin
+      garden-runc-release: admin
+      go-diodes: admin
+      go-log-cache: admin
+      go-loggregator: admin
+      go-metric-registry: admin
+      gorouter: admin
+      guardian: admin
+      healthcheck: admin
+      idmapper: admin
+      inigo: admin
+      lager: admin
+      localdriver: admin
+      localip: admin
+      locket: admin
+      log-cache-cli: admin
+      log-cache-release: admin
+      loggregator-agent-release: admin
+      loggregator-api: admin
+      loggregator-ci: admin
+      loggregator-release: admin
+      metrics-discovery-release: admin
+      nats-release: admin
+      netplugin-shim: admin
+      networking-oss-deployments: admin
+      noisy-neighbor-nozzle: admin
+      operationq: admin
+      rep: admin
+      route-emitter: admin
+      route-registrar: admin
+      routing-acceptance-tests: admin
+      routing-api: admin
+      routing-api-cli: admin
+      routing-info: admin
+      routing-perf-release: admin
+      routing-release: admin
+      service-metrics-release: admin
+      silk: admin
+      silk-release: admin
+      statsd-injector-release: admin
+      syslog-ci-private: admin
+      syslog-release: admin
+      system-metrics-release: admin
+      system-metrics-scraper-release: admin
+      systemcerts: admin
+      tlsconfig: admin
+      vizzini: admin
+      volman: admin
+      windows-syslog-release: admin
+      workpool: admin
+  stratos-ui:
+    description: ""
+    maintainers:
+    - nwmac
+    members:
+    - richard-cox
+    - kreinecke
+    privacy: closed
+    repos:
+      stratos: admin
+      stratos-buildpack: write
+  tas-vcf-vmc-anycloud:
+    description: TAS VCF, VMC, Anycloud team
+    members:
+    - evanfarrar
+    - cunnie
+    - syslxg
+    - markstokan
+    - julian-hj
+    - moleske
+    - ram-pivot
+    - galenhammond
+    privacy: closed
+    repos:
+      bosh-vsphere-cpi-release: write
+  tempest:
+    description: ""
+    members:
+    - anfernee
+    - kushmerick
+    - dgolds
+    - animatedmax
+    privacy: secret
+    repos:
+      bosh-cpi-kb: read
+  toc:
+    description: Technical Oversight Committee
+    maintainers:
+    - dsboulder
+    - loewenstein
+    - LeePorte
+    - stephanme
+    - emalm
+    privacy: closed
+    repos:
+      community: admin
+  toolsmiths-bots:
+    description: Gitbot and Dreddbot
+    members:
+    - cf-gitbot
+    privacy: closed
+    repos:
+      .github: admin
+      app-autoscaler-cli-plugin: admin
+      app-autoscaler-release: admin
+      app-autoscaler-ui: admin
+      archive-expanding-cnb: admin
+      auth-proxy: admin
+      azure-application-insights-cnb: admin
+      bbl-state-resource: admin
+      blackbox: admin
+      bosh: admin
+      bosh-acceptance-tests: admin
+      bosh-agent: admin
+      bosh-agent-index: admin
+      bosh-aws-cpi-release: admin
+      bosh-aws-light-stemcell-builder: admin
+      bosh-azure-cpi-release: admin
+      bosh-cli: admin
+      bosh-compiled-releases-index: admin
+      bosh-cpi-ruby: admin
+      bosh-davcli: admin
+      bosh-deployment: admin
+      bosh-dns-release: admin
+      bosh-gcscli: admin
+      bosh-google-cpi-release: admin
+      bosh-google-light-stemcell-builder: admin
+      bosh-linux-stemcell-builder: admin
+      bosh-openstack-cpi-release: admin
+      bosh-s3cli: admin
+      bosh-stemcells-ci: admin
+      bosh-system-metrics-forwarder-release: admin
+      bosh-system-metrics-server-release: admin
+      bosh-utils: admin
+      bpm-release: admin
+      bsdtar: admin
+      build-system-cnb: admin
+      buildpack-acceptance-tests: admin
+      buildpacks-feature-eng-ci: admin
+      capi-bara-tests: admin
+      capi-workspace: admin
+      cert-injector: admin
+      certsplitter: admin
+      cf-acceptance-tests: admin
+      cf-drain-cli: admin
+      cf-k8s-networking: admin
+      cf-mysql-deployment: admin
+      cf-relint-ci-semver: admin
+      cf-smoke-tests-release: admin
+      cf-uaa-lib: admin
+      cfar-logging-acceptance-tests: admin
+      cfar-proposals: admin
+      cfcd-prep: admin
+      cflinuxfs2-release: admin
+      cflinuxfs3: admin
+      cflinuxfs3-release: admin
+      cli-i18n: admin
+      cli-workstation: admin
+      cnb-tools: admin
+      commandrunner: admin
+      config-server: admin
+      config-server-release: admin
+      cpu-entitlement-admin-plugin: admin
+      cpu-entitlement-plugin: admin
+      dagger: admin
+      debug-cnb: admin
+      deployments-routing: admin
+      developer-training-class-apps: admin
+      developer-training-class-site: admin
+      diego-logging-client: admin
+      dist-zip-cnb: admin
+      dockerdriver: admin
+      docs-bbr: admin
+      docs-bosh: admin
+      docs-cfcr: admin
+      docs-credhub: admin
+      docs-dotnet-core-tutorial: admin
+      docs-uaa: admin
+      dontpanic: admin
+      dotnet-core-cnb: admin
+      dropsonde-protocol-js: admin
+      durandal-env: admin
+      ecrhelper: admin
+      exemplar-release: admin
+      existingvolumebroker: admin
+      filelock: admin
+      fluentbit-loggr-plugin: admin
+      garden: admin
+      garden-ci-artifacts-release: admin
+      garden-dotfiles: admin
+      garden-integration-tests: admin
+      garden-performance-acceptance-tests: admin
+      garden-runc-release: admin
+      garden-windows-ci: admin
+      go-batching: admin
+      go-cnb: admin
+      go-diodes: admin
+      go-envstruct: admin
+      go-log-cache: admin
+      go-loggregator: admin
+      go-metric-registry: admin
+      go-pubsub: admin
+      go-socks5: admin
+      google-stackdriver-cnb: admin
+      goshims: admin
+      gosigar: admin
+      grace: admin
+      groot: admin
+      groot-windows: admin
+      guardian: admin
+      homebrew-tap: admin
+      honeycomb-ginkgo-reporter: admin
+      hwc: admin
+      hydrator: admin
+      identity-tools: admin
+      idmapper: admin
+      istio-scaling: admin
+      istio-scriptio: admin
+      java-buildpack-client-certificate-mapper: admin
+      java-buildpack-security-provider: admin
+      java-cnb: admin
+      jdbc-cnb: admin
+      jmx-cnb: admin
+      jumpbox-deployment: admin
+      jvm-application-cnb: admin
+      leadership-election: admin
+      leadership-election-release: admin
+      leela-env: admin
+      libcfbuildpack: admin
+      log-cache: admin
+      log-cache-acceptance-tests: admin
+      log-cache-acceptance-tests-release: admin
+      log-cache-ci: admin
+      log-cache-cli: admin
+      log-cache-deployments: admin
+      log-cache-release: admin
+      log-stream-cli: admin
+      logging-acceptance-tests: admin
+      logging-acceptance-tests-release: admin
+      loggregator: admin
+      loggregator-agent: admin
+      loggregator-agent-release: admin
+      loggregator-dotfiles: admin
+      mapfs: admin
+      mapfs-release: admin
+      metric-proxy: admin
+      metric-store-ci: admin
+      metric-store-dotfiles: admin
+      metric-store-rampup: admin
+      metric-store-release: admin
+      metrics-discovery-release: admin
+      migrate_mysql_to_credhub: admin
+      netplugin-shim: admin
+      networking-program-checklists: admin
+      networking-workspace: admin
+      nfs-volume-release: admin
+      nfsbroker: admin
+      nfsv3driver: admin
+      nodejs-cnb: admin
+      nodejs-compat-cnb: admin
+      noisy-neighbor-nozzle: admin
+      openjdk-cnb: admin
+      os-conf-release: admin
+      oss-summit-class: admin
+      php-cnb: admin
+      php-compat-cnb: admin
+      pip-pop: admin
+      policy_client: admin
+      procfile-cnb: admin
+      python-cnb: admin
+      python-compat-cnb: admin
+      relint-ci-pools: admin
+      relogger: admin
+      routing-ci: admin
+      routing-sample-apps: admin
+      sample-http-app: admin
+      sample-service-metrics-release: admin
+      secure-credentials-broker: admin
+      service-broker-store: admin
+      service-logs-release: admin
+      service-metrics: admin
+      service-metrics-release: admin
+      sipid: admin
+      smb-volume-release: admin
+      smbbroker: admin
+      smbdriver: admin
+      socks5-proxy: admin
+      spring-auto-reconfiguration-cnb: admin
+      spring-boot-cnb: admin
+      stack-auditor: admin
+      stratos: admin
+      stratos-buildpack: admin
+      summit-hands-on-labs: admin
+      syslog-blackbox-release: admin
+      syslog-ci-private: admin
+      syslog-release: admin
+      system-metrics-release: admin
+      system-metrics-scraper-release: read
+      tlsconfig: admin
+      tomcat-cnb: admin
+      tycho-env: admin
+      uaa-hey: admin
+      uaa-key-rotator: admin
+      uptimer: admin
+      usn-resource: admin
+      volume-mount-options: admin
+      volumedriver: admin
+      winc: admin
+      winc-release: admin
+      windows-regression-tests: admin
+      windows-syslog-release: admin
+      windows-tools-release: admin
+      windows2016fs: admin
+      windows2019fs-release: admin
+      windowsfs-online-release: admin
+      yagnats: admin
+      ykk: admin
+  uaa-keystone:
+    description: a team for collaborating on UAA and OpenStack Keystone
+    members:
+    - objectfox
+    - maximilien
+    - rmorgan
+    - fhanik
+    - satiar
+    - roshan-a
+    - christo4ferris
+    privacy: secret
+  vulnerability-management:
+    description: ""
+    members:
+    - hyakuhei
+    - Markus-Ehrnsperger
+    privacy: secret
+    repos:
+      security-notices: admin


### PR DESCRIPTION
This PR adds initial org management automation using Github Actions and [peribolos](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos) (a tools created by the k8s test-infra group).