### PR TITLE
Add the repo for CredHub BOSH Release to the scope of the infra WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -166,6 +166,7 @@ Components from the BOSH, BOSH Backup and Restore, CredHub, MySQL, Postgres, and
 - [cloudfoundry-incubator/credhub](https://github.com/cloudfoundry-incubator/credhub)
 - [cloudfoundry/docs-credhub](https://github.com/cloudfoundry/docs-credhub)
 - [cloudfoundry/secure-credentials-broker](https://github.com/cloudfoundry/secure-credentials-broker)
+- [pivotal/credhub-release](https://github.com/pivotal/credhub-release)
 
 ### Integrated Databases
 - [cloudfoundry-incubator/cf-mysql-ci](https://github.com/cloudfoundry-incubator/cf-mysql-ci)


### PR DESCRIPTION
Hi CFF fellows,

I've just stumbled upon this repo, which in my opinion should be within the scope of our _Foundational Infrastructure_ Working Group, and should be a good candidate for being donated by VMware to the CFF foundation.

Who should we get in touch with for pushing forward that idea of this repo joining the `cloudfoundry` GitHub org?

Benjamin