### PR TITLE
Remove archived repos from the CF-on-K8s WG TAs

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -49,7 +49,5 @@ Execution Lead:
 
 ## Technical Assets
 
-* https://github.com/cloudfoundry/cf-k8s-api
 * https://github.com/cloudfoundry/cf-k8s-controllers
-* https://github.com/cloudfoundry/cf-crd-explorations
 * https://github.com/cloudfoundry-incubator/eirini-controller


### PR DESCRIPTION
This removes a couple of repositories from the CF-on-K8s WG Technical Assets:
* `cloudfoundry/cf-crd-explorations` which has been archived
* `cloudfoundry/cf-k8s-api` which has been merged into `cloudfoundry/cf-k8s-controllers` and archived