### PR TITLE
Add areas for docs to existing Working Groups

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -66,6 +66,9 @@ CLI
 - @a-b 
 - @jdgonzaleza
 
+Docs
+- @mjgutermuth
+
 Java Tools
 - @dmikusa-pivotal
 - @pivotal-david-osullivan
@@ -142,6 +145,7 @@ Buildpacks
 - https://github.com/cloudfoundry/brats
 
 CAPI
+- https://github.com/cloudfoundry/api-docs
 - https://github.com/cloudfoundry/cloud_controller_ng
 - https://github.com/cloudfoundry/capi-release
 - https://github.com/cloudfoundry/capi-dockerfiles
@@ -159,6 +163,12 @@ CLI
 - https://github.com/cloudfoundry/cli-i18n
 - https://github.com/cloudfoundry/cli-ci
 - https://github.com/cloudfoundry/cli-plugin-repo
+
+Docs
+- https://github.com/cloudfoundry/docs-cf-cli
+- https://github.com/cloudfoundry/docs-cloudfoundry-concepts
+- https://github.com/cloudfoundry/docs-dev-guide
+- https://github.com/cloudfoundry/docs-services
 
 Java Tools
 - https://github.com/cloudfoundry/cf-java-client

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -46,6 +46,9 @@ Diego:
 - @reneighbor
 - @selzoc
 
+Docs:
+- @mjgutermuth
+
 Garden Containers:
 - @aemengo
 - @danail-branekov
@@ -125,6 +128,12 @@ Components from the Diego, Garden, HAproxy, Logging and Metrics, Networking, Win
   * https://github.com/cloudfoundry/vizzini
   * https://github.com/cloudfoundry/volman
   * https://github.com/cloudfoundry/workpool
+
+### Docs
+* https://github.com/cloudfoundry/docs-book-cloudfoundry
+* https://github.com/cloudfoundry/docs-cf-admin
+* https://github.com/cloudfoundry/docs-loggregator
+* https://github.com/cloudfoundry/docs-running-cf
 
 ### Garden Containers
 * https://github.com/cloudfoundry/garden-runc-release

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -151,6 +151,7 @@ Components from the BOSH, BOSH Backup and Restore, CredHub, MySQL, Postgres, and
 ### Identity and Auth (UAA)
 - [cloudfoundry/cf-uaa-lib](https://github.com/cloudfoundry/cf-uaa-lib)
 - [cloudfoundry/cf-uaac](https://github.com/cloudfoundry/cf-uaac)
+- [cloudfoundry/docs-uaa](https://github.com/cloudfoundry/docs-uaa)
 - [cloudfoundry/omniauth-uaa-oauth2](https://github.com/cloudfoundry/omniauth-uaa-oauth2)
 - [cloudfoundry/uaa-key-rotator](https://github.com/cloudfoundry/uaa-key-rotator)
 - [cloudfoundry/uaa-release](https://github.com/cloudfoundry/uaa-release)
@@ -159,6 +160,7 @@ Components from the BOSH, BOSH Backup and Restore, CredHub, MySQL, Postgres, and
 
 ### Credential Management (Credhub)
 - [cloudfoundry-incubator/credhub-acceptance-tests](https://github.com/cloudfoundry-incubator/credhub-acceptance-tests)
+- [cloudfoundry-incubator/credhub-api-docs](https://github.com/cloudfoundry-incubator/credhub-api-docs)
 - [cloudfoundry-incubator/credhub-api-site](https://github.com/cloudfoundry-incubator/credhub-api-site)
 - [cloudfoundry-incubator/credhub-ci-locks](https://github.com/cloudfoundry-incubator/credhub-ci-locks)
 - [cloudfoundry-incubator/credhub-cli](https://github.com/cloudfoundry-incubator/credhub-cli)


### PR DESCRIPTION
This change adds the active docs repos to the App Runtime Interfaces, App Runtime Platform, and Foundational Infrastructure working groups, as proposed in https://github.com/cloudfoundry/community/pull/150#issuecomment-993419174.