### PR TITLE
No dry-run + switch to github app auth

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -20,4 +20,4 @@ jobs:
         uses: docker://gcr.io/k8s-prow/peribolos
         with:
           entrypoint: /app/prow/cmd/peribolos/app.binary
-          args: --confirm=true --required-admins=thelinuxfoundation --min-admins=5 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --config-path=org/cloudfoundry.yml --fix-org --fix-org-members --fix-teams --fix-team-members
+          args: --confirm=true --required-admins=thelinuxfoundation --min-admins=5 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --require-self=false --config-path=org/cloudfoundry.yml --fix-org --fix-org-members --fix-teams --fix-team-members

--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: write token
-        run: echo "${GITHUB_TOKEN}" > token
+      - name: write github private key
+        run: echo "${GITHUB_PRIVATE_KEY}" > private_key
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
       - name: peribolos
         uses: docker://gcr.io/k8s-prow/peribolos
         with:
           entrypoint: /app/prow/cmd/peribolos/app.binary
-          args: --confirm=false --required-admins=thelinuxfoundation --min-admins=5 --github-token-path token --config-path=org/cloudfoundry.yml --fix-org --fix-org-members --fix-teams --fix-team-members
+          args: --confirm=true --required-admins=thelinuxfoundation --min-admins=5 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --config-path=org/cloudfoundry.yml --fix-org --fix-org-members --fix-teams --fix-team-members

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -5,7 +5,6 @@ orgs:
     - dsboulder
     - emalm
     - halliwilljustin
-    - jpalmerLinuxFoundation
     - LeePorte
     - loewenstein
     - mjear
@@ -28,6 +27,7 @@ orgs:
     - a-sudarsanan
     - aaronshurley
     - ab-pivot
+    - abdermendz
     - AbelHu
     - abg
     - ablease
@@ -42,6 +42,7 @@ orgs:
     - addytripathi
     - adobley
     - aduffeck
+    - advpetc
     - aemengo
     - ahrtr
     - aiswarianair
@@ -50,7 +51,6 @@ orgs:
     - akodali18
     - akrishna90
     - Albertoimpl
-    - albertoleal
     - alejandra-lara
     - altonf4
     - amakhija
@@ -98,6 +98,7 @@ orgs:
     - bosh-ci-push-pull
     - bosh-init-concourse
     - bosh-windows-ci
+    - boyan-velinov
     - boyang9527
     - brannon
     - brayanhenao
@@ -150,6 +151,7 @@ orgs:
     - ciriarte
     - ClaudeFaundry
     - claurence
+    - clintyoshimura
     - cobyrne
     - cobyrne-pivot
     - colins
@@ -176,6 +178,7 @@ orgs:
     - davidschachner
     - dbasner
     - dbuchko
+    - ddonchev
     - degaurab
     - DennisDenuto
     - derwei
@@ -207,6 +210,7 @@ orgs:
     - edespino
     - edwardecook
     - edwardstudy
+    - eirinici
     - ekcasey
     - elsony
     - EngineerBetterCI
@@ -255,6 +259,7 @@ orgs:
     - gossion
     - GowriRegistry
     - graeme-davison
+    - grahamlutz
     - greenhouse-ci
     - gsiener
     - gu-bin
@@ -267,7 +272,6 @@ orgs:
     - hemarsai
     - herrjulz
     - heyjcollins
-    - hillrw3
     - hjcalderon10
     - hmanukyanVMw
     - hnandiwada
@@ -278,8 +282,10 @@ orgs:
     - idoru
     - IgorBelyi
     - ihcsim
+    - ikasarov
     - ilackarms
     - iplay88keys
+    - IvanBorislavovDimitrov
     - jackfengibm
     - jacksoncvm
     - JacquesPerrault
@@ -311,7 +317,6 @@ orgs:
     - joergdw
     - johha
     - johncornish
-    - jomsie
     - JordanICollier
     - josephgee
     - joshlong
@@ -332,7 +337,6 @@ orgs:
     - kcboyle
     - KeepAustinWired
     - kejadlen
-    - KeshavS0519
     - Kiemes
     - kieron-dev
     - kimago
@@ -428,6 +432,7 @@ orgs:
     - nmaslarski
     - notrepo05
     - nouseforaname
+    - nvvalchev
     - nwmac
     - objectfox
     - ograves-pivotal
@@ -482,6 +487,7 @@ orgs:
     - qibobo
     - qu1queee
     - rade
+    - radito3
     - ragaskar
     - rahulkj
     - rainmaker
@@ -524,7 +530,6 @@ orgs:
     - Samze
     - sanagaraj-pivotal
     - satiar
-    - sbawaska
     - sboyajyan
     - schaefm-ibm
     - schubert
@@ -586,6 +591,7 @@ orgs:
     - Tejuvmware
     - tekul
     - test-12341234
+    - theghost5800
     - thepeterstone
     - thisisnotashwin
     - thitch97
@@ -610,6 +616,7 @@ orgs:
     - videlov
     - vikafed
     - viovanov
+    - vkalapov
     - voelzmo
     - wattersjames
     - wayneadams
@@ -748,8 +755,8 @@ orgs:
         description: Signed URLs, or your money back!
         has_projects: true
       bosh:
-        description: Cloud Foundry BOSH is an open source tool chain for release engineering,
-          deployment and lifecycle management of large scale distributed services.
+        default_branch: main
+        description: Cloud Foundry BOSH is an open source tool chain for release engineering, deployment and lifecycle management of large scale distributed services.
         has_projects: false
         has_wiki: false
         homepage: https://bosh.io
@@ -783,6 +790,9 @@ orgs:
         description: BOSH Azure CPI
         has_projects: true
         has_wiki: false
+      bosh-backup-and-restore:
+        has_projects: true
+        homepage: https://docs.cloudfoundry.org/bbr
       bosh-backup-and-restore-test-releases:
         description: Test Releases for bosh-backup-and-restore
         has_projects: true
@@ -795,8 +805,7 @@ orgs:
         allow_merge_commit: false
         allow_squash_merge: false
         default_branch: main
-        description: Command line utility for standing up a BOSH director on an IAAS
-          of your choice.
+        description: Command line utility for standing up a BOSH director on an IAAS of your choice.
         has_projects: false
         has_wiki: false
       bosh-cli:
@@ -953,6 +962,7 @@ orgs:
         archived: true
         has_projects: true
       buildpack-acceptance-tests:
+        archived: true
         has_projects: false
         has_wiki: false
       buildpack-checklists:
@@ -965,8 +975,7 @@ orgs:
         has_projects: false
         has_wiki: false
       buildpackapplifecycle:
-        description: The bit that takes some bits, mashes them together with other
-          bits, and produces a new bit
+        description: The bit that takes some bits, mashes them together with other bits, and produces a new bit
         has_projects: false
         has_wiki: false
       buildpacks-ci:
@@ -1052,8 +1061,7 @@ orgs:
         has_projects: true
       cc-uploader:
         default_branch: main
-        description: CC Bridge component to enable Diego to upload files to Cloud
-          Controller's blobstore
+        description: CC Bridge component to enable Diego to upload files to Cloud Controller's blobstore
         has_projects: true
       cert-injector:
         has_projects: true
@@ -1138,9 +1146,13 @@ orgs:
       cf-lite-ci:
         has_projects: true
         private: true
+      cf-mysql-bootstrap:
+        description: Auto-bootstrap errand for cf-mysql-release
+        has_projects: true
       cf-mysql-ci:
-        description: Contains Concourse CI scripts and configuration we use to test
-          cf-mysql-release
+        description: Contains Concourse CI scripts and configuration we use to test cf-mysql-release
+        has_projects: true
+      cf-mysql-cluster-health-logger:
         has_projects: true
       cf-mysql-deployment:
         default_branch: develop
@@ -1151,8 +1163,7 @@ orgs:
         has_projects: true
       cf-networking-deployments:
         archived: true
-        description: Private manifests and credentials for the Container Networking
-          team
+        description: Private manifests and credentials for the Container Networking team
         has_issues: false
         has_projects: true
         has_wiki: false
@@ -1165,8 +1176,7 @@ orgs:
         has_wiki: false
       cf-networking-onboarding:
         default_branch: main
-        description: Onboarding materials for new contributors in the routing/networking
-          area of CF
+        description: Onboarding materials for new contributors in the routing/networking area of CF
         has_projects: true
       cf-networking-release:
         allow_merge_commit: false
@@ -1175,6 +1185,12 @@ orgs:
         has_projects: true
         has_wiki: false
       cf-on-k8s-integration:
+        default_branch: main
+        has_projects: true
+      cf-performance-tests:
+        default_branch: main
+        has_projects: true
+      cf-performance-tests-pipeline:
         default_branch: main
         has_projects: true
       cf-relint-ci-semver:
@@ -1189,8 +1205,7 @@ orgs:
         private: true
       cf-smoke-tests:
         default_branch: main
-        description: Smoke tests for CloudFoundry that are safe to run in a production
-          environment
+        description: Smoke tests for CloudFoundry that are safe to run in a production environment
         has_projects: true
       cf-smoke-tests-release:
         default_branch: main
@@ -1201,8 +1216,7 @@ orgs:
         description: TCP Router repository for Cloud Foundry
         has_projects: true
       cf-uaa-lib:
-        description: Ruby client APIs to access the Cloud Foundry User Account and
-          Authentication service
+        description: Ruby client APIs to access the Cloud Foundry User Account and Authentication service
         has_projects: true
       cf-uaac:
         has_projects: true
@@ -1219,8 +1233,7 @@ orgs:
         has_projects: true
       cfcd-broker:
         default_branch: main
-        description: This service broker to manage infrastructure as part of the Cloud
-          Foundry Certified Developer exam.
+        description: This service broker to manage infrastructure as part of the Cloud Foundry Certified Developer exam.
         has_projects: true
         private: true
       cfcd-cert-items:
@@ -1267,10 +1280,7 @@ orgs:
         has_projects: true
         private: true
       cff-platform-certification:
-        description: Cloud Foundry Platform Certification technical requirements.
-          All changes to the technical requirements document must be approved by the
-          PMC Council, but may be proposed by any member in good standing of the Cloud
-          Foundry Foundation.
+        description: Cloud Foundry Platform Certification technical requirements. All changes to the technical requirements document must be approved by the PMC Council, but may be proposed by any member in good standing of the Cloud Foundry Foundation.
         has_projects: true
         private: true
       cfhttp:
@@ -1327,6 +1337,13 @@ orgs:
         description: time provider & rich fake for Go
         has_issues: false
         has_projects: true
+      cloud-service-broker:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        description: OSBAPI service broker that uses Terraform to provision and bind services. Derived from https://github.com/GoogleCloudPlatform/gcp-service-broker
+        has_projects: true
+        has_wiki: false
       cloud_controller_ng:
         default_branch: main
         description: Cloud Foundry Cloud Controller
@@ -1338,6 +1355,7 @@ orgs:
         archived: true
         has_projects: true
       cnb2cf:
+        archived: true
         has_projects: true
       commandrunner:
         has_projects: true
@@ -1347,10 +1365,10 @@ orgs:
         has_projects: true
         has_wiki: false
       communitydashboard:
+        archived: true
         has_projects: true
       compile-extensions:
-        description: Bash library which provides extra functions and overrides for
-          Cloud Foundry Buildpack compile scripts.
+        description: Bash library which provides extra functions and overrides for Cloud Foundry Buildpack compile scripts.
         has_projects: false
         has_wiki: false
       config-server:
@@ -1378,8 +1396,7 @@ orgs:
         allow_merge_commit: false
         allow_squash_merge: false
         default_branch: main
-        description: CredHub centralizes and secures credential generation, storage,
-          lifecycle management, and access
+        description: CredHub centralizes and secures credential generation, storage, lifecycle management, and access
         has_projects: true
         has_wiki: false
       credhub-acceptance-tests:
@@ -1398,10 +1415,24 @@ orgs:
         has_projects: true
       credhub-cli:
         default_branch: main
-        description: CredHub CLI provides a command line interface to interact with
-          CredHub servers
+        description: CredHub CLI provides a command line interface to interact with CredHub servers
         has_projects: true
       credhub-perf-release:
+        has_projects: true
+      csb-brokerpak-aws:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        has_projects: true
+      csb-brokerpak-azure:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        has_projects: true
+      csb-brokerpak-gcp:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
         has_projects: true
       dagger:
         has_projects: true
@@ -1418,8 +1449,7 @@ orgs:
         has_projects: true
       deployments-diego:
         allow_merge_commit: false
-        description: Configuration files for deployments owned and managed by the
-          CF Diego team.
+        description: Configuration files for deployments owned and managed by the CF Diego team.
         has_projects: true
         private: true
       deployments-loggregator:
@@ -1434,18 +1464,15 @@ orgs:
         has_wiki: false
         private: true
       dev-cert:
-        description: CF Developer Certification Exam - Private to all that have signed
-          agreement
+        description: CF Developer Certification Exam - Private to all that have signed agreement
         has_projects: true
         private: true
       dev-cert-grading:
-        description: Grading code developed by the Biarca team and to be reviewed
-          by Item Writers
+        description: Grading code developed by the Biarca team and to be reviewed by Item Writers
         has_projects: true
         private: true
       developer-training-class-apps:
-        description: Public repo making apps that are used for the developer training
-          course available to students
+        description: Public repo making apps that are used for the developer training course available to students
         has_projects: true
       developer-training-class-site:
         has_projects: true
@@ -1488,8 +1515,7 @@ orgs:
         description: Diego Notes
         has_projects: true
       diego-perf-release:
-        description: Used to deploy multiple app-pushers and fezzik-runners for performance-testing
-          a Diego(+Runtime) deployment
+        description: Used to deploy multiple app-pushers and fezzik-runners for performance-testing a Diego(+Runtime) deployment
         has_projects: true
       diego-release:
         allow_merge_commit: false
@@ -1553,8 +1579,7 @@ orgs:
         has_wiki: false
         homepage: http://docs.cloudfoundry.org/buildpacks/
       docs-cf-admin:
-        description: A place to put documentation about how to operate your Cloud
-          Foundry deployment using the command line tools bosh and cf
+        description: A place to put documentation about how to operate your Cloud Foundry deployment using the command line tools bosh and cf
         has_projects: true
       docs-cf-cli:
         has_projects: true
@@ -1571,8 +1596,7 @@ orgs:
         description: The docs repo for material on deploying Cloud Foundry
         has_projects: true
       docs-dev-guide:
-        description: Documentation for application developers who want to deploy their
-          applications to Cloud Foundry
+        description: Documentation for application developers who want to deploy their applications to Cloud Foundry
         has_projects: true
       docs-dotnet-core-tutorial:
         has_projects: true
@@ -1581,8 +1605,7 @@ orgs:
       docs-routing:
         has_projects: true
       docs-running-cf:
-        description: A place for docs related to running, monitoring, and troubleshooting
-          a Cloud Foundry deployment
+        description: A place for docs related to running, monitoring, and troubleshooting a Cloud Foundry deployment
         has_projects: true
       docs-services:
         description: Documentation on extending Cloud Foundry
@@ -1605,8 +1628,7 @@ orgs:
         archived: true
         has_projects: true
       dropsonde:
-        description: Go library to collect and emit metric and logging data from CF
-          components.
+        description: Go library to collect and emit metric and logging data from CF components.
         has_projects: true
       dropsonde-protocol:
         description: Protobuf protocol for dropsonde
@@ -1625,12 +1647,30 @@ orgs:
         allow_merge_commit: false
         has_issues: false
         has_projects: true
+      eirini:
+        description: Pluggable container orchestration for Cloud Foundry, and a Kubernetes backend
+        has_projects: false
+        has_wiki: false
+      eirini-ci:
+        description: CI for Eirini
+        has_projects: false
+        has_wiki: false
+        homepage: https://jetson.eirini.cf-app.com
+      eirini-controller:
+        has_projects: true
       eirini-private-config:
         has_projects: false
         private: true
+      eirini-release:
+        description: Helm release for Project Eirini
+        has_projects: true
+      envoy-nginx-release:
+        default_branch: develop
+        description: BOSH release for deploying nginx in place of envoy to enable route integrity on Windows.
+        has_projects: true
       etcd:
-        description: A highly-available key value store for shared configuration and
-          service discovery
+        archived: true
+        description: A highly-available key value store for shared configuration and service discovery
         has_issues: false
         has_projects: true
         has_wiki: false
@@ -1677,6 +1717,9 @@ orgs:
         description: Foundation Charter Documents
         has_projects: true
         private: true
+      galera-healthcheck:
+        description: A lightweight web server written in Golang to check the health of a node in a Galera cluster
+        has_projects: true
       galera-init:
         description: Monit ctl script for MariaDB in cf-mysql-release
         has_projects: true
@@ -1710,6 +1753,7 @@ orgs:
       garden-windows-ci:
         has_projects: true
       git-release-notes:
+        archived: true
         has_projects: true
       go-batching:
         description: Batching implements a generic batcher that can be specialized.
@@ -1728,8 +1772,7 @@ orgs:
         allow_rebase_merge: false
         allow_squash_merge: false
         default_branch: main
-        description: A proof of concept implementation as an alternative to cloud_controller_ng,
-          written in Go.
+        description: A proof of concept implementation as an alternative to cloud_controller_ng, written in Go.
         has_projects: true
         has_wiki: false
         homepage: https://cloudfoundry.github.io/go-cf-api/
@@ -1741,11 +1784,11 @@ orgs:
         archived: true
         has_projects: true
       go-diodes:
+        default_branch: main
         description: Diodes are ring buffers manipulated via atomics.
         has_projects: true
       go-envstruct:
-        description: envstruct is a simple library for populating values on structs
-          from environment variables.
+        description: envstruct is a simple library for populating values on structs from environment variables.
         has_projects: true
       go-fetcher:
         has_projects: true
@@ -1753,13 +1796,19 @@ orgs:
         has_projects: true
       go-log-cache:
         allow_merge_commit: false
+        default_branch: main
+        description: Go Client Library for Log Cache
         has_projects: true
       go-loggregator:
         allow_merge_commit: false
+        default_branch: main
         description: Go Client Library for Loggregator
         has_projects: true
       go-metric-registry:
         allow_merge_commit: false
+        default_branch: main
+        has_projects: true
+      go-orchestrator:
         has_projects: true
       go-pubsub:
         description: Tree based pubsub library for Go.
@@ -1769,6 +1818,7 @@ orgs:
         has_issues: false
         has_projects: true
       gofileutils:
+        archived: true
         description: A collection of go packages to simplify working with files.
         has_projects: true
         has_wiki: false
@@ -1789,10 +1839,14 @@ orgs:
         has_projects: true
         has_wiki: false
       gosteno:
+        archived: true
         has_projects: true
         has_wiki: false
       grace:
         has_projects: true
+      greenhouse-ci:
+        has_projects: true
+        has_wiki: false
       groot:
         has_projects: true
         has_wiki: false
@@ -1890,8 +1944,7 @@ orgs:
         has_projects: true
       java-buildpack-dependency-builder:
         default_branch: main
-        description: Automated building and publication of Java Buildpack dependency
-          artifacts
+        description: Automated building and publication of Java Buildpack dependency artifacts
         has_projects: true
       java-buildpack-memory-calculator:
         default_branch: main
@@ -1931,8 +1984,7 @@ orgs:
       jsonry:
         allow_merge_commit: false
         default_branch: main
-        description: A Go library and notation for converting between a Go struct
-          and JSON
+        description: A Go library and notation for converting between a Go struct and JSON
         has_projects: false
         has_wiki: false
         homepage: https://pkg.go.dev/code.cloudfoundry.org/jsonry?tab=doc
@@ -2021,8 +2073,7 @@ orgs:
         has_projects: true
       log-stream-cli:
         default_branch: develop
-        description: Cloud Foundry CLI plugin to consume logs and metrics from the
-          RLP
+        description: Cloud Foundry CLI plugin to consume logs and metrics from the RLP
         has_projects: true
       logging-acceptance-tests:
         archived: true
@@ -2070,6 +2121,8 @@ orgs:
         default_branch: main
         description: Cloud Native Logging
         has_projects: true
+      loggregator-tools:
+        has_projects: true
       loggregator_emitter:
         archived: true
         has_projects: true
@@ -2087,6 +2140,7 @@ orgs:
         description: BOSH release with mapfs, allows uid/gid mapping at the path
         has_projects: true
       membrane:
+        archived: true
         has_projects: true
         has_wiki: false
       metric-proxy:
@@ -2107,14 +2161,12 @@ orgs:
         allow_merge_commit: false
         allow_squash_merge: false
         default_branch: develop
-        description: 'Metric Store: A Cloud-Native Time Series Database for Cloud
-          Foundry'
+        description: 'Metric Store: A Cloud-Native Time Series Database for Cloud Foundry'
         has_projects: true
       metrics-discovery-release:
         allow_merge_commit: false
         default_branch: main
-        description: BOSH Release to discovery Prometheus-formatted metric endpoints
-          in Cloud Foundry
+        description: BOSH Release to discover Prometheus-formatted metric endpoints in Cloud Foundry
         has_projects: true
       migrate_mysql_to_credhub:
         description: A go tool to migrate broker data from mysql to credhub
@@ -2122,6 +2174,15 @@ orgs:
       minimal-env:
         has_projects: true
         private: true
+      multiapps:
+        description: Parsers, validators, persistence and utilities for Multi-Target Application (MTA) models.
+        has_projects: true
+      multiapps-cli-plugin:
+        description: A CLI plugin for Multi-Target Application (MTA) operations in Cloud Foundry
+        has_projects: true
+      multiapps-controller:
+        description: The server side component (controller) for Multi-Target Application (MTA) for Cloud Foundry
+        has_projects: true
       multierror:
         has_projects: true
       mysql-backup-release:
@@ -2163,8 +2224,7 @@ orgs:
         has_projects: true
         private: true
       noaa:
-        description: NOAA is a client library to consume metric and log messages from
-          Doppler.
+        description: NOAA is a client library to consume metric and log messages from Doppler.
         has_projects: true
       nodejs-buildpack:
         description: Cloud Foundry buildpack for Node.js
@@ -2185,8 +2245,14 @@ orgs:
       noisy-neighbor-nozzle:
         allow_merge_commit: false
         archived: true
-        description: A nozzle and CLI tool for identifying high volume log producing
-          applications
+        description: A nozzle and CLI tool for identifying high volume log producing applications
+        has_projects: true
+      notifications:
+        description: The notifications service component of Cloud Foundry
+        has_projects: true
+        has_wiki: false
+      notifications-release:
+        description: A BOSH release that contains the notifications application and an errand to push it
         has_projects: true
       omniauth-uaa-oauth2:
         has_projects: true
@@ -2209,13 +2275,11 @@ orgs:
         has_projects: true
         private: true
       oss-summit-class:
-        description: 'Lab assets for Cloud Foundry class at Open Source Summit ''18
-          in Vancouver '
+        description: 'Lab assets for Cloud Foundry class at Open Source Summit ''18 in Vancouver '
         has_projects: true
       overview-broker:
         allow_merge_commit: false
-        description: A service broker that provides an overview of its service instances
-          and bindings. Conforms to the Open Service Broker API standard.
+        description: A service broker that provides an overview of its service instances and bindings. Conforms to the Open Service Broker API standard.
         has_projects: true
       persi-ci:
         has_projects: true
@@ -2244,12 +2308,10 @@ orgs:
         has_projects: true
         private: true
       pmc-notes:
-        description: Agendas and Notes for Cloud Foundry Project Management Committee
-          Meetings
+        description: Agendas and Notes for Cloud Foundry Project Management Committee Meetings
         has_projects: true
       policy_client:
-        description: Policy Client allows Cloud Foundry system components to query
-          the policy server for policies
+        description: Policy Client allows Cloud Foundry system components to query the policy server for policies
         has_projects: true
       postgres-ci-env:
         has_projects: true
@@ -2319,8 +2381,7 @@ orgs:
         private: true
       rep:
         allow_merge_commit: false
-        description: Representative bids on tasks and schedules them on an associated
-          Executor
+        description: Representative bids on tasks and schedules them on an associated Executor
         has_issues: false
         has_projects: true
       resolvconf-manager:
@@ -2329,15 +2390,13 @@ orgs:
         has_projects: true
       route-emitter:
         allow_merge_commit: false
-        description: Registers and unregisters processes running on executors with
-          the gorouter
+        description: Registers and unregisters processes running on executors with the gorouter
         has_issues: false
         has_projects: true
       route-registrar:
         allow_merge_commit: false
         default_branch: main
-        description: A standalone executable written in golang that continuously broadcasts
-          a route using NATS to the CF router.
+        description: A standalone executable written in golang that continuously broadcasts a route using NATS to the CF router.
         has_projects: true
       routing-acceptance-tests:
         allow_merge_commit: false
@@ -2458,8 +2517,7 @@ orgs:
       silk:
         allow_merge_commit: false
         default_branch: main
-        description: a network fabric for containers.  inspired by flannel, designed
-          for Cloud Foundry.
+        description: a network fabric for containers.  inspired by flannel, designed for Cloud Foundry.
         has_projects: true
       silk-release:
         allow_merge_commit: false
@@ -2493,8 +2551,7 @@ orgs:
         archived: true
         has_projects: true
       stack-auditor:
-        description: Stack Auditor is a cf CLI plugin that provides commands for listing
-          apps and their stacks, migrating apps to a new stack, and deleting a stack.
+        description: Stack Auditor is a cf CLI plugin that provides commands for listing apps and their stacks, migrating apps to a new stack, and deleting a stack.
         has_projects: true
         homepage: https://docs.cloudfoundry.org/adminguide/stack-auditor.html
       staticfile-buildpack:
@@ -2508,16 +2565,14 @@ orgs:
         homepage: http://bosh.io/releases/github.com/cloudfoundry/staticfile-buildpack-release
       statsd-injector:
         archived: true
-        description: Companion component to Metron that receives Statsd and emits
-          Dropsonde to Metron
+        description: Companion component to Metron that receives Statsd and emits Dropsonde to Metron
         has_projects: true
       statsd-injector-release:
         allow_merge_commit: false
         default_branch: main
         has_projects: true
       stembuild:
-        description: Binary to be used to build BOSH-compatible stemcells for Windows
-          Server 2019 on vSphere.
+        description: Binary to be used to build BOSH-compatible stemcells for Windows Server 2019 on vSphere.
         has_projects: true
       stemcells-alicloud-index:
         description: Alibaba Cloud Stemcell index produced by Alibaba Cloud team
@@ -2535,12 +2590,15 @@ orgs:
         description: Hands-on Labs for CF Summit Boston '18 and beyond
         has_projects: true
       summit-training-classes:
-        description: 'Opensourced content for cloud foundry training classes: zero
-          to hero (beginner), bosh/operator, and microservices'
+        description: 'Opensourced content for cloud foundry training classes: zero to hero (beginner), bosh/operator, and microservices'
         has_projects: true
       switchblade:
         default_branch: main
         has_projects: false
+        has_wiki: false
+      switchboard:
+        description: Golang TCP Proxy
+        has_projects: true
         has_wiki: false
       sync-integration-tests:
         has_projects: true
@@ -2558,8 +2616,7 @@ orgs:
       syslog-release:
         allow_merge_commit: false
         default_branch: main
-        description: BOSH release for forwarding logs (either sent to syslog or picked
-          up /var/vcap/sys/log/**/*)
+        description: BOSH release for forwarding logs (either sent to syslog or picked up /var/vcap/sys/log/**/*)
         has_projects: true
         has_wiki: false
       system-metrics-release:
@@ -2598,6 +2655,9 @@ orgs:
         description: CloudFoundry User Account and Authentication (UAA) Server
         has_projects: true
         has_wiki: false
+      uaa-cli:
+        description: CLI for UAA written in Go
+        has_projects: true
       uaa-developer-training:
         has_projects: true
         private: true
@@ -2653,8 +2713,7 @@ orgs:
         has_projects: true
       winc:
         default_branch: develop
-        description: CLI tool for spawning and running containers on Windows according
-          to the OCI specification
+        description: CLI tool for spawning and running containers on Windows according to the OCI specification
         has_projects: true
         has_wiki: false
       winc-release:
@@ -2714,25 +2773,89 @@ orgs:
       App Runtime Interfaces WG:
         description: Approvers for the App Runtime Interfaces Working Group
         maintainers:
+        - dsboulder
         - Gerg
         members:
+        - bonzofenix
+        - ddonchev
+        - a-b
         - philippthun
+        - Gerg
+        - totherme
+        - dlresende
         - sethboyles
+        - arjun024
+        - nvvalchev
+        - silvestre
+        - dmikusa-pivotal
+        - joergdw
         - FloThinksPi
+        - menehune23
         - monamohebbi
         - andy-paine
+        - radito3
         - tjvman
         - MarcPaquette
+        - brayanhenao
+        - mjgutermuth
+        - theghost5800
         - sweinstein22
         - MerricdeLauney
+        - jdgonzaleza
+        - pivotal-david-osullivan
+        - IvanBorislavovDimitrov
+        - abdermendz
+        - boyan-velinov
+        - ikasarov
+        - fejnartal
+        - vkalapov
         privacy: closed
         teams:
-          App Runtime Interfaces CAPI:
-            description: Approvers for the App Runtime CAPI Area
+          App Runtime Interfaces WG Autoscaler:
+            description: Approvers for the App Runtime Interfaces Autoscaler area
+            maintainers:
+            - bonzofenix
+            - Gerg
+            - silvestre
+            - joergdw
+            privacy: closed
+          App Runtime Interfaces WG Buildpacks:
+            description: Approvers for the App Runtime Buildpacks area
             maintainers:
             - Gerg
-            members:
+            - arjun024
+            - dmikusa-pivotal
+            - menehune23
+            - brayanhenao
+            - pivotal-david-osullivan
+            privacy: closed
+            repos:
+              binary-buildpack: read
+              brats: read
+              docs-buildpacks: read
+              go-buildpack: read
+              ibm-websphere-liberty-buildpack: read
+              java-buildpack: read
+              java-buildpack-auto-reconfiguration: read
+              java-buildpack-client-certificate-mapper: read
+              java-buildpack-container-customizer: read
+              java-buildpack-dependency-builder: read
+              java-buildpack-memory-calculator: read
+              java-buildpack-metric-writer: read
+              java-buildpack-security-provider: read
+              java-buildpack-support: read
+              java-buildpack-system-test: read
+              java-test-applications: read
+              nodejs-buildpack: read
+              php-buildpack: read
+              python-buildpack: read
+              ruby-buildpack: read
+              staticfile-buildpack: read
+          App Runtime Interfaces WG CAPI:
+            description: Approvers for the App Runtime CAPI area
+            maintainers:
             - philippthun
+            - Gerg
             - sethboyles
             - FloThinksPi
             - monamohebbi
@@ -2749,17 +2872,94 @@ orgs:
               capi-k8s-release: write
               capi-release: write
               cc-uploader: write
+              cf-performance-tests: write
+              cf-performance-tests-pipeline: write
               cloud_controller_ng: write
               go-cf-api: write
               go-cf-api-release: write
               sync-integration-tests: write
               tps: write
+          App Runtime Interfaces WG CLI:
+            description: Approvers for the App Runtime CLI Area
+            maintainers:
+            - a-b
+            - Gerg
+            - jdgonzaleza
+            privacy: closed
+            repos:
+              cli: read
+              cli-plugin-repo: read
+          App Runtime Interfaces WG Docs:
+            description: Approvers for the App Runtime Docs area
+            maintainers:
+            - Gerg
+            - mjgutermuth
+            privacy: closed
+            repos:
+              docs-cf-cli: read
+              docs-cloudfoundry-concepts: read
+              docs-dev-guide: read
+              docs-services: read
+          App Runtime Interfaces WG Java Tools:
+            description: Approvers for the App Runtime Java Tools area
+            maintainers:
+            - Gerg
+            - dmikusa-pivotal
+            - pivotal-david-osullivan
+            privacy: closed
+            repos:
+              cf-java-client: read
+          App Runtime Interfaces WG Leads:
+            description: Leads for the App Runtime Interfaces WG
+            maintainers:
+            - Gerg
+            privacy: closed
+            repos:
+              cf-performance-tests: admin
+              cf-performance-tests-pipeline: admin
+              cloud_controller_ng: admin
+              multiapps: admin
+              multiapps-cli-plugin: admin
+              multiapps-controller: admin
+              notifications: admin
+          App Runtime Interfaces WG MultiApps:
+            description: Approvers for the App Runtime MultiApps area
+            maintainers:
+            - ddonchev
+            - Gerg
+            - nvvalchev
+            - radito3
+            - theghost5800
+            - abdermendz
+            - boyan-velinov
+            - ikasarov
+            - vkalapov
+            members:
+            - IvanBorislavovDimitrov
+            privacy: closed
+            repos:
+              multiapps: write
+              multiapps-cli-plugin: write
+              multiapps-controller: write
+          App Runtime Interfaces WG Notifications:
+            description: Approvers for the App Runtime Notifications area
+            maintainers:
+            - dsboulder
+            - Gerg
+            - totherme
+            - dlresende
+            - fejnartal
+            privacy: closed
+            repos:
+              notifications: write
+              notifications-release: write
       App Runtime Platform WG:
         description: Approvers for the App Runtime WG
         maintainers:
         - ameowlia
         members:
         - stefanlay
+        - ameowlia
         privacy: closed
         repos:
           archiver: write
@@ -2788,12 +2988,14 @@ orgs:
           dontpanic: write
           durationjson: write
           ecrhelper: write
+          envoy-nginx-release: read
           eventhub: write
           executor: write
           fileserver: write
           garden: write
           garden-integration-tests: write
           garden-runc-release: write
+          go-orchestrator: read
           gorouter: admin
           groot-windows: write
           grootfs: write
@@ -2808,6 +3010,7 @@ orgs:
           log-cache-release: write
           loggregator-agent-release: write
           loggregator-release: write
+          loggregator-tools: read
           metrics-discovery-release: write
           nats-release: write
           netplugin-shim: write
@@ -2867,12 +3070,14 @@ orgs:
               dontpanic: admin
               durationjson: admin
               ecrhelper: admin
+              envoy-nginx-release: read
               eventhub: admin
               executor: admin
               fileserver: admin
               garden: admin
               garden-integration-tests: admin
               garden-runc-release: admin
+              go-orchestrator: read
               go-pubsub: admin
               gorouter: admin
               groot-windows: admin
@@ -2888,10 +3093,12 @@ orgs:
               log-cache-release: admin
               loggregator-agent-release: admin
               loggregator-release: admin
+              loggregator-tools: read
               metrics-discovery-release: admin
               nats-release: admin
               netplugin-shim: admin
               networking-oss-deployments: admin
+              notifications-release: admin
               operationq: admin
               rep: admin
               route-emitter: admin
@@ -3020,9 +3227,20 @@ orgs:
         - klakin-pivotal
         - camilalonart
         members:
+        - aramprice
+        - jpalermo
+        - ragaskar
+        - ystros
         - idoru
+        - selzoc
+        - cunnie
+        - mrosecrance
         - bgandon
+        - julian-hj
+        - danielfor
+        - klakin-pivotal
         - nouseforaname
+        - camilalonart
         - bosh-windows-ci
         - suraiyasuliman
         privacy: closed
@@ -3079,8 +3297,7 @@ orgs:
           yagnats: admin
         teams:
           CF BOSH:
-            description: Child of BOSH Ecosystem, for backwards compatability for
-              resources that need this team name stable
+            description: Child of BOSH Ecosystem, for backwards compatability for resources that need this team name stable
             maintainers:
             - aramprice
             - jpalermo
@@ -3295,7 +3512,6 @@ orgs:
         - mvach
         - beyhan
         - ramonskie
-        - bgandon
         - joergdw
         - FlorianNachtigall
         - cf-bosh-ci-bot
@@ -3606,7 +3822,6 @@ orgs:
         - cf-cli-eng
         - pivotalgeorge
         - reedr3
-        - sebGilR
         - jdgonzaleza
         - ccjaimes
         - gururajsh
@@ -3659,6 +3874,7 @@ orgs:
         - jpatel-pivotal
         - cf-toolsmiths
         - degaurab
+        - achasveachas
         - dsharp-pivotal
         - swati-nair
         - RiaMahoney
@@ -3704,6 +3920,8 @@ orgs:
           cf-acceptance-tests: write
           cf-deployment: write
           credhub: admin
+          credhub-acceptance-tests: admin
+          credhub-cli: admin
           docs-credhub: write
           secure-credentials-broker: admin
       CF Developer Training:
@@ -3854,7 +4072,6 @@ orgs:
         - rosenhouse
         - danail-branekov
         - georgethebeatle
-        - mnitchev
         - garden-gnome
         - kieron-dev
         privacy: closed
@@ -3906,6 +4123,7 @@ orgs:
           diego-release: write
           diego-windows-release: admin
           diff-exporter: write
+          envoy-nginx-release: admin
           filelock: admin
           garden-ci: read
           garden-windows-ci: admin
@@ -4021,6 +4239,7 @@ orgs:
           go-log-cache: admin
           go-loggregator: admin
           go-metric-registry: admin
+          go-orchestrator: read
           go-pubsub: admin
           jsonry: write
           lamb-ci-tools: write
@@ -4046,6 +4265,7 @@ orgs:
           loggregator-dotfiles: admin
           loggregator-rampup: admin
           loggregator-release: admin
+          loggregator-tools: read
           loggregator_emitter: admin
           metric-proxy: admin
           metric-store-dotfiles: write
@@ -4067,7 +4287,6 @@ orgs:
       CF London:
         description: ""
         members:
-        - albertoleal
         - kirederik
         - tinygrasshopper
         - avade
@@ -4127,7 +4346,6 @@ orgs:
         members:
         - dprotaso
         - xtremerui
-        - jomsie
         - xtreme-jason-smith
         - ryanmattcollins
         - xtreme-vikram-yadav
@@ -4147,9 +4365,10 @@ orgs:
         - kauana
         - KauzClay
         - jrussett
-        - KeshavS0519
         members:
         - routing-ci
+        - kauana
+        - KauzClay
         privacy: closed
         repos:
           capi-k8s-release: write
@@ -4186,7 +4405,6 @@ orgs:
             members:
             - kauana
             - KauzClay
-            - KeshavS0519
             privacy: closed
             repos:
               capi-k8s-release: write
@@ -4249,6 +4467,7 @@ orgs:
         - emalm
         - Birdrock
         - julian-hj
+        - clintyoshimura
         - acosta11
         - gnovv
         - akrishna90
@@ -4761,6 +4980,7 @@ orgs:
         - christopherclark
         members:
         - jpalermo
+        - beyhan
         - lnguyen
         - ramonskie
         - Benjamintf1
@@ -4779,6 +4999,7 @@ orgs:
           bosh-aws-cpi-release: write
           bosh-aws-light-stemcell-builder: write
           bosh-azure-cpi-release: write
+          bosh-backup-and-restore: write
           bosh-backup-and-restore-test-releases: write
           bosh-bbl-ci-envs: write
           bosh-cli: write
@@ -4813,7 +5034,9 @@ orgs:
           bosh-workstation: write
           bpm-release: write
           bsdtar: write
+          cf-mysql-bootstrap: write
           cf-mysql-ci: write
+          cf-mysql-cluster-health-logger: write
           cf-mysql-deployment: write
           cf-mysql-release: write
           cf-uaa-lib: write
@@ -4832,9 +5055,11 @@ orgs:
           docs-credhub: write
           event-log-release: write
           exemplar-backup-and-restore-release: write
+          galera-healthcheck: write
           galera-init: write
           gofileutils: write
           gosigar: write
+          greenhouse-ci: write
           mysql-backup-release: write
           mysql-monitoring-release: write
           omniauth-uaa-oauth2: write
@@ -4848,9 +5073,11 @@ orgs:
           socks5-proxy: write
           stembuild: write
           stemcells-alicloud-index: write
+          switchboard: write
           syslog-release: write
           tlsconfig: write
           uaa: write
+          uaa-cli: write
           uaa-key-rotator: write
           uaa-release: write
           uaa-singular: write
@@ -4862,8 +5089,7 @@ orgs:
           yagnats: write
         teams:
           Foundational Infrastructure WG leads:
-            description: Technical and Execution Leads for the Foundational Infrastructure
-              WG
+            description: Technical and Execution Leads for the Foundational Infrastructure WG
             maintainers:
             - rkoster
             - christopherclark
@@ -4881,6 +5107,7 @@ orgs:
               bosh-aws-cpi-release: admin
               bosh-aws-light-stemcell-builder: admin
               bosh-azure-cpi-release: admin
+              bosh-backup-and-restore: admin
               bosh-backup-and-restore-test-releases: admin
               bosh-bbl-ci-envs: admin
               bosh-cli: admin
@@ -4915,7 +5142,9 @@ orgs:
               bosh-workstation: admin
               bpm-release: admin
               bsdtar: admin
+              cf-mysql-bootstrap: admin
               cf-mysql-ci: admin
+              cf-mysql-cluster-health-logger: admin
               cf-mysql-deployment: admin
               cf-mysql-release: admin
               cf-uaa-lib: admin
@@ -4934,9 +5163,11 @@ orgs:
               docs-credhub: admin
               event-log-release: admin
               exemplar-backup-and-restore-release: admin
+              galera-healthcheck: admin
               galera-init: admin
               gofileutils: admin
               gosigar: admin
+              greenhouse-ci: admin
               mysql-backup-release: admin
               mysql-monitoring-release: admin
               omniauth-uaa-oauth2: admin
@@ -4950,9 +5181,11 @@ orgs:
               socks5-proxy: admin
               stembuild: admin
               stemcells-alicloud-index: admin
+              switchboard: admin
               syslog-release: admin
               tlsconfig: admin
               uaa: admin
+              uaa-cli: admin
               uaa-key-rotator: admin
               uaa-release: admin
               uaa-singular: admin
@@ -5054,8 +5287,7 @@ orgs:
         repos:
           metric-store-release: read
       OSS-PMS-SECURITY:
-        description: Open Source PMs +anchors that should have access to security
-          issues
+        description: Open Source PMs +anchors that should have access to security issues
         maintainers:
         - emalm
         members:
@@ -5101,6 +5333,8 @@ orgs:
         - GowriRegistry
         - Tejuvmware
         - pkvatvmware
+        - jhasu
+        - a-sudarsanan
         privacy: secret
         repos:
           deployments-routing: read
@@ -5157,8 +5391,8 @@ orgs:
         - robertjsullivan
         - iplay88keys
         - jessepye
-        - hillrw3
         - markthemarkest
+        - advpetc
         - dpruitt2
         - fredwangwang
         - jpmcb
@@ -5308,7 +5542,6 @@ orgs:
         repos:
           cf-slackin: admin
           cfdreddbot: admin
-          cli-private: write
           docs-book-cloudfoundry: write
           go-fetcher: admin
           homebrew-tap: write
@@ -5484,6 +5717,29 @@ orgs:
         - nand2
         - cf-services
         privacy: secret
+      Service Management WG:
+        description: ""
+        maintainers:
+        - pivotal-marcela-campo
+        members:
+        - fejnartal
+        privacy: closed
+        repos:
+          existingvolumebroker: admin
+          goshims: admin
+          mapfs: admin
+          mapfs-release: admin
+          migrate_mysql_to_credhub: admin
+          nfs-volume-release: admin
+          nfsbroker: admin
+          nfsv3driver: admin
+          persi-ci: admin
+          service-broker-store: admin
+          smb-volume-release: admin
+          smbbroker: admin
+          smbdriver: admin
+          volume-mount-options: admin
+          volumedriver: admin
       Spinnaker:
         description: ""
         members:
@@ -5492,8 +5748,7 @@ orgs:
         - briannebrown
         privacy: closed
       Tracker:
-        description: A team for the Pivotal Tracker folks to get read only access
-          to key repos
+        description: A team for the Pivotal Tracker folks to get read only access to key repos
         members:
         - oppegard
         - tracker-common
@@ -5530,11 +5785,6 @@ orgs:
           cc-api-v3-style-guide: write
           cf-acceptance-tests: write
           cf-deployment: write
-          cli: admin
-          cli-ci: admin
-          cli-pools: write
-          cli-private: write
-          cli-workstation: admin
           cloud_controller_ng: write
           jsonry: admin
       VMware Licensing:
@@ -5571,6 +5821,7 @@ orgs:
         - gcapizzi
         - beyhan
         - ameowlia
+        - jochenehret
         - georgethebeatle
         privacy: closed
         repos:
@@ -5596,7 +5847,7 @@ orgs:
           capi-ci-private: write
           capi-k8s-release: write
           docs-bbr: read
-          homebrew-tap: write
+          homebrew-tap: admin
       bosh-ci bot:
         description: ""
         members:
@@ -5750,7 +6001,7 @@ orgs:
         - Birdrock
         - julian-hj
         - georgethebeatle
-        - mnitchev
+        - clintyoshimura
         - kieron-dev
         - acosta11
         - gnovv
@@ -5830,35 +6081,48 @@ orgs:
         privacy: secret
         repos:
           ibm-websphere-liberty-buildpack: admin
+      cloud-service-broker:
+        description: Cloud service broker approvers
+        maintainers:
+        - tinygrasshopper
+        - FelisiaM
+        - blgm
+        - pivotal-marcela-campo
+        - jimbo459
+        privacy: closed
+        repos:
+          cloud-service-broker: admin
+          csb-brokerpak-aws: admin
+          csb-brokerpak-azure: admin
+          csb-brokerpak-gcp: admin
       cloudops-ci:
         description: ""
         members:
         - pws-team-admin-client
         privacy: secret
       cryogenics:
-        description: specialists in transitioning from highly agile software development
-          to highly sustainable software maintenance and support
+        description: specialists in transitioning from highly agile software development to highly sustainable software maintenance and support
         maintainers:
-        - kirederik
-        - tinygrasshopper
         - totherme
         - dlresende
-        - neil-hickey
-        - jimbo459
-        - gbandres98
         - fejnartal
         members:
         - cf-gitbot
         - Cryogenics-CI
         privacy: closed
         repos:
-          backup-and-restore-sdk-release: write
+          backup-and-restore-sdk-release: admin
+          bosh-backup-and-restore: admin
+          bosh-backup-and-restore-test-releases: admin
           bosh-bootloader: admin
+          bosh-disaster-recovery-acceptance-tests: admin
           cf-volume-services-acceptance-tests: admin
           cf-volume-services-team: admin
-          disaster-recovery-acceptance-tests: write
+          disaster-recovery-acceptance-tests: admin
           docker_driver_integration_tests: admin
           dockerdriver: admin
+          docs-bbr: admin
+          exemplar-backup-and-restore-release: admin
           existingvolumebroker: admin
           go-git-resource: admin
           goshims: admin
@@ -5913,15 +6177,20 @@ orgs:
         - gcapizzi
         - danail-branekov
         - georgethebeatle
-        - mnitchev
         - kieron-dev
+        members:
+        - eirinici
         privacy: closed
         repos:
           capi-k8s-release: write
           cf-crd-explorations: admin
           cf-for-k8s: write
           cf-k8s-logging: write
+          eirini: admin
+          eirini-ci: admin
+          eirini-controller: admin
           eirini-private-config: admin
+          eirini-release: admin
       friends-of-runtime-deployments:
         description: ""
         members:
@@ -5945,6 +6214,8 @@ orgs:
         - iaftab-alam
         privacy: closed
         repos:
+          cf-performance-tests: write
+          cf-performance-tests-pipeline: write
           go-cf-api: admin
           go-cf-api-release: write
       ibm-read:
@@ -6069,6 +6340,7 @@ orgs:
         maintainers:
         - dsboulder
         - mariash
+        - mkocher
         - reneighbor
         - acrmp
         - selzoc
@@ -6082,9 +6354,11 @@ orgs:
         - rroberts2222
         - jrussett
         - cphi-vmw
+        - suraiyasuliman
         members:
-        - mkocher
+        - dsabeti
         - cf-gitbot
+        - moleske
         - routing-ci
         - tas-runtime-bot
         privacy: closed
@@ -6113,6 +6387,7 @@ orgs:
           cfhttp: admin
           clock: admin
           consuladapter: admin
+          cpu-entitlement-plugin: admin
           debugserver: admin
           deployments-diego: admin
           deployments-loggregator: admin
@@ -6132,6 +6407,7 @@ orgs:
           dontpanic: admin
           durationjson: admin
           ecrhelper: admin
+          envoy-nginx-release: admin
           eventhub: admin
           executor: admin
           filelock: admin
@@ -6140,6 +6416,7 @@ orgs:
           garden-ci: admin
           garden-integration-tests: admin
           garden-runc-release: admin
+          garden-wiki: admin
           garden-windows-ci: admin
           go-diodes: admin
           go-log-cache: admin
@@ -6169,6 +6446,7 @@ orgs:
           networking-oss-deployments: admin
           noisy-neighbor-nozzle: admin
           operationq: admin
+          policy_client: admin
           rep: admin
           route-emitter: admin
           route-registrar: admin
@@ -6198,6 +6476,11 @@ orgs:
           windows2019fs-release: admin
           windowsfs-online-release: admin
           workpool: admin
+      service-fabrik:
+        description: service-fabrik contributors
+        maintainers:
+        - pivotal-marcela-campo
+        privacy: closed
       stratos-ui:
         description: ""
         maintainers:
@@ -6484,3 +6767,4 @@ orgs:
         privacy: secret
         repos:
           security-notices: admin
+


### PR DESCRIPTION
Github org management has been running in dry run mode over the weekend. So far there have been no issues.
This PR changes the value for `--confirm` to `true`. In addition, it switches to using github app auth, so we can use the [cf-foundation github add](https://github.com/organizations/cloudfoundry/settings/apps/cf-foundation-org-manager). This add can be managed by all cloudfoundry org admins.