### PR TITLE
Add floating repos to ARP charter

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -164,8 +164,12 @@ areas:
     github: selzoc
   repositories:
   - cloudfoundry/bosh-system-metrics-forwarder-release
+  - cloudfoundry/bosh-system-metrics-server-release
+  - cloudfoundry/dropsonde-protocol
+  - cloudfoundry/log-cache-cli
   - cloudfoundry/log-cache-release
   - cloudfoundry/go-log-cache
+  - cloudfoundry/loggregator-api
   - cloudfoundry/loggregator-release
   - cloudfoundry/go-diodes
   - cloudfoundry/go-envstruct


### PR DESCRIPTION
Some repos were missing from any working group charters that appear to belong under ARP:
* https://github.com/cloudfoundry/bosh-system-metrics-server-release
* https://github.com/cloudfoundry/dropsonde-protocol
* https://github.com/cloudfoundry/log-cache-cli
* https://github.com/cloudfoundry/loggregator-api