### PR TITLE
Remove Kai Hofstetter from the foundational-infrastructure approver list

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -37,7 +37,6 @@ Provide infrastructure automation and core capabilities shared across CF project
 - Long Nguyen (@lnguyen)
 - Ramon Makkelie (@ramonskie)
 - Benjamin Gandon (@bgandon)
-- Kai Hofstetter (@KaiHofstetter)
 - Felix Riegger (@friegger)
 
 ### Disaster Recovery (BBR)


### PR DESCRIPTION
As discussed with @rkoster ...

I'm going to move from the Cloud Foundry platform side to the application development side (running on Cloud Foundry).
 
For this reason, I would like to resign from the approver role in the “Foundational Infrastructure” working group.