### PR TITLE
Only run on changes to main

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -1,6 +1,8 @@
 name: 'Sync Github Organization Settings'
 on:
   push:
+    branches:
+      - 'main'
     paths:
       - 'org/*'
       - '.github/workflows/org-management.yml'


### PR DESCRIPTION
Currently, when people create a PR the proposed changes are already applied.
A further improvement would be to use dry run mode on PR's