### PR TITLE
Update the name of the App Runtime Deployments WG Approvers team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2794,7 +2794,7 @@ orgs:
           - tjvman
         privacy: closed
         teams:
-          App Runtime Deployments WG:
+          App Runtime Deployments WG Approvers:
             description: Approvers for the App Runtime Deployments area
             maintainers:
               - andrewdriver123


### PR DESCRIPTION
The name of the approvers team can't be the same as the parent team. I have added `Approvers` as a suffix to match with the `Leads` team.