### PR TITLE
add metrics store release to app runtime platform wg

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -177,6 +177,7 @@ areas:
   - cloudfoundry/go-batching
   - cloudfoundry/sonde-go
   - cloudfoundry/metrics-discovery-release
+  - cloudfoundry/metric-store-release
   - cloudfoundry/statsd-injector-release
   - cloudfoundry/system-metrics-scraper-release
 


### PR DESCRIPTION
### The Change

This repo is currently not in any WG and I think it belongs in App Runtime Platform Working Group with the other CF metric components.

### More Context

The Metric Store ingresses all metrics (discarding logs) from the Reverse Log Proxy on Loggregator. Any metric sent to a Loggregator Agent will travel downstream into Metric Store.