### PR TITLE
Remove duglin, to address peribollos failed UpdateOrgMembership

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -208,7 +208,6 @@ orgs:
     - dsyer
     - dtillman
     - dtimm
-    - duglin
     - dumez-k
     - edespino
     - edwardecook
@@ -6113,7 +6112,6 @@ orgs:
         - jgawor
         - jacksoncvm
         - krook
-        - duglin
         - christo4ferris
         - sykesm
         - brunssen


### PR DESCRIPTION
Probably related to rejected org invite.

Here it was still waiting for the invite to be accepted: https://github.com/cloudfoundry/community/runs/5517516950?check_suite_focus=true#step:5:1208

Next build started failing here: https://github.com/cloudfoundry/community/runs/5518446552?check_suite_focus=true#step:5:1259