### PR TITLE
Add loggregator related repos to runtime team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -6487,6 +6487,11 @@ orgs:
           loggregator-api: admin
           loggregator-ci: admin
           loggregator-release: admin
+          loggregator-tools: admin
+          sonde-go: admin
+          dropsonde-protocol: admin
+          dropsonde-protocol-js: admin
+          dropsonde: admin
           metrics-discovery-release: admin
           nats-release: admin
           netplugin-shim: admin


### PR DESCRIPTION
Seems this repo got overlooked at some point. We'd like to merge
https://github.com/cloudfoundry/loggregator-tools/pull/9