### PR TITLE
Add strehle to Foundational Infrastructure Working group

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -5032,6 +5032,7 @@ orgs:
         - bgandon
         - KaiHofstetter
         - friegger
+        - strehle
         - cf-rabbit-bot
         privacy: closed
         repos:


### PR DESCRIPTION
There are no area specific subgroup yet, waiting for naming to be finalized.

This should unblock uaa-cli development: https://github.com/cloudfoundry/community/pull/185#issuecomment-1079710479