### PR TITLE
Add support for opt-in github projects sync for working groups

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,0 +1,36 @@
+name: 'Sync working group project boards'
+
+on:
+  schedule:
+  - cron: '0 */1 * * *'
+
+jobs:
+  configs:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - id: matrix
+        run: |
+          echo "::set-output name=matrix::$(./org/generate_working_group_projects_sync_config.sh)"
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+  sync_projects:
+    needs: configs
+    runs-on: ubuntu-18.04
+    container:
+      image: rkoster/github-multi-repo-project-card-sync
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.configs.outputs.matrix) }}
+
+    steps:
+    - name: write-config
+      run:  echo '${{ toJSON(matrix.config) }}' > config.json
+    - name: github-projects-sync
+      run: /root/sync --config config.json
+      env:
+        GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
+        GITHUB_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}

--- a/org/generate_working_group_projects_sync_config.sh
+++ b/org/generate_working_group_projects_sync_config.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+repo_root=$(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd))
+
+$repo_root/toc/working-groups/parsable-working-groups.sh | \
+    jq 'map(select(.config | has("github_project_sync"))) |
+      map(
+        .name as $name |
+        .areas as $areas |
+        .config.github_project_sync.mapping | to_entries | map({org: .key, project_id: .value}) |
+           map(.org as $org | {
+              project: {organization: $org, number: .project_id},
+              repositories: $areas | map(
+                .name as $area |
+                .repositories | map(select(startswith("\($org)/"))) | map({
+                  name: .,
+                  fields: [
+                    {name: "Last Activity", type: "last_activity"},
+                    {name: "Status", type: "default_single_select", value: "Inbox"},
+                    {name: "Submitter", type: "author"},
+                    {name: "Draft", type: "draft"},
+                    {name: "Area", type: "single_select", value: $area},
+                    {name: "Type", type: "type"},
+                    {name: "Changes", type: "changes"}
+                  ]
+                })
+              ) | flatten
+           })
+      )
+    ' | jq -cs 'flatten'

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -85,7 +85,7 @@ areas:
   - cloudfoundry/uaa-release
   - cloudfoundry/uaa-singular
   - cloudfoundry/uaa
-- name: Integrated Databases
+- name: Integrated Databases (Mysql / Postgres)
   approvers:
   - name: Andrew Garner 
     github: abg
@@ -100,7 +100,7 @@ areas:
   - cloudfoundry/cf-mysql-release
   - cloudfoundry/galera-init
   - cloudfoundry/postgres-release
-- name: System logging and metrics
+- name: System Logging and Metrics (rsyslog / event-log)
   approvers:
   - name: Ben Fuller
     github: Benjamintf1
@@ -174,7 +174,7 @@ areas:
   - cloudfoundry/bosh-openstack-cpi-release
   - cloudfoundry/bosh-s3cli
   - cloudfoundry/bosh-softlayer-cpi-release
-  - cloudfoundry/bosh-stemcell-ci-infra
+  - cloudfoundry/bosh-community-stemcell-ci-infra
   - cloudfoundry/bosh-stemcells-ci
   - cloudfoundry/bosh-utils
   - cloudfoundry/bosh-virtualbox-cpi-release
@@ -195,4 +195,8 @@ areas:
   - cloudfoundry/usn-resource
   - cloudfoundry/yagnats
   - cloudfoundry/windows-tools-release
+config:
+  github_project_sync:
+    mapping:
+      cloudfoundry: 21
 ```

--- a/toc/working-groups/parsable-working-groups.sh
+++ b/toc/working-groups/parsable-working-groups.sh
@@ -7,5 +7,6 @@ repo_root=$(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd))
 pushd $repo_root/toc/working-groups >/dev/null
 
 for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
-    cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | spruce json | jq '[.]' | bosh int -
+    cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
+        ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
 done

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -11,7 +11,7 @@ Provides interfaces for service lifecycle within application platforms and adapt
 - Maintain a set of reference volume service brokers and drivers for CF applications to mount stateful data.
 
 ## Scope
-- Lead OSBAPI.
+- Lead OSB API.
 - Develop and maintain Cloud Service Brokers for AWS, Azure, and GCP.
 - Maintain volume service adapters for NFS and SMB.
 - Develop and maintain ServiceFabrik, a generic BOSH-based and Docker-container-based service instance manager.
@@ -47,7 +47,7 @@ areas:
   - cloudfoundry/csb-brokerpak-azure
   - cloudfoundry/csb-brokerpak-aws
   - cloudfoundry/csb-brokerpak-gcp
-- name: OSBAPI
+- name: OSB API
   approvers:
   - name: Sam Gunaratne
     github: Samze
@@ -56,7 +56,7 @@ areas:
   repositories:
   - openservicebrokerapi/servicebroker
   - openservicebrokerapi/osb-checker
-- name: ServiceFabrik
+- name: Service Fabrik
   approvers:
   - name: Anoop Joseph Babu
     github: anoopjb
@@ -77,7 +77,7 @@ areas:
   - cloudfoundry-incubator/service-fabrik-blueprint-boshrelease
   - cloudfoundry-incubator/service-fabrik-cli-plugin
   - cloudfoundry-incubator/service-fabrik-lvm-volume-driver
-- name: Volume Service Adapters
+- name: Volume Services
   approvers:
   - name: Diego Lemos
     github: dlresende
@@ -101,4 +101,10 @@ areas:
   - cloudfoundry/smb-volume-release
   - cloudfoundry/volume-mount-options
   - cloudfoundry/volumedriver
+config:
+  github_project_sync:
+    mapping:
+      cloudfoundry: 27
+      openservicebrokerapi: 1
+      cloudfoundry-incubator: 3
 ```


### PR DESCRIPTION
* remove spruce dependency from parsable-working-groups.sh script
  to allow running in github actions base ubuntu image (using ruby)
* rename some areas to align with the area names already in use on
  project boards
* enable project sync for foundational infrastructure and service
  management working groups
* due to a limitation in the current github projects beta api it is
  not possible to have cross org issues/PR's


This feature can be enabled per working group by adding:
```
config:
  github_project_sync:
    mapping:
      cloudfoundry: {project_id}
```
To the bottom of their working group charter.