### PR TITLE
Add `bosh-cpi-certification` to BOSH Ecosystem team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -3302,6 +3302,7 @@ orgs:
           bosh-bbl-ci-envs: admin
           bosh-cli: admin
           bosh-compiled-releases-index: admin
+          bosh-cpi-certification: admin
           bosh-cpi-environments: admin
           bosh-cpi-go: admin
           bosh-cpi-kb: admin


### PR DESCRIPTION
The `bosh-cpi-certification` repository does not contain code that reaches users. It is used only for testing within pipelines prior to the final release of individual CPIs.

Currently, some of the CPI pipelines maintained by the BOSH Ecosystem team are blocked because we need to update Terraform templates in this repo. In general, it would be helpful to be able to rapidly iterate on CI code.

https://github.com/cloudfoundry/bosh-cpi-certification