### PR TITLE
Add the `cf-for-k8s` repos to the CF on K8s WG

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -61,6 +61,19 @@ areas:
   - name: Tim Downey
     github: tcdowney
   repositories:
+  - cloudfoundry/cf-for-k8s
+  - cloudfoundry/cf-for-k8s-docs
+  - cloudfoundry/cf-k8s-ci
   - cloudfoundry/cf-k8s-controllers
-  - cloudfoundry-incubator/eirini-controller
+  - cloudfoundry/cf-k8s-logging
+  - cloudfoundry/cf-k8s-logging-fluent
+  - cloudfoundry/cf-k8s-networking
+  - cloudfoundry/cf-k8s-prometheus
+  - cloudfoundry/eirini
+  - cloudfoundry/eirini-ci
+  - cloudfoundry/eirini-controller
+  - cloudfoundry/eirini-release
+  - cloudfoundry/fluent-plugin-syslog_rfc5424
+  - cloudfoundry/metric-proxy
+  - cloudfoundry/yttk8smatchers
 ```


### PR DESCRIPTION
With this the Cloud Foundry on Kubernetes working group adopts all repositories related to the old `cf-for-k8s` project. The following repositories have been left out on purpose:
- `cloudfoundry/cf-k8s-networking-scaling`: please archive.
- `cloudfoundry/cf-for-k8s-metric-examples`: please archive.
- `cloudfoundry/cf-on-k8s-integration`: please delete.

