### PR TITLE
Adding eroberson to the runtime team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -219,6 +219,7 @@ orgs:
     - erabil
     - ericbottard
     - erjohnso
+    - ebroberson
     - evanfarrar
     - Everlag
     - f0rmiga
@@ -6415,6 +6416,7 @@ orgs:
         - jrussett
         - cphi-vmw
         - suraiyasuliman
+        - ebroberson
         members:
         - dsabeti
         - cf-gitbot

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -6416,7 +6416,6 @@ orgs:
         - jrussett
         - cphi-vmw
         - suraiyasuliman
-        - ebroberson
         members:
         - dsabeti
         - cf-gitbot


### PR DESCRIPTION
Adding Brandon Roberson, as he's a member of the runtime team at vmware and contributing to all of the runtime-wg repos