### PR TITLE
Update CF on K8s WG Repos

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1124,13 +1124,6 @@ orgs:
         archived: true
         default_branch: main
         has_projects: true
-      cf-k8s-ci:
-        default_branch: main
-        has_projects: true
-      cf-k8s-controllers:
-        default_branch: main
-        description: Cloud Foundry on Kubernetes
-        has_projects: true
       cf-k8s-logging:
         default_branch: main
         has_projects: true
@@ -2014,6 +2007,13 @@ orgs:
         description: Terminate the JVM when resources are exhausted
         has_projects: true
         has_wiki: false
+      korifi:
+        default_branch: main
+        description: Cloud Foundry on Kubernetes
+        has_projects: true
+      korifi-ci:
+        default_branch: main
+        has_projects: true
       lager:
         allow_merge_commit: false
         description: An opinionated logger for Go.
@@ -6067,10 +6067,9 @@ orgs:
         privacy: closed
         repos:
           cf-k8s-api: admin
-          cf-k8s-ci: admin
-          cf-k8s-controllers: admin
           cf-k8s-secrets: admin
-          cf-on-k8s-integration: write
+          korifi: admin
+          korifi-ci: admin
       cf-release-notes-bot:
         description: Team for bot that creates release notes on cf-release repo
         members:

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -61,6 +61,6 @@ areas:
   - name: Tim Downey
     github: tcdowney
   repositories:
-  - cloudfoundry/cf-k8s-controllers
+  - cloudfoundry/korifi
   - cloudfoundry-incubator/eirini-controller
 ```


### PR DESCRIPTION
Slight adjustments to the repositories that this WG owns:
- Updates cf-k8s-controllers to korifi to reflect the rename
- Adds the korifi-ci CI repo