### PR TITLE
Add korifi-bot to the cloudfoundry org

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -348,6 +348,7 @@ orgs:
     - kirederik
     - klakin-pivotal
     - KlapTrap
+    - korifi-bot
     - kmarkwardt-vmware
     - knm3000
     - kreinecke


### PR DESCRIPTION
This account is used in korifi CI and needs to list members of the cloudfoundry/cf-k8s team. That requires membership of the cloudfoundry org.