### PR TITLE
Remove k-don since this github user no longer exists

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -331,7 +331,6 @@ orgs:
     - jsampson1
     - julian-hj
     - Justin-W
-    - k-don
     - k1tm
     - KaiHofstetter
     - kaleo211
@@ -4447,7 +4446,6 @@ orgs:
         - carlo-colombo
         - hoegaarden
         - st3v
-        - k-don
         - spikymonkey
         - cf-london
         - teddyking


### PR DESCRIPTION
Get a 404 on this link: https://github.com/k-don

Breaks org sync:
```
{"component":"peribolos","file":"k8s.io/test-infra/prow/cmd/peribolos/main.go:209","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure cloudfoundry teams: failed to update CF London members: UpdateTeamMembership(cf-london(CF London), k-don, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/reference/teams#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2022-04-20T14:17:22Z"}
```

https://github.com/cloudfoundry/community/runs/6093041303?check_suite_focus=true#step:5:1821