### PR TITLE
Rename cf-k8s-secrets repo to korifi-secrets

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1146,7 +1146,7 @@ orgs:
       cf-k8s-prometheus:
         default_branch: main
         has_projects: true
-      cf-k8s-secrets:
+      korifi-secrets:
         default_branch: main
         has_projects: true
         private: true
@@ -6165,7 +6165,7 @@ orgs:
         privacy: closed
         repos:
           cf-k8s-api: admin
-          cf-k8s-secrets: admin
+          korifi-secrets: admin
           korifi: admin
           korifi-ci: admin
       cf-release-notes-bot:


### PR DESCRIPTION
This PR is to rename our cf-k8s-secrets repo used for CI to match the new project name.
This is required so that the repo is not automatically recreated when we rename it in the Github UI.

@emalm could you please help us coordinate and expedite this change 