### PR TITLE
Update CF on K8s Charter

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -61,6 +61,8 @@ areas:
   - name: Tim Downey
     github: tcdowney
   repositories:
+  - cloudfoundry/cf-k8s-secrets
+  - cloudfoundry/eirini-controller
   - cloudfoundry/korifi
-  - cloudfoundry-incubator/eirini-controller
+  - cloudfoundry/korifi-ci
 ```


### PR DESCRIPTION
[Request](https://github.com/cloudfoundry/community/pull/257#issuecomment-1109003840) from @emalm to add new korifi repos to the CF-K8s working group charter.

Should be merged *after* this [PR](https://github.com/cloudfoundry/community/pull/257) to rename the cf-k8s-secrets repo.