### PR TITLE
Create 2022 election docs

### DIFF
--- a/toc/elections/2022/Readme.md
+++ b/toc/elections/2022/Readme.md
@@ -1,0 +1,85 @@
+# 2022 CFF TOC Election Guide
+
+
+## Overview
+
+
+Each year, the CFF technical community holds an election for open seats on the 
+Technical Oversight Committee (TOC). The rules governing this election are set in the 
+[CFF's project charter](../../../governing-board/charter.md) (See section 7(b) and 7(e)
+for the relevant details).
+
+
+This guide exists to serve as a guide to this year's election process.
+
+
+## Schedule
+
+
+| Date                       | Event                    |
+| -------------------------- | ------------------------ |
+| May 11                   | Announcement of Election (at least 4 weeks before results) |
+| May 11 through May 28  | Candidate nomination period (at least 2 weeks long and ending 2 weeks before results) |
+| May 31     | Election Begins via email ballots (alow 2 work days to prepare election system) |
+| June 15     | Election Closes (at least 2 weeks after election begins) |
+| *June 17*   | Announcement of Results (at least 2 work days after election ends) |
+
+
+## Candidate Processes
+
+
+**Nominations**
+
+
+Every eligible voter can nominate candidates for the TOC, and we encourage you to do so. If you are 
+eligible to serve on the TOC, you can self nominate! If you want to nominate someone else, do so as 
+well! 
+
+
+You can nominate someone for the TOC by [submitting an issue using this template](https://github.com/cloudfoundry/community/issues/new?assignees=&labels=election&template=toc-candidate-nomination.md&title=TOC+Candidate+Nomination+for+%5BPerson+Name%5D). 
+
+
+The deadline is May 28th to be nominated (and for the nominee to indicate acceptance).
+
+
+It is strongly recommended that you confirm that a nominee is interested and willing
+to accept the nomination prior to submitting the nomination issue.
+
+
+**Confirming Nominee Eligibility**
+
+
+Once a nomination is received, the CFF staff will contact the nominee to confirm acceptance
+of the nomination. If the nominee accepts, they will be added to the list of nominees at the bottom
+of this file. The nomination issue will be closed, noting if the nominee accepted or declined the 
+nomination.
+
+
+## Voting Process
+
+
+The election will be conducted using a time-limited [Condorcet](https://civs.cs.cornell.edu/rp.html) ranking 
+on [CIVS](http://civs.cs.cornell.edu/) using the Schulze method. 
+
+
+Voters will receive an email with a ballot link. Voters will have until the end of the election cycle 
+to submit their ballot.
+
+
+## Election Results
+
+
+The newly elected body will be announced via cf-dev@lists.cloudfoundry.org on 17 Jun, 2022.
+
+
+Following the announcement, the raw voting results and winners will be published.
+
+
+## Nominees
+
+
+|    Name    | Organization/Company |  GitHub  |
+|:----------:|:--------------------:|:--------:|
+| Name | Employer | [@githubid](https://github.com/githubid) |
+
+

--- a/toc/elections/2022/Readme.md
+++ b/toc/elections/2022/Readme.md
@@ -18,11 +18,11 @@ This guide exists to serve as a guide to this year's election process.
 
 | Date                       | Event                    |
 | -------------------------- | ------------------------ |
-| May 11                   | Announcement of Election (at least 4 weeks before results) |
-| May 11 through May 28  | Candidate nomination period (at least 2 weeks long and ending 2 weeks before results) |
-| May 31     | Election Begins via email ballots (alow 2 work days to prepare election system) |
-| June 15     | Election Closes (at least 2 weeks after election begins) |
-| *June 17*   | Announcement of Results (at least 2 work days after election ends) |
+| May 18                   | Announcement of Election (at least 4 weeks before results) |
+| May 18 through June 2  | Candidate nomination period (at least 2 weeks long and ending 2 weeks before results) |
+| June 2     | Election Begins via email ballots (alow 2 work days to prepare election system) |
+| June 17     | Election Closes (at least 2 weeks after election begins) |
+| *June 22*   | Announcement of Results (at least 2 work days after election ends) |
 
 
 ## Candidate Processes
@@ -39,7 +39,7 @@ well!
 You can nominate someone for the TOC by [submitting an issue using this template](https://github.com/cloudfoundry/community/issues/new?assignees=&labels=election&template=toc-candidate-nomination.md&title=TOC+Candidate+Nomination+for+%5BPerson+Name%5D). 
 
 
-The deadline is May 28th to be nominated (and for the nominee to indicate acceptance).
+The deadline is June 2nd to be nominated (and for the nominee to indicate acceptance).
 
 
 It is strongly recommended that you confirm that a nominee is interested and willing
@@ -69,7 +69,7 @@ to submit their ballot.
 ## Election Results
 
 
-The newly elected body will be announced via cf-dev@lists.cloudfoundry.org on 17 Jun, 2022.
+The newly elected body will be announced via cf-dev@lists.cloudfoundry.org on 22 Jun, 2022.
 
 
 Following the announcement, the raw voting results and winners will be published.


### PR DESCRIPTION
Initial docs for 2022 election. This reflects almost the same dates as 2021 - if the TOC wants to amend anything at all here, please do. Before May 11, I'll have calculated a list of eligible voters, and drafted a cf-dev post.  