### PR TITLE
Update CF CAPI maintainers

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -3827,11 +3827,11 @@ orgs:
         - dsboulder
         - Gerg
         - sethboyles
-        - monamohebbi
         - moleske
         - tjvman
-        - sweinstein22
         - MerricdeLauney
+        - xandroc
+        - klakin-pivotal
         members:
         - evanfarrar
         - matt-royal


### PR DESCRIPTION
- Kenneth Lakin and Alex Rocha joined
- Mona Mohebbi and Sarah Weinstein left