### PR TITLE
Maintain App Runtime Interfaces WG Autoscaler

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2985,8 +2985,7 @@ orgs:
             - bonzofenix
             - Gerg
             - joergdw
-            - mvach
-            - salzmannsusan
+            - KevinJCross
             - silvestre
             privacy: closed
           App Runtime Interfaces WG Buildpacks:
@@ -6132,15 +6131,15 @@ orgs:
         description: CF Application Autoscaler core dev team
         maintainers:
         - asalan316
+        - bonzofenix
         - joergdw
-        - mvach
-        - salzmannsusan
+        - KevinJCross
         - silvestre
         members:
         - app-autoscaler-ci-bot
-        - bonzofenix
         - donacarr
-        - KevinJCross
+        - mvach
+        - salzmannsusan
         privacy: closed
         repos:
           app-autoscaler: admin

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -71,11 +71,13 @@ orgs:
     - ankeesler
     - ansd
     - ansergit
+    - app-autoscaler-ci-bot
     - APShirley
     - aqan213
     - aramprice
     - arjun024
     - asahil9009
+    - asalan316
     - ashvinmoro
     - atwoosnam
     - avade
@@ -341,6 +343,7 @@ orgs:
     - kcboyle
     - KeepAustinWired
     - kejadlen
+    - KevinJCross
     - Kiemes
     - kieron-dev
     - kimago
@@ -532,6 +535,7 @@ orgs:
     - ryanmoran
     - ryanwittrup
     - s4heid
+    - salzmannsusan
     - sampeinado
     - Samze
     - sanagaraj-pivotal
@@ -2977,10 +2981,13 @@ orgs:
           App Runtime Interfaces WG Autoscaler:
             description: Approvers for the App Runtime Interfaces Autoscaler area
             maintainers:
+            - asalan316
             - bonzofenix
             - Gerg
-            - silvestre
             - joergdw
+            - mvach
+            - salzmannsusan
+            - silvestre
             privacy: closed
           App Runtime Interfaces WG Buildpacks:
             description: Approvers for the App Runtime Buildpacks area
@@ -6124,10 +6131,16 @@ orgs:
       cf-autoscaler:
         description: CF Application Autoscaler core dev team
         maintainers:
+        - asalan316
+        - joergdw
+        - mvach
+        - salzmannsusan
         - silvestre
         members:
+        - app-autoscaler-ci-bot
         - bonzofenix
         - donacarr
+        - KevinJCross
         privacy: closed
         repos:
           app-autoscaler: admin

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -42,16 +42,12 @@ technical_leads:
 areas:
 - name: Autoscaler
   approvers:
-  - name: Gareth Evans
-    github: garethjevans
   - name: Arsalan Khan
     github: asalan316
   - name: Silvestre Zabala
     github: silvestre
   - name: Kevin Cross
     github: KevinJCross 
-  - name: Aadesh Misra
-    github: aadeshmisra
   - name: Alan Morán
     github: bonzofenix
   - name: Jörg Weisbarth


### PR DESCRIPTION
Adding current App Runtime Interfaces WG Autoscaler members and
maintainers to the cloudfoundry org and the relevant teams:

- asalan316
- mvach
- salzmannsusan
- KevinJCross

as well as our bot:

- app-autoscaler-ci-bot
