### PR TITLE
Enable community project sync

### DIFF
--- a/toc/TOC.md
+++ b/toc/TOC.md
@@ -115,3 +115,26 @@ approval, based on community feedback.
 
 The initial content of this page is from the work of the [Knative community](https://github.com/knative/community)
 under the terms of the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
+
+```yaml
+name: Technical Oversight Committee
+execution_leads:
+- name: Lee Porte
+  github: leeporte
+- name: David Stevenson
+  github: dsboulder
+- name: Eric Malm
+  github: emalm
+- name: Jan von Löwenstein
+  github: loewenstein
+- name: Stephan Merker
+  github: stephanme
+areas:
+- name: CloudFoundry Community
+  repositories:
+  - cloudfoundry/community
+config:
+  github_project_sync:
+    mapping:
+      cloudfoundry: 31
+```

--- a/toc/working-groups/parsable-working-groups.sh
+++ b/toc/working-groups/parsable-working-groups.sh
@@ -6,7 +6,13 @@ repo_root=$(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd))
 
 pushd $repo_root/toc/working-groups >/dev/null
 
-for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
-    cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
+for group in $(ls ../*.md | grep -v -e ROLES -e CHANGEPLAN -e PRINCIPLES -e GOVERNANCE); do
+    cat ${group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
         ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
+    for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
+          cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
+                ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
+    done
 done
+
+


### PR DESCRIPTION
We previously didn't have any YAML in place for the TOC in order to enable project sync workflows.

This PR adds this functionality.

Have run locally before and after the changes and produced the following diff

before: `toc/working-groups/./parsable-working-groups.sh > groups.json`

after: `toc/working-groups/./parsable-working-groups.sh > groups-and-toc.json`

```
leeporte@gds8976:~/code/src/github.com/cloudfoundry/community$ diff toc/working-groups/groups.json toc/working-groups/groups-and-toc.json
2a3,44
>     "name": "Technical Oversight Committee",
>     "execution_leads": [
>       {
>         "name": "Lee Porte",
>         "github": "leeporte"
>       },
>       {
>         "name": "David Stevenson",
>         "github": "dsboulder"
>       },
>       {
>         "name": "Eric Malm",
>         "github": "emalm"
>       },
>       {
>         "name": "Jan von Löwenstein",
>         "github": "loewenstein"
>       },
>       {
>         "name": "Stephan Merker",
>         "github": "stephanme"
>       }
>     ],
>     "areas": [
>       {
>         "name": "CloudFoundry Community",
>         "repositories": [
>           "cloudfoundry/community"
>         ]
>       }
>     ],
>     "config": {
>       "github_project_sync": {
>         "mapping": {
>           "cloudfoundry": 31
>         }
>       }
>     }
>   }
> ]
> [
>   {
```

I have also included the generated files (had to add the .txt extension due to GH limitations)

[groups.json.txt](https://github.com/cloudfoundry/community/files/8630415/groups.json.txt)

[groups-and-toc.json.txt](https://github.com/cloudfoundry/community/files/8630410/groups-and-toc.json.txt)

