### PR TITLE
[FI] Enable stale bot for recently inherited repos

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -3786,6 +3786,7 @@ orgs:
         - bosh-admin-bot
         privacy: closed
         repos:
+          bbl-state-resource: admin
           bosh: admin
           bosh-acceptance-tests: admin
           bosh-agent: admin
@@ -3794,6 +3795,7 @@ orgs:
           bosh-aws-light-stemcell-builder: admin
           bosh-azure-cpi-release: admin
           bosh-bbl-ci-envs: admin
+          bosh-bootloader: admin
           bosh-cli: admin
           bosh-compiled-releases-index: admin
           bosh-cpi-environments: admin
@@ -3823,9 +3825,11 @@ orgs:
           config-server: admin
           config-server-release: admin
           docs-bosh: admin
+          exemplar-release: admin
           gofileutils: admin
           gosigar: admin
           homebrew-tap: write
+          jumpbox-deployment: admin
           os-conf-release: admin
           socks5-proxy: admin
           syslog-release: admin


### PR DESCRIPTION
Our current stale bot uses the `BOSH admin bot` team to generate its configuration.

This PR adds the repos which where added to the FI working group in: https://github.com/cloudfoundry/community/pull/272