### PR TITLE
Add markdown copy of CFF code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Code of Conduct
+
+To ensure we maintain a welcome and thriving environment to collaborate we’ve come up with some general guidelines that apply to participants in the Cloud Foundry community.
+
+This markdown file is taken from the [online code of conduct](https://www.cloudfoundry.org/code-of-conduct/). If deviations occur, please alert the project and consider the online version to be the correct source.
+
+## Guidelines
+
+**Act Professionally**: Be courteous, respectful and polite to fellow community members: no racial, gender, or other abuse will be tolerated.
+
+**We value diversity and inclusiveness**: Make everyone in our community feel welcome, regardless of their background and the extent of their contributions, and do everything possible to encourage participation in our community. We do not tolerate exclusionary behavior.
+
+**Be careful in the words that we choose**: Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior are not acceptable. This includes, but is not limited to:
+
+- Violent threats or language directed against another person.
+- Sexist, racist, or otherwise discriminatory jokes and language.
+- Posting sexually explicit or violent material.
+- Posting (or threatening to post) other people’s personally identifying information (“doxing”).
+- Sharing private content without prior consent, such as emails sent privately or non-publicly, or unlogged forums such as private IMs.
+- Personal insults, especially those using racist or sexist terms.
+- Unwelcome sexual attention.
+- Bullying or repeated harassment of others. In general, if someone asks you to stop, then stop.
+- Advocating for, staying silent about, not reporting, or encouraging, any of the above behavior.
+
+**Keep it legal**: Share only content that you own, do not share private or sensitive information, and do not break the law.
+
+**Stay on topic**: Make sure that you are posting to the correct channel and avoid off-topic discussions. Remember when you update an issue or respond to an email you are potentially sending to a large number of people.
+
+**Respect all Cloud Foundry community forums**: The previous list applies to all forms of interaction including, but not limited to: participation in the Dojos, social media such as Twitter, IRC, the mailing lists, the issue tracker, review comments, and any other forum that is used by the community. Events that take place in public spaces, such as conferences and meetup groups, will generally have their own code of conduct or similar community guidelines. As such, the guidelines for a specific event should be followed.
+
+**Step down considerately**: Members of every project come and go, and Cloud Foundry is no different. When somebody leaves or disengages from the project, in whole or in part, we ask that they do so in a way that minimizes disruption to the project. This means they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+**Keep in mind**: Your work will be used by other people, and you, in turn, will depend on the work of others.
+
+Decisions that you make will often affect others in the community.
+
+Disagreements happen, but should not be an excuse for poor behavior and bad manners. When disagreements do happen, work together to solve them effectively and with comity.
+
+People may not understand jokes, sarcasm, and oblique references in the same way that you do. So remember that and be kind to the other members of the community.
+
+Sexist, racist, and other prejudicial or exclusionary comments are not welcome in the community.
+
+You are participating in an open source software project of a global scope. Please keep in mind how words, the tone of statements and sarcasm may be interpreted (or misinterpreted) by others.
+
+## Report an Incident
+
+To report incidents or to appeal reports of incidents, send an email to [conduct@cloudfoundry.org](mailto:conduct@cloudfoundry.org). Please include any available relevant information, including links to any publicly accessible material relating to the matter. Every effort will be taken to ensure a safe and collegial environment in which to collaborate on matters relating to the Foundation. In order to protect the community, the Foundation reserves the right to take appropriate action, potentially including the removal of an individual from any and all participation in the project. The Foundation will work towards an equitable resolution in the event of a misunderstanding.
+
+## Credits
+
+This code of conduct is based on the example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers, as well as several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work. Additional thanks to the Ubuntu, Chef, Puppet, Docker, CouchDB and OpenStack communities for providing inspiration for these guidelines.


### PR DESCRIPTION
Hat tip to @dmikusa-pivotal for [requesting a Markdown-formatted copy of the CFF Code of Conduct](https://cloudfoundry.slack.com/archives/C026XJGNC2U/p1652900933596659) for https://github.com/paketo-buildpacks/.github/pull/15.