### PR TITLE
Propose using Elekto as the system for the 2022 TOC election

### DIFF
--- a/governing-board/charter.md
+++ b/governing-board/charter.md
@@ -212,7 +212,9 @@ c)	The Governing Board manages the CFF. The CFF will also have an Outreach Commi
 
         -   (1) If the number of candidates is equal to or less than the number of TOC seats available to be elected, the candidates shall be approved after the nomination period has closed.
         
-        -   (2) If there are more Qualified Nominees than open TOC seats available for election, all eligible votes shall elect the TOC members using a time-limited [Condorcet](https://civs.cs.cornell.edu/rp.html) ranking on [CIVS](http://civs.cs.cornell.edu/) using the Schulze method.
+        -   (2) If there are more Qualified Nominees than open TOC seats available for election, all eligible votes shall elect the TOC members using a time-limited [Condorcet](https://civs.cs.cornell.edu/rp.html) ranking using the Schulze method.
+
+        -   (3) Elections may be run either via the [Condorcet Internet Voting Service](https://civs1.civs.us/) or via a deployment of [Elekto](https://elekto.dev/) administered by the CFF staff.
 
 -   f)  TOC Member Resignations or Removal
 

--- a/toc/elections/2022/Readme.md
+++ b/toc/elections/2022/Readme.md
@@ -20,7 +20,7 @@ This guide exists to serve as a guide to this year's election process.
 | -------------------------- | ------------------------ |
 | May 18                   | Announcement of Election (at least 4 weeks before results) |
 | May 18 through June 2  | Candidate nomination period (at least 2 weeks long and ending 2 weeks before results) |
-| June 2     | Election Begins via email ballots (alow 2 work days to prepare election system) |
+| June 2     | Election Begins (alow 2 work days to prepare election system) |
 | June 17     | Election Closes (at least 2 weeks after election begins) |
 | *June 22*   | Announcement of Results (at least 2 work days after election ends) |
 
@@ -60,14 +60,14 @@ nomination.
 
 The 2022 TOC election will be conducted using a [CFF-managed instance]
 (https://elections.cloudfoundry.org) of [Elekto](https://elekto.dev), a CNCF infrastructure project
-that implements Condorcet ranked-choice voting using the Schulze method. Elekto uses GitHub OAuth
-as its identity and authentication system, which better matches how members interact with the Cloud
+that implements Condorcet ranked-choice voting using the Schulze method. Elekto relies on GitHub
+for user identity and authentication, which better matches how members interact with the Cloud
 Foundry community on a day-to-day basis than the email identity that the [Condorcet Internet Voting
 Service](https://civs1.civs.us/) requires.
 
 If Elekto fails to recognize you as eligible to vote in this election even though you believe you
 should be, please file a voting exception request [within the Elekto app]
-(https://elections.cloudfoundry.org/app/elections/2022-TOC/exception) or [via an issue on the
+(https://elections.cloudfoundry.org/app/elections/2022---TOC/exception) or [via an issue on the
 community repository](https://github.com/cloudfoundry/community/issues/new?assignees=&labels=election&template=request-to-be-elector-for-toc-election.md&title=Request+to+be+an+elector+for+TOC+election).
 
 Once the official election period starts, you will be able to rank the candidates in your preferred
@@ -85,7 +85,7 @@ aggregate form.
 The newly elected body will be announced via cf-dev@lists.cloudfoundry.org on 22 Jun, 2022.
 
 
-Following the announcement, the raw voting results and winners will be published.
+Following the announcement, the voting results and winners will be published.
 
 
 ## Nominees

--- a/toc/elections/2022/Readme.md
+++ b/toc/elections/2022/Readme.md
@@ -58,12 +58,25 @@ nomination.
 ## Voting Process
 
 
-The election will be conducted using a time-limited [Condorcet](https://civs.cs.cornell.edu/rp.html) ranking 
-on [CIVS](http://civs.cs.cornell.edu/) using the Schulze method. 
+The 2022 TOC election will be conducted using a [CFF-managed instance]
+(https://elections.cloudfoundry.org) of [Elekto](https://elekto.dev), a CNCF infrastructure project
+that implements Condorcet ranked-choice voting using the Schulze method. Elekto uses GitHub OAuth
+as its identity and authentication system, which better matches how members interact with the Cloud
+Foundry community on a day-to-day basis than the email identity that the [Condorcet Internet Voting
+Service](https://civs1.civs.us/) requires.
 
+If Elekto fails to recognize you as eligible to vote in this election even though you believe you
+should be, please file a voting exception request [within the Elekto app]
+(https://elections.cloudfoundry.org/app/elections/2022-TOC/exception) or [via an issue on the
+community repository](https://github.com/cloudfoundry/community/issues/new?assignees=&labels=election&template=request-to-be-elector-for-toc-election.md&title=Request+to+be+an+elector+for+TOC+election).
 
-Voters will receive an email with a ballot link. Voters will have until the end of the election cycle 
-to submit their ballot.
+Once the official election period starts, you will be able to rank the candidates in your preferred
+order and submit your ballot. You may set a password on your ballot, which is required to change
+your ballot later within the election period. Once the election period ends, all ballots are final.
+
+All ballot data for Elekto is stored on a database managed by the CFF staff, and is not shared with
+third parties. Individual ballot data is encrypted, and ballot data can be retrieved only in
+aggregate form.
 
 
 ## Election Results
@@ -81,5 +94,3 @@ Following the announcement, the raw voting results and winners will be published
 |    Name    | Organization/Company |  GitHub  |
 |:----------:|:--------------------:|:--------:|
 | Name | Employer | [@githubid](https://github.com/githubid) |
-
-


### PR DESCRIPTION
* Amend the CFF charter to permit a CFF-managed Elekto instance as an election system