### PR TITLE
Nomation: Max Hufnagel to App Runtime Platform as Docs approver

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -3171,6 +3171,7 @@ orgs:
         maintainers:
         - ameowlia
         members:
+        - animatedmax
         - Benjamintf1
         - Gerg
         - acrmp
@@ -3418,8 +3419,10 @@ orgs:
           App Runtime Platform WG Docs Reviewers:
             members:
             - geofffranks
+            - animatedmax
           App Runtime Platform WG Docs:
-            members: []
+            members:
+            - animatedmax
             privacy: closed
             repos:
               docs-book-cloudfoundry: write

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -113,6 +113,8 @@ areas:
 
 - name: Docs
   approvers:
+  - name: Max Hufnagel
+    github: animatedmax
   repositories:
   - cloudfoundry/docs-book-cloudfoundry
   - cloudfoundry/docs-cf-admin


### PR DESCRIPTION
Max Hugnagel (@animatedmax) has been a core member of the Cloud Foundry docs team for over 8 years. He is the `#1` contributor for many of the CF docs repos.

The ARP working group currently has no approvers for docs and really needs one.