### PR TITLE
Add GitHub username field to TOC nomination template

### DIFF
--- a/.github/ISSUE_TEMPLATE/toc-candidate-nomination.md
+++ b/.github/ISSUE_TEMPLATE/toc-candidate-nomination.md
@@ -9,6 +9,8 @@ assignees: ''
 
 Candidate Name: [name of person being nominated]
 
+Candidate GitHub Username: [GitHub username of person being nominated]
+
 Affiliation: [employer of candidate]
 
 Nomination Statement: [Describe why this person (or you!) would make a good member of the TOC]


### PR DESCRIPTION
The CFF TOC conducts its affairs primarily through GitHub and also uses it for identity and authentication in elections with Elekto. Let's make this identification explicit for TOC candidate nominations.