### PR TITLE
Remove menehune23 from charter

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -63,8 +63,6 @@ areas:
     github: dmikusa-pivotal
   - name: David O'Sullivan
     github: pivotal-david-osullivan
-  - name: Andrew Meyer
-    github: menehune23
   - name: Arjun Sreedharan
     github: arjun024
   - name: Brayan Henao


### PR DESCRIPTION
This is a follow on from: https://github.com/cloudfoundry/community/commit/0fe856acca8adba89268405b427cf9cc5b485f69

This has become a problem because of: https://github.com/cloudfoundry/community/pull/284