### PR TITLE
Add bosh-psmodules repo back to cloudfoundry github org

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -271,6 +271,9 @@ orgs:
         has_issues: false
         has_projects: true
         private: true
+      bosh-psmodules:
+        description: PowerShell modules for building Windows Stemcells
+        has_projects: false
       bosh-s3cli:
         description: Go CLI for S3
         has_projects: false

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -181,6 +181,7 @@ areas:
   - cloudfoundry/bosh-google-light-stemcell-builder
   - cloudfoundry/bosh-linux-stemcell-builder
   - cloudfoundry/bosh-openstack-cpi-release
+  - cloudfoundry/bosh-psmodules
   - cloudfoundry/bosh-s3cli
   - cloudfoundry/bosh-softlayer-cpi-release
   - cloudfoundry/bosh-community-stemcell-ci-infra


### PR DESCRIPTION
This repo was moved to [cloudfoundry-attic](https://github.com/cloudfoundry-attic/bosh-psmodules) as the intent was to replace the current Windows stemcell build process with stembuild for all IAASs.

This work was never finished and we continue to use the bosh-psmodules repo for building stemcells.

cc @christopherclark as we'll need the repo moved from https://github.com/cloudfoundry-attic/bosh-psmodules once this PR is merged.