### PR TITLE
Transfer BOSH Bootloader to App Runtime deployments

### DIFF
--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -77,4 +77,6 @@ areas:
   - cloudfoundry/cf-test-helpers
   - cloudfoundry/uptimer
   - cloudfoundry/runtime-ci
+  - cloudfoundry/bosh-bootloader
+  - cloudfoundry/bbl-state-resource
 ```

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -150,7 +150,6 @@ areas:
   - bosh-packages/nginx-release
   - bosh-packages/python-release
   - bosh-packages/ruby-release
-  - cloudfoundry/bbl-state-resource
   - cloudfoundry/bosh-alicloud-light-stemcell-builder
   - cloudfoundry/bosh-cpi-certification
   - cloudfoundry/bosh-windows-acceptance-tests
@@ -162,7 +161,6 @@ areas:
   - cloudfoundry/bosh-aws-light-stemcell-builder
   - cloudfoundry/bosh-azure-cpi-release
   - cloudfoundry/bosh-bbl-ci-envs
-  - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-cli
   - cloudfoundry/bosh-community-stemcell-ci-infra
   - cloudfoundry/bosh-compiled-releases-index


### PR DESCRIPTION
This project was initially given to FI, probably because it has BOSH in its name, and the deployment working group did not exist yet, however, this project actually requires intimate knowledge of cf-deployment to be able to properly maintain it.

This PR proposes to move BOSH Bootloader and the related concourse bbl state resource to the App Runtime Deployments working group.

cc @jochenehret
