### PR TITLE
[ARI] Remove App Autoscaler dev team access to `runtime-og-ci-private`

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -5836,7 +5836,6 @@ orgs:
           app-autoscaler-release: admin
           app-autoscaler-ui: write
           bosh-compile-action: admin
-          runtime-og-ci-private: write
       cf-frontend bot:
         description: ""
         members:


### PR DESCRIPTION
We (the current team) have never used `runtime-og-ci-private` and have no need to have access to it.