### PR TITLE
List the CF-on-K8s WG bots

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -37,7 +37,11 @@ technical_leads:
   github: gcapizzi
 - name: George
   github: georgethebeatle
-bots: []
+bots:
+- name: eirinici
+  github: eirinici
+- name: korifi-bot
+  github: korifi-bot
 areas:
 - name: CF on k8s
   approvers:


### PR DESCRIPTION
This makes sure that after #262 happens our bots still have the access they need to our repos.