### PR TITLE
Add --allow-repo-archival to org automation

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -77,6 +77,7 @@ jobs:
             --fix-teams
             --fix-team-members
             --fix-team-repos
+            --allow-repo-archival
       - name: debug
         run: |
           echo "steps.peribolos.outcome = ${{ steps.peribolos.outcome }}"


### PR DESCRIPTION
Archiving is triggered by adding "archived: true" to the repository entry
in cloudfoundry.yml.

Org automation fails without --allow-repo-archival.