### PR TITLE
Add "missing" App Runtime Deployments repositories

### DIFF
--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -69,12 +69,17 @@ areas:
   - github: shaun7pan
     name: Shaun Pan
   repositories:
+  - cloudfoundry/cf-acceptance-tests
   - cloudfoundry/cf-deployment
   - cloudfoundry/cf-deployment-concourse-tasks
-  - cloudfoundry/cf-acceptance-tests
+  - cloudfoundry/cf-relint-ci-semver
   - cloudfoundry/cf-smoke-tests
   - cloudfoundry/cf-smoke-tests-release
   - cloudfoundry/cf-test-helpers
-  - cloudfoundry/uptimer
+  - cloudfoundry/honeycomb-ginkgo-reporter
+  - cloudfoundry/relint-ci-pools
+  - cloudfoundry/relint-envs
+  - cloudfoundry/relint-team
   - cloudfoundry/runtime-ci
+  - cloudfoundry/uptimer
 ```


### PR DESCRIPTION
Add some missing private repositories used to test CF-Deployment and CATs.

This PR supersedes #270.