### PR TITLE
[ARP] Add tas-runtime-bot as a bot

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -40,7 +40,9 @@ execution_leads:
 technical_leads:
 - name: Amelia Downs
   github: ameowlia
-bots: []
+bots:
+- name: CI bot
+  github: tas-runtime-bot
 areas:
 - name: Diego
   approvers:


### PR DESCRIPTION
🔑 Most of the current ARP CI uses this bot's credentials to interact with ARP's GitHub repos.

👎 The bot currently gets its access from the `runtime` team, which will likely be deleted when #262 is implemented.

➡️ Bring the bot account into the fold as a working group bot.