### PR TITLE
service-management: add new terraform-provider-csbpg repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -5951,7 +5951,6 @@ orgs:
           csb-brokerpak-azure: admin
           csb-brokerpak-gcp: admin
           upgrade-all-services-cli-plugin: admin
-          terraform-provider-csbpg: admin
       cloudops-ci:
         description: ""
         members:

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2138,6 +2138,13 @@ orgs:
         allow_merge_commit: false
         has_issues: false
         has_projects: true
+      terraform-provider-csbpg:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        description: Terraform provider to manage Cloud Service Broker bindings for PostgreSQL
+        has_projects: true
+        has_wiki: false
       test-log-emitter:
         has_projects: true
       test-log-emitter-release:
@@ -5944,6 +5951,7 @@ orgs:
           csb-brokerpak-azure: admin
           csb-brokerpak-gcp: admin
           upgrade-all-services-cli-plugin: admin
+          terraform-provider-csbpg: admin
       cloudops-ci:
         description: ""
         members:

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -53,6 +53,7 @@ areas:
   - cloudfoundry/csb-brokerpak-aws
   - cloudfoundry/csb-brokerpak-gcp
   - cloudfoundry/upgrade-all-services-cli-plugin
+  - cloudfoundry/terraform-provider-csbpg
 - name: OSB API
   approvers:
   - name: Sam Gunaratne


### PR DESCRIPTION
This repo will contain https://github.com/cloudfoundry/csb-brokerpak-gcp/tree/main/providers/terraform-provider-csbpg so that it can be used in other CSB brokerpaks