### PR TITLE
[ARI] Add `app-autoscaler-ci-bot` to ARI WG bots

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -39,7 +39,9 @@ execution_leads:
 technical_leads:
 - name: Greg Cobb 
   github: gerg
-bots: []
+bots:
+- name: App Autoscaler CI Bot
+  github: app-autoscaler-ci-bot
 areas:
 - name: Autoscaler
   approvers:


### PR DESCRIPTION
:key: The App Autoscaler CI uses this bot's credentials to interact with the App Autoscaler GitHub repos.

:-1: The bot currently gets its access from the the `cf-autoscaler` team, which will likely be deleted when #262 is implemented.

:arrow_right: Bring the bot account into the fold as a working group bot.
