### PR TITLE
Move all org admins into TOC charter

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1,12 +1,7 @@
 ---
 orgs:
   cloudfoundry:
-    admins:
-    - christopherclark
-    - halliwilljustin
-    - mjear
-    - ramiyengar
-    - thelinuxfoundation
+    admins: [] # shall be empty, maintained in TOC.md
     billing_email: ap@cloudfoundry.org
     company: ""
     default_repository_permission: none

--- a/org/test_org_management.py
+++ b/org/test_org_management.py
@@ -311,7 +311,9 @@ class TestOrgGenerator(unittest.TestCase):
 
         o.generate_org_members()
         members = o.org_cfg["orgs"]["cloudfoundry"]["members"]
+        admins = o.org_cfg["orgs"]["cloudfoundry"]["admins"]
         self.assertGreater(len(members), 100)
+        self.assertGreater(len(admins), 7)  # 5 toc members + CFF technical staff
         self.assertIn("cf-bosh-ci-bot", members)
 
         o.generate_teams()
@@ -323,5 +325,6 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertIn("cf-deployment", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["repos"])
         self.assertIn("cf-gitbot", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["members"])
         self.assertIn("toc", teams)
+        self.assertEquals(5, len(teams["toc"]["maintainers"]))
         self.assertIn("community", teams["toc"]["repos"])
         self.assertIn("wg-leads", teams)

--- a/toc/TOC.md
+++ b/toc/TOC.md
@@ -129,7 +129,17 @@ execution_leads:
   github: rkoster
 - name: Stephan Merker
   github: stephanme
-technical_leads: []
+technical_leads:
+- name: Chris Clark
+  github: christopherclark
+- name: Justin Halliwill
+  github: halliwilljustin
+- name: Michele Jear
+  github: mjear
+- name: Ram Iyengar
+  github: ramiyengar
+- name: The Linux Foundation
+  github: thelinuxfoundation
 bots: []
 areas:
 - name: CloudFoundry Community

--- a/toc/TOC.md
+++ b/toc/TOC.md
@@ -132,10 +132,6 @@ execution_leads:
 technical_leads:
 - name: Chris Clark
   github: christopherclark
-- name: Justin Halliwill
-  github: halliwilljustin
-- name: Michele Jear
-  github: mjear
 - name: Ram Iyengar
   github: ramiyengar
 - name: The Linux Foundation


### PR DESCRIPTION
- execution leads = TOC = toc github team
- technical leads = CFF staff
- both get cloudfoundry org admins