### PR TITLE
Add runtime bot to foundational infrastructure for syslog/etc

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -43,6 +43,8 @@ bots:
   github: bosh-admin-bot
 - name: cf-gitbot
   github: cf-gitbot
+- name: runtime-bot
+  github: tas-runtime-bot
 areas:
 - name: Credential Management (Credhub)
   approvers:


### PR DESCRIPTION
Most of the current CI uses this bot's credentials to interact with System Logging and Metrics (rsyslog / event-log) GitHub repos.

The bot currently gets its access from the runtime team, which will likely be deleted when https://github.com/cloudfoundry/community/pull/262 is implemented.

Bring the bot account into the fold as a working group bot. 