### PR TITLE
Add stefanlay to App Runtime Platform Networking Approvers/Main group

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2957,6 +2957,7 @@ orgs:
             - reneighbor
             - selzoc
             - MarcPaquette
+            - stefanlay
           App Runtime Platform WG Networking:
             members:
               - aminjam
@@ -2970,6 +2971,7 @@ orgs:
               - plowin
               - reneighbor
               - selzoc
+              - stefanlay
             privacy: closed
             repos:
               cf-networking-helpers: write


### PR DESCRIPTION
Per [the App Runtime Platform WG page](https://github.com/cloudfoundry/community/blob/main/toc/working-groups/app-runtime-platform.md),
@stefanlay is an authorized approver. They are in the
`wg-app-runtime-platform-networking-approvers` group already, but absent from
`app-runtime-platform-wg-networking` and
`app-runtime-platform-wg-networking-reviewers`.
