### PR TITLE
Make RFC numbering script handle WG-specific RFC drafts

### DIFF
--- a/toc/rfc/assign-rfc-number.sh
+++ b/toc/rfc/assign-rfc-number.sh
@@ -88,9 +88,9 @@ RFC_ID=$(generate_id)
 echo "> Generated RFC number: ${RFC_ID}"
 
 
-SOURCE_DOC=$(find "${script_dir}" -maxdepth 1 -type f -name 'rfc-draft-*')
+SOURCE_DOC=$(find "${script_dir}" -maxdepth 2 -type f -name 'rfc-draft-*')
 TARGET_DOC=${SOURCE_DOC//rfc-draft/rfc-${RFC_ID}}
-SOURCE_DIR=$(find "${script_dir}" -maxdepth 1 -type d -name 'rfc-draft-*')
+SOURCE_DIR=$(find "${script_dir}" -maxdepth 2 -type d -name 'rfc-draft-*')
 TARGET_DIR=${SOURCE_DIR//rfc-draft/rfc-${RFC_ID}}
 
 echo "> Transforming '${SOURCE_DOC}' into '${TARGET_DOC}'"


### PR DESCRIPTION
Increasing the maxdepth to 2 lets the script find files in the working groups' subdirectories, and matches what it does to determine the latest ID across all the numbered RFC documents.

I used this change successfully to number the documents from #279 in https://github.com/cloudfoundry/community/commit/a467b44951bf3e94d6f378aeec115337a51daf11 (even if I had the merge commit from #333 selected accidentally 😅 ).