### PR TITLE
add capi-ci-private to capi approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -155,6 +155,7 @@ areas:
   - cloudfoundry/capi-bara-tests
   - cloudfoundry/capi-k8s-release
   - cloudfoundry/capi-ci
+  - cloudfoundry/capi-ci-private
   - cloudfoundry/cf-performance-tests
   - cloudfoundry/cf-performance-tests-pipeline
   - cloudfoundry/tps


### PR DESCRIPTION
- capi approvers need capi-ci-private to connect to environments used in ci

tagging some of the capi-approvers and working group lead to make them aware

@cloudfoundry/wg-app-runtime-interfaces-capi-approvers or @cloudfoundry/app-runtime-interfaces-wg-capi (since neither list seems to be correct based on [this](https://github.com/cloudfoundry/community/blob/main/toc/working-groups/app-runtime-interfaces.md#roles--technical-assets))