### PR TITLE
Remove mjear from all roles and teams

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -4620,7 +4620,6 @@ orgs:
         maintainers:
         - dsboulder
         - emalm
-        - mjear
         members:
         - evanfarrar
         - schubert
@@ -5121,11 +5120,6 @@ orgs:
           spring-auto-reconfiguration-cnb: admin
           spring-boot-cnb: admin
           tomcat-cnb: admin
-      License Finder:
-        description: ""
-        maintainers:
-        - mjear
-        privacy: secret
       OSS Review:
         description: ""
         members:


### PR DESCRIPTION
Was removed from org admins by #376 and now automation fails because there
are still references in non-standard teams.