### PR TITLE
Add Seth Boyles to back to CAPI approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -148,6 +148,8 @@ areas:
     github: johha
   - name: Michael Oleske
     github: moleske
+  - name: Seth Boyles
+    github: sethboyles
   repositories:
   - cloudfoundry/cloud_controller_ng
   - cloudfoundry/capi-release


### PR DESCRIPTION
I was erroneously removed in this commit: https://github.com/cloudfoundry/community/commit/72f17ed4719eb513e2aac3f2430b7ea385127a7b