### PR TITLE
[ARI] Add Buildpacks area bot to ARI WG bots

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -39,7 +39,9 @@ execution_leads:
 technical_leads:
 - name: Greg Cobb 
   github: gerg
-bots: []
+bots:
+- name: Cloud Foundry Buildpacks Team Robot
+  github: cf-buildpacks-eng
 areas:
 - name: Autoscaler
   approvers:


### PR DESCRIPTION
This is the bot used by the buildpacks area CI.

cc @brayanhenao @ryanmoran @dmikusa-pivotal @pivotal-david-osullivan
