### PR TITLE
Add capi-bot to bots for app runtime interfaces

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -44,6 +44,8 @@ bots:
   github: app-autoscaler-ci-bot
 - name: Cloud Foundry Buildpacks Team Robot
   github: cf-buildpacks-eng
+- name: capi-bot
+  github: capi-bot
 areas:
 - name: Autoscaler
   approvers:


### PR DESCRIPTION
https://github.com/capi-bot is used for cutting releases of [capi-release](https://github.com/cloudfoundry/capi-release/releases), as well as other automated environment management work.  It is currently added to the repositories it needs as an outside collaborated and not as a member of a team, which is why it is not listed in cloudfoundry.yml

tagging @cloudfoundry/wg-app-runtime-interfaces-capi-approvers since needs some approvals