### PR TITLE
wg-service-management: add Ian Findlay to wg charter

### DIFF
--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -96,6 +96,8 @@ areas:
     github: fejnartal
   - name: Gareth Smith
     github: totherme
+  - name: Ian Findlay
+    github: ifindlay-cci
   repositories:
   - cloudfoundry/existingvolumebroker
   - cloudfoundry/goshims


### PR DESCRIPTION
Ian had been added as part of [this PR](https://github.com/cloudfoundry/community/pull/232) to one of the groups without adding them to the WG charter.
This is so Ian doesn't lose access to the Volume Services repositories once that non-standard teams are deleted and teams are only created from the wg charter spec.

The Volume Services projects have very little activity at the moment and approvers do basically routine maintenance tasks. So formally passing the criteria to become approver the Foundation has established is not possible for now.