### PR TITLE
wg-service-management: add area specific bots

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -538,7 +538,6 @@ contributors:
 - sebGilR
 - selzoc
 - services-api-ci
-- servicesenablement
 - sethboyles
 - shamus
 - Shanfan

--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -538,6 +538,7 @@ contributors:
 - sebGilR
 - selzoc
 - services-api-ci
+- servicesenablement
 - sethboyles
 - shamus
 - Shanfan

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -47,6 +47,9 @@ areas:
     github: tinygrasshopper
   - name: Andrea Zucchini
     github: zucchinidev
+  bots:
+  - name: Services Enablement bot
+    github: servicesenablement
   repositories:
   - cloudfoundry/cloud-service-broker
   - cloudfoundry/csb-brokerpak-azure
@@ -96,6 +99,9 @@ areas:
     github: fejnartal
   - name: Gareth Smith
     github: totherme
+  bots:
+  - name: Cryogenics CI Bot
+    github: Cryogenics-CI
   repositories:
   - cloudfoundry/existingvolumebroker
   - cloudfoundry/goshims


### PR DESCRIPTION
Adding area specific bots to the wg charter