### PR TITLE
Move runtimeschema to the App Runtime Interfaces WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -177,6 +177,7 @@ areas:
   - cloudfoundry/capi-workspace
   - cloudfoundry/delayed_job_sequel
   - cloudfoundry/steno
+  - cloudfoundry/runtimeschema
 
 - name: CLI
   approvers:

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -110,7 +110,6 @@ areas:
   - cloudfoundry/operationq
   - cloudfoundry/rep
   - cloudfoundry/route-emitter
-  - cloudfoundry/runtimeschema
   - cloudfoundry/runtime-credentials
   - cloudfoundry/sample-http-app
   - cloudfoundry/systemcerts


### PR DESCRIPTION
It only contains code used for TPS/CC Uploader.

cc/ @Gerg 