### PR TITLE
Archive legacy cf-mysql-release repos

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -518,19 +518,24 @@ orgs:
       cf-mysql-bootstrap:
         description: Auto-bootstrap errand for cf-mysql-release
         has_projects: true
+        archived: true
       cf-mysql-ci:
         description: Contains Concourse CI scripts and configuration we use to test
           cf-mysql-release
         has_projects: true
+        archived: true
       cf-mysql-cluster-health-logger:
         has_projects: true
+        archived: true
       cf-mysql-deployment:
         default_branch: develop
         has_projects: true
+        archived: true
       cf-mysql-release:
         default_branch: develop
         description: Cloud Foundry MySQL Release
         has_projects: true
+        archived: true
       cf-networking-deployments:
         archived: true
         description: Private manifests and credentials for the Container Networking
@@ -1141,9 +1146,11 @@ orgs:
         description: A lightweight web server written in Golang to check the health
           of a node in a Galera cluster
         has_projects: true
+        archived: true
       galera-init:
         description: Monit ctl script for MariaDB in cf-mysql-release
         has_projects: true
+        archived: true
       garden:
         description: Go Warden
         has_projects: true
@@ -2105,6 +2112,7 @@ orgs:
         description: Golang TCP Proxy
         has_projects: true
         has_wiki: false
+        archived: true
       sync-integration-tests:
         has_projects: true
       syslog-adapter-release:

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -106,18 +106,10 @@ areas:
   - name: Shaan Sapra
     github: ssapra
   repositories:
-  - cloudfoundry/cf-mysql-bootstrap
-  - cloudfoundry/cf-mysql-ci
-  - cloudfoundry/cf-mysql-cluster-health-logger
-  - cloudfoundry/cf-mysql-deployment
-  - cloudfoundry/cf-mysql-release
-  - cloudfoundry/galera-healthcheck
-  - cloudfoundry/galera-init
   - cloudfoundry/mysql-backup-release
   - cloudfoundry/mysql-monitoring-release
   - cloudfoundry/postgres-release
   - cloudfoundry/pxc-release
-  - cloudfoundry/switchboard
 - name: System Logging and Metrics (rsyslog / event-log)
   approvers:
   - name: Ben Fuller


### PR DESCRIPTION
cf-mysql-release is no longer maintained and development has shifted to
cloudfoundry/pxc-release.

Co-authored-by: Andrew Garner <garnera@vmware.com>
Co-authored-by: Colin Shield <cshield@vmware.com>