### PR TITLE
Restore bosh-stemcell team to which manages access to stemcell cutting pipeline

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2287,4 +2287,34 @@ orgs:
       yttk8smatchers:
         default_branch: main
         has_projects: true
-    teams: {} # should be empty, rfc-0013-remove-nonstandard-github-teams.md
+    teams:
+      bosh-stemcell:
+        description: "Team used to manage access to bosh.ci.cloudfoundry.org"
+        maintainers:
+        - dsboulder
+        - rkoster
+        - KaiHofstetter
+        - friegger
+        - christopherclark
+        members:
+        - jpalermo
+        - ragaskar
+        - ystros
+        - mvach
+        - selzoc
+        - lnguyen
+        - cunnie
+        - ramonskie
+        - mrosecrance
+        - bgandon
+        - joergdw
+        - danielfor
+        - FlorianNachtigall
+        - klakin-pivotal
+        - nouseforaname
+        - cf-bosh-ci-bot
+        - suraiyasuliman
+        - anshrupani
+        - aramprice
+        privacy: closed
+        repos: []


### PR DESCRIPTION
Discussed during TOC call restore bosh-stemcell team so the extended bosh team can keep cutting stemcells.

A long-term solution might be a ci/viewer role in the working charters.