### PR TITLE
Change my github user id

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -173,7 +173,7 @@ contributors:
 - djac
 - djavos-bot
 - dlresende
-- dmikusa-pivotal
+- dmikusa
 - dmutreja
 - domdom82
 - dominicrobertsc

--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -158,7 +158,7 @@ This working group has no repositories in the `cloudfoundry` GitHub organization
 
 | &nbsp;                                                   | Leads            | Company | Profile                                 |
 | -------------------------------------------------------- | ---------------- | ------- | --------------------------------------- |
-| <img width="30px" src="https://github.com/dmikusa-pivotal.png"> | Daniel Mikusa       | VMware  | [@dmikusa-pivotal](https://github.com/dmikusa-pivotal) |
+| <img width="30px" src="https://github.com/dmikusa.png"> | Daniel Mikusa       | VMware  | [@dmikusa](https://github.com/dmikusa) |
 | <img width="30px" src="https://github.com/ekcasey.png"> | Emily Casey       | VMware  | [@ekcasey](https://github.com/ekcasey) |
 | <img width="30px" src="https://github.com/ryanmoran.png"> | Ryan Moran       | VMware  | [@ryanmoran](https://github.com/ryanmoran) |
 

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -69,7 +69,7 @@ areas:
 - name: Buildpacks
   approvers:
   - name: Daniel Mikusa
-    github: dmikusa-pivotal
+    github: dmikusa
   - name: David O'Sullivan
     github: pivotal-david-osullivan
   - name: Arjun Sreedharan
@@ -211,7 +211,7 @@ areas:
 - name: Java Tools
   approvers:
   - name: Daniel Mikusa
-    github: dmikusa-pivotal
+    github: dmikusa
   - name: David O'Sullivan
     github: pivotal-david-osullivan
   repositories:


### PR DESCRIPTION
Hi, my Github user id has changed. This PR updates my github user id from 'dmikusa-pivotal' to 'dmikusa', which will be my Github id going forward. I have control over the old account, 'dmikusa-pivotal' but am no longer using that.

This is a request to update the records so that my access permissions are set on the correct Github id. Feel free to reach out on Slack if you require confirmation. If there's a different path to request this type of change, please let me know as well. Thanks!

Signed-off-by: Daniel Mikusa <dan@mikusa.com>