### PR TITLE
Update the bosh-stemcell team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2293,7 +2293,6 @@ orgs:
         maintainers:
         - dsboulder
         - rkoster
-        - KaiHofstetter
         - friegger
         - christopherclark
         members:
@@ -2309,12 +2308,14 @@ orgs:
         - bgandon
         - joergdw
         - danielfor
-        - FlorianNachtigall
         - klakin-pivotal
         - nouseforaname
         - cf-bosh-ci-bot
         - suraiyasuliman
         - anshrupani
+        - mvach
+        - max-soe
+        - ShilpaChandrashekara
         - aramprice
         privacy: closed
         repos: []


### PR DESCRIPTION
Remove users not part of the FI WG any more and
add new users needing stemcell cutting access from SAP side