### PR TITLE
Create Stemcell RelEng area to manage ci access

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2295,35 +2295,4 @@ orgs:
       yttk8smatchers:
         default_branch: main
         has_projects: true
-    teams:
-      bosh-stemcell:
-        description: "Team used to manage access to bosh.ci.cloudfoundry.org"
-        maintainers:
-        - dsboulder
-        - rkoster
-        - friegger
-        - christopherclark
-        members:
-        - jpalermo
-        - ragaskar
-        - ystros
-        - mvach
-        - selzoc
-        - lnguyen
-        - cunnie
-        - ramonskie
-        - mrosecrance
-        - bgandon
-        - joergdw
-        - danielfor
-        - klakin-pivotal
-        - nouseforaname
-        - cf-bosh-ci-bot
-        - suraiyasuliman
-        - anshrupani
-        - mvach
-        - max-soe
-        - ShilpaChandrashekara
-        - aramprice
-        privacy: closed
-        repos: {}
+    teams: {}

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -119,6 +119,39 @@ areas:
   - cloudfoundry/system-metrics-release
   - cloudfoundry/syslog-release
   - cloudfoundry/windows-syslog-release
+- name: Stemcell Release Engineering (BOSH)
+  approvers:
+  - name: Joseph Palermo
+    github: jpalermo
+  - name: Rajan Agaskar
+    github: ragaskar
+  - name: Brian Upton
+    github: ystros
+  - name: Matthias Vach
+    github: mvach
+  - name: Long Nguyen
+    github: lnguyen
+  - name: Brian Cunnie
+    github: cunnie
+  - name: Ramon Makkelie
+    github: ramonskie
+  - name: Maya Rosecrance
+    github: mrosecrance
+  - name: Daniel Felipe Ochoa
+    github: danielfor
+  - name: Kenneth Lakin
+    github: klakin-pivotal
+  - name: Konstantin Kiess
+    github: nouseforaname
+  - name: Max Soest
+    github: max-soe
+  - name: Felix Riegger
+    github: friegger
+  - name: Aram Price
+    github: aramprice
+  repositories:
+  - cloudfoundry/bosh-community-stemcell-ci-infra
+  - cloudfoundry/bosh-stemcells-ci
 - name: VM deployment lifecycle (BOSH)
   approvers:
   - name: Joseph Palermo
@@ -188,8 +221,6 @@ areas:
   - cloudfoundry/bosh-psmodules
   - cloudfoundry/bosh-s3cli
   - cloudfoundry/bosh-softlayer-cpi-release
-  - cloudfoundry/bosh-community-stemcell-ci-infra
-  - cloudfoundry/bosh-stemcells-ci
   - cloudfoundry/bosh-utils
   - cloudfoundry/bosh-virtualbox-cpi-release
   - cloudfoundry/bosh-vsphere-cpi-release

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -149,6 +149,12 @@ areas:
     github: friegger
   - name: Aram Price
     github: aramprice
+  - name: Shilpa Chandrashekara
+    github: ShilpaChandrashekara
+  - name: Joerg W
+    github: joergdw
+  - name: Ansh Rupani
+    github: anshrupani
   repositories:
   - cloudfoundry/bosh-community-stemcell-ci-infra
   - cloudfoundry/bosh-stemcells-ci


### PR DESCRIPTION
As discussed during today's TOC meeting split out dedicated area for performing stemcell release engineering (for continuity). 