### PR TITLE
Allow org automation to delete up to 80% of teams

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -63,6 +63,7 @@ jobs:
             --github-endpoint http://ghproxy:8888
             --required-admins=thelinuxfoundation
             --min-admins=5
+            --maximum-removal-delta=0.8
             --github-app-id=${{ secrets.GH_APP_ID }}
             --github-app-private-key-path=private_key
             --require-self=false


### PR DESCRIPTION
https://github.com/cloudfoundry/community/actions/runs/3098873312/jobs/5017315748 failed with:

failed to configure cloudfoundry teams: cannot delete 172 teams or 0.782 of cloudfoundry teams (exceeds limit of 0.250)

This high amount of team deletions is caused by the spicy PR #387 which was merged but not yet successfully applied by peribolos.