### PR TITLE
Fix YAML for the CF-on-K8s WG

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -76,7 +76,6 @@ areas:
   - cloudfoundry/eirini-release
   - cloudfoundry/korifi
   - cloudfoundry/korifi-ci
-areas:
 - name: CF for K8s
   approvers:
   - name: Andrew Wittrock


### PR DESCRIPTION
The YAML fragment had two `areas` keys which meant the second on overrode the first one.