### PR TITLE
remove identity-ci

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1328,10 +1328,6 @@ orgs:
       ibm-websphere-liberty-buildpack:
         description: IBM WebSphere Application Server Liberty Buildpack
         has_projects: true
-      identity-ci:
-        description: where everything else lives
-        has_projects: true
-        private: true
       identity-tools:
         description: 'Cloud Foundry - the open platform as a service project '
         has_projects: true


### PR DESCRIPTION
We moved this repo in the pivotal org here: https://github.com/pivotal/uaa-ci as it is a private repo containing private information.

The whole repo can be deleted.