### PR TITLE
add cf-bosh-ci-bot to bots

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -45,6 +45,8 @@ bots:
   github: cf-gitbot
 - name: runtime-bot
   github: tas-runtime-bot
+- name: cf-bosh-ci-bot
+  github: cf-bosh-ci-bot
 areas:
 - name: Credential Management (Credhub)
   approvers:


### PR DESCRIPTION
Bot used to auto bump bosh agent into stemcell: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/stemcells-ubuntu-bionic/jobs/bump-bosh-agent-master/builds/85
