### PR TITLE
Add `cf-identity` bot to foundational-infrastructure.md

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -45,6 +45,8 @@ bots:
   github: cf-gitbot
 - name: runtime-bot
   github: tas-runtime-bot
+- name: cf-uaa-ci-bot
+  github: cf-identity
 areas:
 - name: Credential Management (Credhub)
   approvers:


### PR DESCRIPTION
- this bot user is used by UAA CI to perform various tasks such as creating GitHub releases, posting CI results to  GitHub PRs, etc.