### PR TITLE
move service metrics release to logging and metrics

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -248,6 +248,7 @@ areas:
   - cloudfoundry/metric-store-release
   - cloudfoundry/metrics-discovery-release
   - cloudfoundry/noaa
+  - cloudfoundry/service-metrics-release
   - cloudfoundry/sonde-go
   - cloudfoundry/statsd-injector-release
   - cloudfoundry/system-metrics-scraper-release
@@ -303,7 +304,6 @@ areas:
   - cloudfoundry/routing-perf-release
   - cloudfoundry/routing-release
   - cloudfoundry/routing-team-checklists
-  - cloudfoundry/service-metrics-release
   - cloudfoundry/silk
   - cloudfoundry/silk-release
 ```


### PR DESCRIPTION
It has to do with getting metrics into loggregator for data services.