### PR TITLE
service-management: add new repository for mysql binding provider

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2145,6 +2145,13 @@ orgs:
         allow_merge_commit: false
         has_issues: false
         has_projects: true
+      terraform-provider-csbmysql:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        description: Terraform provider to manage Cloud Service Broker bindings for MySQL
+        has_projects: true
+        has_wiki: false        
       terraform-provider-csbpg:
         allow_merge_commit: false
         allow_rebase_merge: false

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -59,6 +59,7 @@ areas:
   - cloudfoundry/csb-brokerpak-gcp
   - cloudfoundry/upgrade-all-services-cli-plugin
   - cloudfoundry/terraform-provider-csbpg
+  - cloudfoundry/terraform-provider-csbmysql
 - name: OSB API
   approvers:
   - name: Sam Gunaratne


### PR DESCRIPTION
This is a new repository for a terraform provider that would create bindings to mysql databases and can be reused from multiple projects.