### PR TITLE
move bosh-system-metrics-server-release to the metrics subgroup of infrastructure working group

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -148,6 +148,7 @@ areas:
   - cloudfoundry/system-metrics-release
   - cloudfoundry/syslog-release
   - cloudfoundry/windows-syslog-release
+  - cloudfoundry/bosh-system-metrics-server-release
 - name: Stemcell Release Engineering (BOSH)
   approvers:
   - name: Joseph Palermo
@@ -278,7 +279,6 @@ areas:
   - cloudfoundry/stembuild
   - cloudfoundry/stemcells-alicloud-index
   - cloudfoundry/socks5-proxy
-  - cloudfoundry/bosh-system-metrics-server-release
   - cloudfoundry/tlsconfig
   - cloudfoundry/usn-resource
   - cloudfoundry/windows-utilities-release


### PR DESCRIPTION
bosh system metrics server is metrics related