### PR TITLE
move bosh-system-metrics-server-release to the metrics subgroup of in foundational infrastructure

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -145,6 +145,7 @@ areas:
     github: Benjamintf1
   repositories:
   - cloudfoundry/blackbox
+  - cloudfoundry/bosh-system-metrics-server-release
   - cloudfoundry/system-metrics-release
   - cloudfoundry/syslog-release
   - cloudfoundry/windows-syslog-release
@@ -278,7 +279,6 @@ areas:
   - cloudfoundry/stembuild
   - cloudfoundry/stemcells-alicloud-index
   - cloudfoundry/socks5-proxy
-  - cloudfoundry/bosh-system-metrics-server-release
   - cloudfoundry/tlsconfig
   - cloudfoundry/usn-resource
   - cloudfoundry/windows-utilities-release


### PR DESCRIPTION
bosh system metrics server is metrics related