### PR TITLE
Add bots to manage automation for BBR

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -49,6 +49,8 @@ bots:
   github: cf-identity
 - name: cf-bosh-ci-bot
   github: cf-bosh-ci-bot
+- name: backup-restore-team-bot
+  github: backup-restore-team-bot
 areas:
 - name: Credential Management (Credhub)
   approvers:

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -51,6 +51,8 @@ bots:
   github: cf-bosh-ci-bot
 - name: backup-restore-team-bot
   github: backup-restore-team-bot
+- name: Cryogenics-CI
+  github: Cryogenics-CI
 areas:
 - name: Credential Management (Credhub)
   approvers:


### PR DESCRIPTION
The VMware/Cryogenics team need these bots in order to cut releases.

This means we need to configure the following repos so that both bots can push to main:
  - cloudfoundry/backup-and-restore-sdk-release
  - cloudfoundry/bosh-backup-and-restore
  - cloudfoundry/bosh-backup-and-restore-test-releases
  - cloudfoundry/bosh-disaster-recovery-acceptance-tests
  - cloudfoundry/disaster-recovery-acceptance-tests
  - cloudfoundry/docs-bbr
  - cloudfoundry/exemplar-backup-and-restore-release

