### PR TITLE
[ARI] Add Ryker Reed as CLI approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -190,6 +190,8 @@ areas:
     github: a-b
   - name: Juan Diego González
     github: jdgonzaleza
+  - name: Ryker Reed
+    github: reedr3
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge
@@ -197,8 +199,6 @@ areas:
     github: ccjaimes
   - name: Pete Levine
     github: PeteLevineA
-  - name: Ryker Reed
-    github: reedr3
   - name: Michael Oleske
     github: moleske
   - name: Shwetha Guraraj


### PR DESCRIPTION
I'm an engineer at VMware and have been on the CLI team for 1.5 years. @a-b and @jdgonzaleza are current CLI approvers who can attest to my meeting the criteria laid out in the [roles document](https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#requirements-2) and per the rules on getting [approver role](https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#promotion-to-approver)

cc @Gerg 