### PR TITLE
Remove windows-tools-release from FIWG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -289,7 +289,6 @@ areas:
   - cloudfoundry/usn-resource
   - cloudfoundry/windows-utilities-release
   - cloudfoundry/windows-utilities-tests
-  - cloudfoundry/windows-tools-release
   - cloudfoundry/yagnats
 config:
   github_project_sync:


### PR DESCRIPTION
* Before this PR this repo was in both FI and ARP
* ARP already owns the pipeline and automation around this release
* @rkoster and I agreed [on slack](https://cloudfoundry.slack.com/archives/C026XJGNC2U/p1665412932475289?thread_ts=1665412830.558489&cid=C026XJGNC2U) that ARP should keep it.