### PR TITLE
Move the CF on K8s SIG call to Wednesday

### DIFF
--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -112,7 +112,7 @@ The GitHub repos this WG manages in the `cloudfoundry` GitHub organization are t
 | -------------------------- | ---- |
 | Charter                    | [cf-on-k8s.md](./cf-on-k8s.md)  |
 | Forum                      | [Video chat](https://zoom.us/j/98762513821?pwd=dUk1WGZwcXJqR0UxRXQ4NnljcCtydz09)  |
-| Community Meeting Calendar | Every other Tuesday at 11:30 am ET / 8:30 am PT  |
+| Community Meeting Calendar | Every other Wednesday at 11:30 am ET / 8:30 am PT  |
 | Meeting Notes              | [Google Doc](https://docs.google.com/document/d/1ULNBEjlrNAgn3ko9y8ZJfwI7mw5-oofYdjl-dhkEoDA/edit)  |
 | Slack Channel              | [&#x23;cf-k8s-dev](https://cloudfoundry.slack.com/archives/C0297673ASK) |
 


### PR DESCRIPTION
We'd like to move our SIG call back to every other Wednesday. @christopherclark can you help me make sure that the calendar invite is synced with this PR?