### PR TITLE
Correct the status and start date of RFC 0001

### DIFF
--- a/toc/rfc/rfc-0001-jammy-os.md
+++ b/toc/rfc/rfc-0001-jammy-os.md
@@ -1,9 +1,9 @@
 # Meta
 [meta]: #meta
 - Name: Move to Jammy Jellyfish (22.04) as the next CF Linux Operating System after Bionic.
-- Start Date: (fill in today's date: 2022-01-01)
+- Start Date: 2022-01-22
 - Author(s): @dsboulder @rkoster
-- Status: Draft
+- Status: Accepted
 - RFC Pull Request: https://github.com/cloudfoundry/community/pull/191
 
 ## Summary


### PR DESCRIPTION
When an RFC is merged, it should have its status set to "Accepted". The date should also be set to the date the PR was raised.