### PR TITLE
[ARI] Add Core Deps CI to Buildpacks Area

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -136,6 +136,7 @@ areas:
   - cloudfoundry/public-buildpacks-ci-robots
   - cloudfoundry/stack-auditor
   - cloudfoundry/switchblade
+  - cloudfoundry/core-deps-ci
 
 - name: CAPI
   approvers:


### PR DESCRIPTION
- We missed this repo during the original team allocation
- This repo contains configuration for a Concourse release pipeline