### PR TITLE
Add a docs area to the FI WG and add docs approvers

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -54,6 +54,16 @@ bots:
 - name: Cryogenics-CI
   github: Cryogenics-CI
 areas:
+- name: Docs
+  approvers:
+  - name: Chloe Hollingsworth
+    github: cshollingsworth
+  - name: Max Hufnagel
+    github: animatedmax
+  repositories:
+  - cloudfoundry/docs-bbr
+  - cloudfoundry/docs-credhub
+  - cloudfoundry/docs-uaa
 - name: Credential Management (Credhub)
   approvers:
   - name: Peter Chen
@@ -75,7 +85,6 @@ areas:
   - cloudfoundry/credhub-cli
   - cloudfoundry/credhub-ci-locks
   - cloudfoundry/credhub-perf-release
-  - cloudfoundry/docs-credhub
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)
   approvers:
@@ -91,7 +100,6 @@ areas:
   - cloudfoundry/bosh-backup-and-restore-test-releases
   - cloudfoundry/bosh-disaster-recovery-acceptance-tests
   - cloudfoundry/disaster-recovery-acceptance-tests
-  - cloudfoundry/docs-bbr
   - cloudfoundry/exemplar-backup-and-restore-release
 - name: Identity and Auth (UAA)
   approvers:
@@ -114,7 +122,6 @@ areas:
   - cloudfoundry/cf-identity-acceptance-tests-release
   - cloudfoundry/cf-uaa-lib
   - cloudfoundry/cf-uaac
-  - cloudfoundry/docs-uaa
   - cloudfoundry/identity-tools
   - cloudfoundry/omniauth-uaa-oauth2
   - cloudfoundry/uaa

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -92,7 +92,7 @@ areas:
     github: dlresende
   - name: Fernando Naranjo
     github: fejnartal
-  - name: Gareth Smith 
+  - name: Gareth Smith
     github: totherme
   repositories:
   - cloudfoundry/backup-and-restore-sdk-release
@@ -103,7 +103,7 @@ areas:
   - cloudfoundry/exemplar-backup-and-restore-release
 - name: Identity and Auth (UAA)
   approvers:
-  - name: Peter Chen 
+  - name: Peter Chen
     github: peterhaochen47
   - name: Bruce Ricard
     github: bruce-ricard
@@ -132,7 +132,7 @@ areas:
   - cloudfoundry/uaa-singular
 - name: Integrated Databases (Mysql / Postgres)
   approvers:
-  - name: Andrew Garner 
+  - name: Andrew Garner
     github: abg
   - name: Colin Shield
     github: colins
@@ -207,7 +207,7 @@ areas:
     github: lnguyen
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Benjamin Gandon 
+  - name: Benjamin Gandon
     github: bgandon
   - name: Brian Cunnie
     github: cunnie


### PR DESCRIPTION
## Problem
Technical writers need to be approvers to do their jobs. These three docs repos (docs-bbr, docs-credhub, and docs-uaa) are part of the documentation @cshollingsworth and @animatedmax maintain for Cloud Foundry.

## Solution
This fix adds a docs area to the Foundational Infrastructure WG. This fix follows the prior art set by the other working groups with docs repos[1] for how to give technical writers access.

[1] App Runtime Interfaces and App Runtime Platform

## Approvers
There is very little activity on these repos. Because of their low volume I do not think the approvers for them can be held to standard as other areas; if we did it would take years before anyone could become an approver. Below I break down how these docs writers have done the majority of work in these repos and why they should be approvers.

**[Docs-UAA](https://github.com/cloudfoundry/docs-uaa)**
* Since Jan 2021 there have been 12 commits
* 7/12 (58%) by @cshollingsworth
* 3/12 (25%) by @animatedmax

**[Docs-Credhub](https://github.com/cloudfoundry/docs-credhub/commits/master)**
* Since Jan 2020 there have been 19 commits
* 2/19 (10%) by @animatedmax

Additionally, both of these approvers have long tenure as CF docs writers, @cshollingsworth for 5 years and @animatedmax for 8 years.

