### PR TITLE
Add Networking CI Bot to ARP bots list

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -49,6 +49,8 @@ bots:
   github: cf-diego
 - name: Garden Bot
   github: garden-gnome
+- name: Networking CI Bot
+  github: CFN-CI
 areas:
 - name: Diego
   approvers:


### PR DESCRIPTION
Required to run CI for
- [haproxy-boshrelease](https://github.com/cloudfoundry/haproxy-boshrelease)
- [pcap-release](https://github.com/cloudfoundry/pcap-release)

[CFN-CI](https://github.com/cfn-ci) account is managed by SAP CF Routing & Networking team.