### PR TITLE
[ARP] Create separate area for SAP CFN managed repos

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -296,12 +296,10 @@ areas:
   - cloudfoundry/cf-tcp-router
   - cloudfoundry/envoy-nginx-release
   - cloudfoundry/gorouter
-  - cloudfoundry/haproxy-boshrelease
   - cloudfoundry/logging-route-service
   - cloudfoundry/multierror
   - cloudfoundry/nats-release
   - cloudfoundry/networking-oss-deployments
-  - cloudfoundry/pcap-release
   - cloudfoundry/policy_client
   - cloudfoundry/route-registrar
   - cloudfoundry/routing-acceptance-tests
@@ -313,4 +311,21 @@ areas:
   - cloudfoundry/routing-team-checklists
   - cloudfoundry/silk
   - cloudfoundry/silk-release
+
+- name: Networking-Extensions
+  approvers:
+  - name: Alexander Lais
+    github: peanball
+  - name: Dominik Froehlich
+    github: domdom82
+  - name: Maximilian Moehl
+    github: maxmoehl
+  - name: Patrick Lowin
+    github: plowin
+  - name: Tamara Boehm
+    github: b1tamara
+  repositories:
+  - cloudfoundry/haproxy-boshrelease
+  - cloudfoundry/pcap-release
+
 ```


### PR DESCRIPTION
The Bosh releases [haproxy-boshrelease](https://github.com/cloudfoundry/haproxy-boshrelease) and [pcap-release](https://github.com/cloudfoundry/pcap-release) are managed by the SAP BTP CF Routing & Networking team.
As discussed with @plowin and @ameowlia, this PR moves these repos into a separate area (`Networking-Extensions`) of the Application Runtime Platform WG.
This is needed for reviews and CI purposes (`run-ci` label needed for PR validation through [concourse.cfi.sapcloud.io](https://concourse.cfi.sapcloud.io)).

This PR also adds the following approvers to the new `Networking-Extensions` area:

Approvers for the new area that are already approvers for Networking area:
- Dominik Froehlich ([domdom82](https://github.com/domdom82))
- Patrick Lowin ([plowin](https://github.com/plowin))

New approvers:
- Alexander Lais ([peanball](https://github.com/peanball)) ([Activity](https://github.com/search?l=&p=1&q=user%3Acloudfoundry+author%3Apeanball&ref=advsearch&type=Issues))
- Maximilian Moehl ([maxmoehl](https://github.com/maxmoehl)) ([Activity](https://github.com/search?l=&p=1&q=user%3Acloudfoundry+author%3Amaxmoehl&ref=advsearch&type=Issues))
- Tamara Boehm ([b1tamara](https://github.com/b1tamara)) ([Activity](https://github.com/search?l=&p=1&q=user%3Acloudfoundry+author%3Ab1tamara&ref=advsearch&type=Issues))

The new approvers all have done essential work in the community for more than a year (see "Activity") and a lot more invisible conceptual work in the background.
