### PR TITLE
Remove @mnitchev

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -394,7 +394,6 @@ contributors:
 - mkocher
 - mkuratczyk
 - MMisoch
-- mnitchev
 - MoatazBM
 - modelseer
 - moggibear

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -150,8 +150,6 @@ areas:
     github: georgethebeatle
   - name: Kieron Browne
     github: kieron-dev
-  - name: Mario Nitchev
-    github: mnitchev
   - name: Amin Jamali
     github: aminjam
   - name: Geoff Franks

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -65,8 +65,6 @@ areas:
     github: kieron-dev
   - name: Matt Royal
     github: matt-royal
-  - name: Mario Nitchev
-    github: mnitchev
   - name: Tim Downey
     github: tcdowney
   repositories:


### PR DESCRIPTION
Mario Nitchev (@mnitchev) doesn't work on CF anymore, so after discussing this with him, I'm revoking all his roles.

@ameowlia this includes the approver role on Garden containers.
