### PR TITLE
Add `app-runtime-interfaces-infrastructure` repo for WG ARI

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -51,6 +51,10 @@ orgs:
         archived: true
         description: A UI project for the Cloud Foundry incubator app-autoscaler
         has_projects: true
+      app-runtime-interfaces-infrastructure:
+        description: Infrastructure as Code for the App Runtime Interfaces Working Group
+        has_projects: true
+        default_branch: main
       apt-buildpack:
         has_projects: false
         has_wiki: false

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -65,6 +65,7 @@ areas:
   - cloudfoundry/app-autoscaler-release
   - cloudfoundry/app-autoscaler-cli-plugin
   - cloudfoundry/app-autoscaler-env-bbl-state
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Buildpacks
   approvers:
@@ -137,6 +138,7 @@ areas:
   - cloudfoundry/stack-auditor
   - cloudfoundry/switchblade
   - cloudfoundry/core-deps-ci
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: CAPI
   approvers:
@@ -184,6 +186,7 @@ areas:
   - cloudfoundry/delayed_job_sequel
   - cloudfoundry/steno
   - cloudfoundry/runtimeschema
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: CLI
   approvers:
@@ -216,7 +219,8 @@ areas:
   - cloudfoundry/cli-pools
   - cloudfoundry/jsonry
   - cloudfoundry/ykk
-  
+  - cloudfoundry/app-runtime-interfaces-infrastructure
+
 - name: Docs
   approvers:
   - name: Melinda Jeffs Gutermuth
@@ -229,6 +233,7 @@ areas:
   - cloudfoundry/docs-dev-guide
   - cloudfoundry/docs-services
   - cloudfoundry/docs-dotnet-core-tutorial
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Java Tools
   approvers:
@@ -238,6 +243,7 @@ areas:
     github: pivotal-david-osullivan
   repositories:
   - cloudfoundry/cf-java-client
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: MultiApps
   approvers:
@@ -265,6 +271,7 @@ areas:
   - cloudfoundry/multiapps-controller
   - cloudfoundry/multiapps-cli-plugin
   - cloudfoundry/multiapps
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Notifications
   approvers:
@@ -279,5 +286,6 @@ areas:
   repositories:
   - cloudfoundry/notifications-release
   - cloudfoundry/notifications
+  - cloudfoundry/app-runtime-interfaces-infrastructure
 
 ```


### PR DESCRIPTION
As discussed with @gerg in the [ARI WG Slack] and the TOC in [#toc][toc].

[ARI WG Slack]: https://cloudfoundry.slack.com/archives/C02LR0XCV3M/p1666778886980639
[toc]: https://cloudfoundry.slack.com/archives/C026XJGNC2U/p1666785443423639