### PR TITLE
Add a reference to Eric's talk from CF Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ governing all participation in the Cloud Foundry community
 
 # Technical Community Governance
 
-Changes to these documents require a vote (or consensus) of the Technical Oversight Committee (TOC). 
+Changes to these documents require a vote (or consensus) of the Technical Oversight Committee (TOC).
 
 * [Principles](toc/PRINCIPLES.md) - (Status: INFORMATIONAL) - Core principles that inform the technical 
 governance of the Cloud Foundry community

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ governing all participation in the Cloud Foundry community
 
 # Technical Community Governance
 
-Changes to these documents require a vote (or consensus) of the Technical Oversight Committee (TOC).
+Changes to these documents require a vote (or consensus) of the Technical Oversight Committee (TOC). 
 
 * [Principles](toc/PRINCIPLES.md) - (Status: INFORMATIONAL) - Core principles that inform the technical 
 governance of the Cloud Foundry community
@@ -33,6 +33,8 @@ process
 thinking behind how the TOC should structure the work of the technical community.
 
 * [Change Plan](toc/CHANGEPLAN.md) - (Status: WORK IN PROGRESS) - Plan for how to get from the community's current policies and practices to a new desired state
+
+The evolution of the Cloud Foundry Technical Community Governance is explained in this [talk](https://youtu.be/OBKsdVpFfyQ).
 
 ## Working Groups
 


### PR DESCRIPTION
Eric gave a nice overview of the Technical Community Governance at the Cloud Foundry Day 2022 in Detroit. I think that we should have a reference to it on the community repo. I'm not sure which page fits best. This is my proposal.