### PR TITLE
Add a bot to show CF org members and teams in Backstage

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -584,6 +584,7 @@ contributors:
 - tanayk2610
 - tanglisha
 - tanzeeb
+- tanzu-backstage-bot
 - Tallicia
 - tarpinian
 - tas-runtime-bot


### PR DESCRIPTION
Tanzu folks are experimenting with a backstage instances to keep track of codebases and who owns them. Could we add this bot as an org member? That will let us pull org membership info into backstage and try out cataloging a handful of CF codebases. If this starts to look good, and lots of CF codebases are cataloged, we can provide a community backstage instance. 

Here's an example of catalog metadata associated with a codebase: https://github.com/cloudfoundry/notifications/blob/master/catalog/catalog-info.yaml