### PR TITLE
Remove Melinda as a docs approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -225,8 +225,6 @@ areas:
 
 - name: Docs
   approvers:
-  - name: Melinda Jeffs Gutermuth
-    github: mjgutermuth
   - name: Chloe Hollingsworth
     github: cshollingsworth
   - name: Anita Flegg


### PR DESCRIPTION
Removes @mjgutermuth as a listed approver for docs repos - I approached her a couple of months ago looking for her to review a PR, and she said she was no longer an approver.