### PR TITLE
Added a script to find orphaned repos

### DIFF
--- a/org/orphaned_repos.sh
+++ b/org/orphaned_repos.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+comm -3 <(cat org/cloudfoundry.yml | spruce json \
+           | jq -r '.orgs.cloudfoundry.repos | with_entries(select(.value.archived != true)) | keys | map("cloudfoundry/\(.)") | sort | unique | .[]') \
+     <(./toc/working-groups/parsable-working-groups.sh \
+           | jq -s -r 'map(map(.areas[].repositories)) | flatten | map(select(contains("cloudfoundry"))) | sort | unique | .[]')


### PR DESCRIPTION
Non-archived repos which do not belong to a working group. Also repos that are defined in a working group but do not exist in org/cloudfoundry.yml

Output:
```
	cloudfoundry-incubator/credhub-api-docs
cloudfoundry/.github
cloudfoundry/CLAW
cloudfoundry/admin-tools
cloudfoundry/api-docs
cloudfoundry/benchmarklocket
cloudfoundry/bits-service-private-config
cloudfoundry/bosh-azure-cpi-ci
cloudfoundry/bosh-compile-action
cloudfoundry/bosh-openstack-cpi-ci
cloudfoundry/bosh-openstack-cpi-shared
cloudfoundry/bosh_rackspace_cpi_spike
cloudfoundry/capi-datadog
cloudfoundry/capi-team-checklists
cloudfoundry/certauthority
cloudfoundry/cf-for-k8s-metric-examples
cloudfoundry/cf-k8s-logging-fluent
cloudfoundry/cf-k8s-networking-scaling
cloudfoundry/cf-k8s-prometheus
cloudfoundry/cf-lite-ci
cloudfoundry/cf-on-k8s-integration
cloudfoundry/cf-slackin
cloudfoundry/cf-volume-services-team
cloudfoundry/cfcd-broker
cloudfoundry/cfcd-cert-items
cloudfoundry/cfcd-ci
cloudfoundry/cfcd-course-content
cloudfoundry/cfcd-dockerfile
cloudfoundry/cfcd-exam-info
cloudfoundry/cfcd-facts
cloudfoundry/cfcd-items
cloudfoundry/cfcd-mappings
cloudfoundry/cfcd-mindmaps
cloudfoundry/cfcd-parser
cloudfoundry/cfcd-prep
cloudfoundry/cff-platform-certification
	cloudfoundry/claw
cloudfoundry/cloudfoundry.github.com
	cloudfoundry/concourse-flake-hunter
cloudfoundry/dev-cert
cloudfoundry/dev-cert-grading
cloudfoundry/developer-training-class-apps
cloudfoundry/developer-training-class-site
cloudfoundry/developer-training-course
cloudfoundry/developer-training-hugo-parser
	cloudfoundry/diego-upgrade-stability-tests
cloudfoundry/docs-deploying-cf
cloudfoundry/flintstone
cloudfoundry/fluent-plugin-syslog_rfc5424
cloudfoundry/foundation
cloudfoundry/garden-dotfiles-archived
cloudfoundry/go-fetcher
cloudfoundry/go-git-resource
	cloudfoundry/gofileutils
cloudfoundry/grootfs-ci-secrets
cloudfoundry/homebrew-tap
cloudfoundry/identity-ci
cloudfoundry/infrastructure-ci-bbl-states
cloudfoundry/infrastructure-ci-deployment-locks
cloudfoundry/istio-scriptio
cloudfoundry/java-buildpack-container-certificate-trust-store
cloudfoundry/korifi-website
cloudfoundry/lamb-ci-tools
cloudfoundry/lds
cloudfoundry/lf-elearning
cloudfoundry/log-cache-deployments
cloudfoundry/log-stream-cli
cloudfoundry/logging-deployment
cloudfoundry/loggregator-ci-old
cloudfoundry/loggregator-credentials
cloudfoundry/loggregator-rampup
cloudfoundry/logos
cloudfoundry/metric-store-deployments
cloudfoundry/metric-store-rampup
cloudfoundry/minimal-env
cloudfoundry/networking-program-checklists
cloudfoundry/nicky
cloudfoundry/open-source-licenses
cloudfoundry/oss-s3-buckets-stack
cloudfoundry/oss-summit-class
cloudfoundry/overview-broker
cloudfoundry/persistence-load-tests
cloudfoundry/platform-certification
cloudfoundry/postgres-ci-env
cloudfoundry/quarks-private
cloudfoundry/relogger
cloudfoundry/routing-datadog-config
cloudfoundry/runtime-og-ci-private
cloudfoundry/runtime-team-checklists
cloudfoundry/runtime1-env
cloudfoundry/sample-service-metrics-release
cloudfoundry/sapi-env-pool
cloudfoundry/security-notices
cloudfoundry/slack-interrupt-bot
cloudfoundry/stratos
cloudfoundry/stratos-buildpack
cloudfoundry/summit-hands-on-labs
cloudfoundry/summit-training-classes
cloudfoundry/syslog-adapter-release
cloudfoundry/training-cert-admin
cloudfoundry/uaa-developer-training
cloudfoundry/uaa-hey
cloudfoundry/uaa-performance-release
cloudfoundry/uaa-singular-example
cloudfoundry/uaa-workstation

```