### PR TITLE
Remove @gnovv

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -241,7 +241,6 @@ contributors:
 - gggevorgyan
 - git-narya
 - gmrodgers
-- gnovv
 - gossion
 - GowriRegistry
 - graeme-davison

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -57,8 +57,6 @@ areas:
     github: danail-branekov
   - name: Dave Walter
     github: davewalter
-  - name: Akira Wong
-    github: gnovv
   - name: Julian Hjortshoj
     github: julian-hj
   - name: Kieron Browne


### PR DESCRIPTION
Akira Wong (@gnovv) doesn't work on CF anymore, so I'm revoking all his roles. I couldn't get in touch with him to discuss this, but he has two weeks to refute this decision, as per the [Technical Community Governance](https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#promotion-and-revocation).
