### PR TITLE
Modify approvers for integrated-databases

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -144,9 +144,9 @@ areas:
     github: ohkyle
   - name: Kim Basset
     github: kimago
-  reviewers:
   - name: Ryan Wittrup
     github: ryanwittrup
+  reviewers:
   - name: Kevin Markwardt
     github: kmarkwardt-vmware
   repositories:


### PR DESCRIPTION
Update Ryan from reviewer to approver

Based on meeting requirements as defined in https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0006-approver-requirements.md

Reference previous PR, https://github.com/cloudfoundry/community/pull/426

PR's increased to meet threshold of 20
PXC - 11
MySQL Backup - 9
Backup and Restore SDK - 1

Total = 21


Approvers:
name: Ryan Wittrup
github: ryanwittrup
21 commits