### PR TITLE
Support renaming the  diego-ci-pools + healthchecker repos

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -95,7 +95,7 @@ areas:
   - cloudfoundry/diego-acceptance
   - cloudfoundry/diego-checkman
   - cloudfoundry/diego-ci
-  - cloudfoundry/diego-ci-pools
+  - cloudfoundry/runtime-ci-pools
   - cloudfoundry/diego-design-notes
   - cloudfoundry/diego-dockerfiles
   - cloudfoundry/diego-logging-client
@@ -317,7 +317,7 @@ areas:
   - cloudfoundry/cf-tcp-router
   - cloudfoundry/envoy-nginx-release
   - cloudfoundry/gorouter
-  - cloudfoundry/healthchecker
+  - cloudfoundry/healthchecker-release
   - cloudfoundry/logging-route-service
   - cloudfoundry/multierror
   - cloudfoundry/nats-release


### PR DESCRIPTION
diego-ci-pools -> runtime-ci-pools (now used also by garden)
healthchecker -> healthchecker-release (changing from go package to bosh vendorable package)