### PR TITLE
add Samia Nneji to docs teams across WGs

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -236,6 +236,8 @@ areas:
     github: cshollingsworth
   - name: Anita Flegg
     github: anita-flegg
+  - name: Samia Nneji
+    github: snneji
   repositories:
   - cloudfoundry/docs-buildpacks
   - cloudfoundry/docs-cf-cli

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -141,6 +141,8 @@ areas:
     github: cshollingsworth
   - name: Anita Flegg
     github: anita-flegg
+  - name: Samia Nneji
+    github: snneji
   repositories:
   - cloudfoundry/docs-book-cloudfoundry
   - cloudfoundry/docs-cf-admin

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -62,6 +62,8 @@ areas:
     github: animatedmax
   - name: Anita Flegg
     github: anita-flegg
+  - name: Samia Nneji
+    github: snneji
   repositories:
   - cloudfoundry/docs-bbr
   - cloudfoundry/docs-credhub


### PR DESCRIPTION
Samia Nneji is a VMware docs writer. I am very excited to see our docs teams growing. 

Given that this is adding her to 3 different WGs it will require approval from a lead from each group.
* App Runtime Platform - that's me! I approve!
* App Runtime Interfaces - @Gerg 
* Foundational Infrastructure - @rkoster and @beyhan 