### PR TITLE
Add Sophie Wigmore to Buildpacks approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -84,6 +84,8 @@ areas:
     github: brayanhenao
   - name: Ryan Moran
     github: ryanmoran
+  - name: Sophie Wigmore
+    github: sophiewigmore
   repositories:
   - cloudfoundry/cflinuxfs3
   - cloudfoundry/cflinuxfs4


### PR DESCRIPTION
Hi y'all!
I have been a contributor to CF Buildpacks for many years now, starting in 2019 with a few contributions to the CF Windows ecosystem, and more recently contributions to the buildpacks ecosystem starting in 2020, 2021, and I am getting involved again now. My contributions can be found on my Github page: https://github.com/sophiewigmore?tab=overview&from=2021-12-01&to=2021-12-31&org=cloudfoundry

Additionally, the current approvers @ryanmoran, @arjun024, and @brayanhenao can all confirm that I meet that qualifications for approval.

cc/ @Gerg for approval