### PR TITLE
service-management: Add jdbctestapp repository

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1418,6 +1418,13 @@ orgs:
       jdbc-cnb:
         archived: true
         has_projects: true
+      jdbctestapp:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        default_branch: main
+        description: A Spring Boot app for testing JDBC connectivity in general and TLS in particular
+        has_projects: true
+        has_wiki: false
       jmx-cnb:
         archived: true
         has_projects: true

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -53,6 +53,7 @@ areas:
   - cloudfoundry/csb-brokerpak-azure
   - cloudfoundry/csb-brokerpak-aws
   - cloudfoundry/csb-brokerpak-gcp
+  - cloudfoundry/jdbctestapp
   - cloudfoundry/upgrade-all-services-cli-plugin
   - cloudfoundry/terraform-provider-csbpg
   - cloudfoundry/terraform-provider-csbmysql


### PR DESCRIPTION
This is a new repository for a Spring Boot application to test JDBC connectivity on Cloud Foundry via the Java buildpack, additionally reporting on the TLS information of the database connection.