### PR TITLE
add HenryBorys to contributors.yml

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -652,3 +652,4 @@ contributors:
 - zucchinidev
 - zyjiaobj
 - zzori-theoriginal
+- HenryBorys


### PR DESCRIPTION
@emalm suggested I do this, as I need to join the Cloudfoundry org to get access to a number of repos for migrating TAS documentation to doc.VMware.