### PR TITLE
Prepare the rename of 'bosh-community-stemcell-ci-infra' to 'concours…

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -787,6 +787,10 @@ orgs:
         description: Example BOSH release for config server
         has_projects: true
         homepage: https://github.com/cloudfoundry/config-server
+      concourse-infra-for-gke:
+        description: This repo holds the deployment templates used to deploy a CF community Concourse instance and supporting infra structure
+        default_branch: main
+        has_projects: true
       consuladapter:
         allow_merge_commit: false
         description: Consul client adapter and test cluster runner


### PR DESCRIPTION
…e-infra-for-gke'

As discussed in [this
issue](https://github.com/cloudfoundry/bosh-community-stemcell-ci-infra/issues/62) we want to rename the 'bosh-community-stemcell-ci-infra' because it is no more only used in the FI WG.