### PR TITLE
Promote Joseph Palermo to Tech Lead in the FI working group

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -211,8 +211,6 @@ areas:
   - cloudfoundry/bosh-stemcells-ci
 - name: VM deployment lifecycle (BOSH)
   approvers:
-  - name: Joseph Palermo
-    github: jpalermo
   - name: Long Nguyen
     github: lnguyen
   - name: Ramon Makkelie

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -38,6 +38,8 @@ technical_leads:
   github: rkoster
 - name: Beyhan Veli
   github: beyhan
+- name: Joseph Palermo
+  github: jpalermo
 bots:
 - name: bosh-admin-bot
   github: bosh-admin-bot
@@ -174,8 +176,6 @@ areas:
   - cloudfoundry/windows-syslog-release
 - name: Stemcell Release Engineering (BOSH)
   approvers:
-  - name: Joseph Palermo
-    github: jpalermo
   - name: Rajan Agaskar
     github: ragaskar
   - name: Brian Upton


### PR DESCRIPTION
Through this PR I would like to promote @jpalermo to Tech Lead in the Foundation Infrastructure working group.
The screenshot below proves Joseph has been involved in the [required number of reviews](https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#working-group-technical-lead).
<img width="1326" alt="Screenshot 2023-01-26 at 14 52 37" src="https://user-images.githubusercontent.com/380697/214852941-3d047104-4bec-41e4-9603-3392a7ff7ce9.png">
[source](https://insights.lfx.linuxfoundation.org)

Joseph has been active in the Cloud Foundry github org for [10 years now](https://github.com/jpalermo?tab=overview&from=2013-12-01&to=2013-12-31&org=cloudfoundry), and made his [first contribution to bosh in 2014](https://github.com/cloudfoundry/bosh/commit/fa7edcf46f385cbf0debae34310d842f05a6ce0d).

cc @beyhan 