### PR TITLE
Add bosh-azure-storage-cli project

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -167,6 +167,10 @@ orgs:
         description: BOSH Azure CPI
         has_projects: true
         has_wiki: false
+      bosh-azure-storage-cli:
+        description: Go CLI for Azure storage
+        has_projects: true
+        default_branch: main
       bosh-backup-and-restore:
         has_projects: true
         homepage: https://docs.cloudfoundry.org/bbr

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -263,6 +263,7 @@ areas:
   - cloudfoundry/bosh-aws-cpi-release
   - cloudfoundry/bosh-aws-light-stemcell-builder
   - cloudfoundry/bosh-azure-cpi-release
+  - cloudfoundry/bosh-azure-storage-cli
   - cloudfoundry/bosh-bbl-ci-envs
   - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-cli


### PR DESCRIPTION
- This project allows BOSH to use Azure blobstores. Same as bosh-s3cli allows BOSH to use AWS blobstores.