### PR TITLE
Add Chris Selzo to BOSH areas

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -206,6 +206,8 @@ areas:
     github: joergdw
   - name: Ansh Rupani
     github: anshrupani
+  - name: Chris Selzo
+    github: selzoc
   repositories:
   - cloudfoundry/concourse-infra-for-gke
   - cloudfoundry/bosh-stemcells-ci
@@ -231,6 +233,8 @@ areas:
     github: danielfor
   - name: Brian Upton
     github: ystros
+  - name: Chris Selzo
+    github: selzoc
   reviewers:
   - name: Matthias Vach
     github: mvach


### PR DESCRIPTION
Hi Friends!

I am a long-time (since 2017) contributor to CF.
I have contributed to many areas of CF over the years, most notably Release Integration, CAPI, VAT, BOSH, and most of the App Runtime Platform WG areas.
I would like to request to be made an approver for the Stemcell Release Engineering (BOSH) and VM deployment lifecycle (BOSH) area of the Foundational Infrastructure WG.
I was on parental leave when the old groups were deleted, and therefore lost access to the BOSH repos I had been working in.
I joined the BOSH team in October of 2021, and then I spent most of 2022 in the App Runtime WG space, but have returned to the BOSH team.

Thanks,
Chris