### PR TITLE
Remove greenhouse-ci/garden-gnome users as CF org members

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -226,7 +226,6 @@ contributors:
 - gab-satchi
 - galenhammond
 - gaowa0215
-- garden-gnome
 - GarfieldLinux
 - GarimaSharma
 - garrying
@@ -245,7 +244,6 @@ contributors:
 - GowriRegistry
 - graeme-davison
 - grahamlutz
-- greenhouse-ci
 - gsiener
 - gu-bin
 - gururajsh


### PR DESCRIPTION
We removed these manually from the cloudfoundry org. Some automation tried to re-add them though. Hopefully this is the right thing to do to prevent them from getting invited back in again 🤞