### PR TITLE
Archive repos related to CF for K8s

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -426,6 +426,7 @@ orgs:
         default_branch: main
         has_projects: true
       capi-k8s-release:
+        archived: true
         default_branch: main
         description: The CF API parts of cloudfoundry/cf-for-k8s
         has_projects: true
@@ -486,13 +487,16 @@ orgs:
         description: CF CLI plugin to create syslog drains
         has_projects: true
       cf-for-k8s:
+        archived: true
         default_branch: develop
         description: The open source deployment manifest for Cloud Foundry on Kubernetes
         has_projects: true
       cf-for-k8s-docs:
+        archived: true
         default_branch: main
         has_projects: true
       cf-for-k8s-metric-examples:
+        archived: true
         has_projects: true
       cf-identity-acceptance-tests-release:
         has_projects: true
@@ -506,19 +510,24 @@ orgs:
         default_branch: main
         has_projects: true
       cf-k8s-logging:
+        archived: true
         default_branch: main
         has_projects: true
       cf-k8s-logging-fluent:
+        archived: true
         default_branch: main
         has_projects: true
       cf-k8s-networking:
+        archived: true
         default_branch: develop
         description: building a cloud foundry without gorouter....
         has_projects: false
         has_wiki: false
       cf-k8s-networking-scaling:
+        archived: true
         has_projects: true
       cf-k8s-prometheus:
+        archived: true
         default_branch: main
         has_projects: true
       cf-k8s-secrets:
@@ -575,6 +584,7 @@ orgs:
         has_projects: true
         has_wiki: false
       cf-on-k8s-integration:
+        archived: true
         default_branch: main
         has_projects: true
       cf-performance-tests:
@@ -1619,6 +1629,7 @@ orgs:
         has_projects: true
         has_wiki: false
       metric-proxy:
+        archived: true
         default_branch: main
         description: Translates Kubelet metrics into the log-cache API
         has_projects: true
@@ -2223,6 +2234,7 @@ orgs:
         has_projects: true
         private: true
       uaa-k8s-release:
+        archived: true
         default_branch: main
         has_projects: true
       uaa-key-rotator:

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -17,7 +17,7 @@ Provides APIs for the CF App Runtime and community clients for end users.
 
 - Provide the community with regular releases of the CF API, clients and higher-level CF API related services.
 - Maintain public roadmaps for the CF API and the CF cli. Ensure a wise balance between stable APIs and clients, feature enhancements and deprecations.
-- Provide a CF API suitable for the different CF deployment scenarios: from small to very large foundations, VM- and k8s-based, support for major IaaS providers.
+- Provide a CF API suitable for the different CF deployment scenarios: from small to very large foundations, VM-based, support for major IaaS providers.
 - Provide the community with pipelines and test suites to validate functionality, compatibility and performance of the CF API.
 - Provide the community with technical API documentation, end user documentation and operator documentation.
 - Collaborate with the other Working Groups and evolve the cf-push experience.
@@ -182,7 +182,6 @@ areas:
   - cloudfoundry/capi-release
   - cloudfoundry/capi-dockerfiles
   - cloudfoundry/capi-bara-tests
-  - cloudfoundry/capi-k8s-release
   - cloudfoundry/capi-ci
   - cloudfoundry/capi-ci-private
   - cloudfoundry/capi-env-pool

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -74,19 +74,5 @@ areas:
   - cloudfoundry/eirini-release
   - cloudfoundry/korifi
   - cloudfoundry/korifi-ci
-- name: CF for K8s
-  approvers:
-  - name: Andrew Wittrock
-    github: Birdrock
-  - name: Dave Walter
-    github: davewalter
-  repositories:
-  - cloudfoundry/capi-k8s-release
-  - cloudfoundry/cf-for-k8s
-  - cloudfoundry/cf-for-k8s-docs
-  - cloudfoundry/cf-k8s-logging
-  - cloudfoundry/cf-k8s-networking
-  - cloudfoundry/metric-proxy
-  - cloudfoundry/uaa-k8s-release
   - cloudfoundry/yttk8smatchers
 ```

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -138,7 +138,6 @@ areas:
   - cloudfoundry/omniauth-uaa-oauth2
   - cloudfoundry/uaa
   - cloudfoundry/uaa-cli
-  - cloudfoundry/uaa-k8s-release
   - cloudfoundry/uaa-key-rotator
   - cloudfoundry/uaa-release
   - cloudfoundry/uaa-singular


### PR DESCRIPTION
CF for K8s was marked as deprecated since August 2022. This PR updates the CF org manifest to archive all GitHub repositories related to cf-for-k8s.

It also updates the App Runtime Interfaces WG charter to remove reference to a Kubernetes version of the CF API.

Co-authored-by: Andrew Costa <ancosta@vmware.com>