### PR TITLE
Add bobbygeeze as doc approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -245,6 +245,8 @@ areas:
     github: fifthposition
   - name: Ajayan Borys
     github: HenryBorys
+  - name: Bob Graczyk
+    github: bobbygeeze
   repositories:
   - cloudfoundry/docs-buildpacks
   - cloudfoundry/docs-cf-cli

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -143,6 +143,8 @@ areas:
     github: fifthposition
   - name: Ajayan Borys
     github: HenryBorys
+  - name: Bob Graczyk
+    github: bobbygeeze
   repositories:
   - cloudfoundry/docs-book-cloudfoundry
   - cloudfoundry/docs-cf-admin

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -70,6 +70,8 @@ areas:
     github: fifthposition
   - name: Ajayan Borys
     github: HenryBorys
+  - name: Bob Graczyk
+    github: bobbygeeze
   repositories:
   - cloudfoundry/docs-bbr
   - cloudfoundry/docs-credhub


### PR DESCRIPTION
I am a new docs writer from VMware and am requesting to become an approver for all docs areas.

This affects 3 working groups and requires approval from the tech leads in each working group:
* App Runtime Platform - @ameowlia
* App Runtime Interfaces - @gerg
* Foundational Infrastructure - @beyhan and/or @rkoster