### PR TITLE
Added bbr-ci bot and homebrew-tap repo to BBR

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -55,6 +55,8 @@ bots:
   github: backup-restore-team-bot
 - name: Cryogenics-CI
   github: Cryogenics-CI
+- name: bbr-ci
+  github: bbr-ci
 areas:
 - name: Docs
   approvers:
@@ -113,6 +115,7 @@ areas:
   - cloudfoundry/bosh-disaster-recovery-acceptance-tests
   - cloudfoundry/disaster-recovery-acceptance-tests
   - cloudfoundry/exemplar-backup-and-restore-release
+  - cloudfoundry/homebrew-tap
 - name: Identity and Auth (UAA)
   approvers:
   - name: Peter Chen


### PR DESCRIPTION
bbr-ci is a bot account currently in use
cloudfoundry/homebrew-tap is a repo used by BBR pipelines