### PR TITLE
Enable branch protection for ARD

### DIFF
--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -83,4 +83,6 @@ areas:
   - cloudfoundry/relint-team
   - cloudfoundry/runtime-ci
   - cloudfoundry/uptimer
+config:
+  generate_rfc0015_branch_protection_rules: true
 ```


### PR DESCRIPTION
Enables branch protection rule generation as specified in [rfc-0015-branch-protection](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0015-branch-protection.md).