### PR TITLE
Move stack-auditor to CLI team

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -147,7 +147,6 @@ areas:
   - cloudfoundry/libbuildpack
   - cloudfoundry/pip-pop
   - cloudfoundry/public-buildpacks-ci-robots
-  - cloudfoundry/stack-auditor
   - cloudfoundry/switchblade
   - cloudfoundry/core-deps-ci
   - cloudfoundry/app-runtime-interfaces-infrastructure
@@ -232,6 +231,7 @@ areas:
   - cloudfoundry/cli-pools
   - cloudfoundry/jsonry
   - cloudfoundry/ykk
+  - cloudfoundry/stack-auditor
   - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Docs


### PR DESCRIPTION
The Buildpacks team does not feel that it can successfully maintain the the `stack-auditor` project. It was a repository that was historically owned by this team, but should probably be maintained elsewhere. I've suggested a move to the CLI team, but I'm open to other places that might make sense.

cc/ @cloudfoundry/wg-app-runtime-interfaces-cli-approvers 