### PR TITLE
Add @thitch97 to Buildpacks approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -91,6 +91,8 @@ areas:
     github: ForestEckhardt
   - name: Victoria Campbell
     github: tisvictress
+  - name: Timothy Hitchener
+    github: thitch97
   repositories:
   - cloudfoundry/cflinuxfs3
   - cloudfoundry/cflinuxfs4


### PR DESCRIPTION
I have been a contributor to CF Buildpacks on and off since 2019 and currently assist with the maintenance of multiple buildpacks (most recently the python and staticfile buildpacks). Additionally, current approvers @ryanmoran, @arjun024, and @brayanhenao can all confirm that I meet the qualifications for approval.

cc/ @Gerg for approval