### PR TITLE
Fix org automation blocked by "backup-restore-team-bot"

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -51,8 +51,6 @@ bots:
   github: cf-identity
 - name: cf-bosh-ci-bot
   github: cf-bosh-ci-bot
-- name: backup-restore-team-bot
-  github: backup-restore-team-bot
 - name: Cryogenics-CI
   github: Cryogenics-CI
 areas:


### PR DESCRIPTION
This bot has been added with https://github.com/cloudfoundry/community/pull/448 The pr didn't add the bot to the contributors.yml. To unblock the org automation I will remove it.

If this bot is required please add it again also to the contributors.yml.