### PR TITLE
add PHP buildpack to buildpacks temporary team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2325,6 +2325,7 @@ orgs:
           libbuildpack: admin
           nginx-buildpack: admin
           nodejs-buildpack: admin
+          php-buildpack: admin
           python-buildpack: admin
           r-buildpack: admin
           ruby-buildpack: admin


### PR DESCRIPTION
The PHP buildpack was missing from this list, and as a result our team members are not able to manage repository settings.