### PR TITLE
[ARI] Remove Autoscaler approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -54,8 +54,6 @@ areas:
     github: asalan316
   - name: Silvestre Zabala
     github: silvestre
-  - name: Kevin Cross
-    github: KevinJCross
   - name: Alan Morán
     github: bonzofenix
   - name: Jörg Weisbarth

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -56,8 +56,6 @@ areas:
     github: silvestre
   - name: Jörg Weisbarth
     github: joergdw
-  - name: Marcin Kubica
-    github: marcinkubica
   - name: Oliver Mautschke
     github: olivermautschke
   reviewers:

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -54,8 +54,6 @@ areas:
     github: asalan316
   - name: Silvestre Zabala
     github: silvestre
-  - name: Alan Morán
-    github: bonzofenix
   - name: Jörg Weisbarth
     github: joergdw
   - name: Marcin Kubica


### PR DESCRIPTION
This PRs removes three former contributors to the Autoscaler area in the App Runtime Interfaces working group:

- Remove @KevinJCross from ARI Autoscaler approvers
- Remove @bonzofenix from ARI Autoscaler approvers
- Remove @marcinkubica from ARI Autoscaler approvers

According to [RFC-0008] "An existing Approver may submit the revocation request on behalf of someone else, but the person whose role is being revoked must be given two weeks to refute the revocation."

@KevinJCross, @bonzofenix, @marcinkubica: Please speak up if you want to continue to contribute to the Autoscaler area in the App Runtime Interfaces working group. You have until March, 18th 2023 to veto your removal from the approver role.
In any case, thank you for your contributions to the Autoscaler area. :heart:

[RFC-0008]: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0008-role-change-process.md#revoking-approver-role

