### PR TITLE
Move lager to diego group

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -115,6 +115,7 @@ areas:
   - cloudfoundry/grace
   - cloudfoundry/healthcheck
   - cloudfoundry/inigo
+  - cloudfoundry/lager
   - cloudfoundry/localdriver
   - cloudfoundry/localip
   - cloudfoundry/locket
@@ -262,7 +263,6 @@ areas:
   - cloudfoundry/go-metric-registry
   - cloudfoundry/go-orchestrator
   - cloudfoundry/go-pubsub
-  - cloudfoundry/lager
   - cloudfoundry/log-cache-cli
   - cloudfoundry/log-cache-release
   - cloudfoundry/loggregator-agent-release


### PR DESCRIPTION
This repository has been historically used within diego and other runtime components. Additionally [Import path for this repo](https://pkg.go.dev/code.cloudfoundry.org/lager?tab=importedby) also suggests that no logging and metrics component imports this repo.