### PR TITLE
add capi-team-checklists to AppRuntimeInterfaces repos

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -185,6 +185,7 @@ areas:
   - cloudfoundry/capi-ci
   - cloudfoundry/capi-ci-private
   - cloudfoundry/capi-env-pool
+  - cloudfoundry/capi-team-checklists
   - cloudfoundry/cf-performance-tests
   - cloudfoundry/cf-performance-tests-pipeline
   - cloudfoundry/tps


### PR DESCRIPTION
cloudfoundry/capi-team-checklists has some old miscellaneous information in the wiki we'd like to check/extract before maybe archiving the repo