### PR TITLE
No branchprotection for ARD relint projects

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -19,3 +19,7 @@ branch-protection:
             bypass_pull_request_allowances:
               teams: ["wg-app-runtime-deployments-bots"] # no area bots configured
           include: [ "main", "v[0-9]*"]
+        relint-ci-pools:
+          protect: false
+        relint-envs:
+          protect: false


### PR DESCRIPTION
- relint-ci-pools
- relint-envs

The repos don't contain sources but are used to maintain locks and bbl state. Pipelines use github deploy keys to commit data.