### PR TITLE
as we cannot reuse the relint-env repo.

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -191,6 +191,13 @@ orgs:
           of your choice.
         has_projects: false
         has_wiki: false
+      bosh-bootloader-ci-envs:
+        allow_merge_commit: false
+        allow_squash_merge: false
+        default_branch: main
+        description: state files for bbl ci environments
+        has_projects: false
+        has_wiki: false
       bosh-cli:
         default_branch: main
         description: BOSH CLI v2+
@@ -1477,7 +1484,7 @@ orgs:
         has_projects: true
       korifi-website:
         default_branch: main
-        has_projects: false 
+        has_projects: false
       lager:
         allow_merge_commit: false
         description: An opinionated logger for Go.
@@ -2185,7 +2192,7 @@ orgs:
         default_branch: main
         description: Terraform provider to manage Cloud Service Broker bindings for MySQL
         has_projects: true
-        has_wiki: false        
+        has_wiki: false
       terraform-provider-csbpg:
         allow_merge_commit: false
         allow_rebase_merge: false

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -280,6 +280,7 @@ areas:
   - cloudfoundry/bosh-azure-storage-cli
   - cloudfoundry/bosh-bbl-ci-envs
   - cloudfoundry/bosh-bootloader
+  - cloudfoundry/bosh-bootloader-ci-envs
   - cloudfoundry/bosh-cli
   - cloudfoundry/bosh-compiled-releases-index
   - cloudfoundry/bosh-cpi-environments


### PR DESCRIPTION
we need this repo so that we can store bbl state of the bosh-bootloader pipeline information in this repo
see https://github.com/cloudfoundry/bosh-bootloader/blob/main/ci/pipelines/bosh-bootloader.yml#L82