### PR TITLE
service-management: add Fernando Naranjo as approver

### DIFF
--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -45,6 +45,8 @@ areas:
     github: zucchinidev
   - name: Konstantin Semenov
     github: jhvhs    
+  - name: Fernando Naranjo
+    github: fnaranjo-vmw        
   bots:
   - name: Services Enablement bot
     github: servicesenablement


### PR DESCRIPTION
We would be thrilled to welcome Fernando Naranjo as approver for the cloud service broker area of the working group. He has been constantly contributing with high quality code and tests, thorough code reviews, great new ideas and spotting a number of bugs and potential issues.

11 PRS in [csb-brokerpak-aws](https://github.com/cloudfoundry/csb-brokerpak-aws/pulls?q=is%3Apr+author%3Afnaranjo-vmw)
4 reviews in [csb-brokerpak-aws](https://github.com/cloudfoundry/csb-brokerpak-aws/pulls?q=is%3Apr+reviewed-by%3Afnaranjo-vmw+-author%3Afnaranjo-vmw)
1 PR in [csb-brokerpak-azure](https://github.com/cloudfoundry/csb-brokerpak-azure/pulls?q=is%3Apr+author%3Afnaranjo-vmw)
2 PRs in [csb-brokerpak-gcp](https://github.com/cloudfoundry/csb-brokerpak-gcp/pulls?q=is%3Apr+author%3Afnaranjo-vmw)
1 PR in [cloud-service-broker](https://github.com/cloudfoundry/cloud-service-broker/pulls?q=is%3Apr+author%3Afnaranjo-vmw)