### PR TITLE
branch protection: match complete branch name

### DIFF
--- a/org/org_management.py
+++ b/org/org_management.py
@@ -431,7 +431,7 @@ class OrgGenerator:
                 "allow_force_pushes": False,
                 "allow_deletions": False,
                 "allow_disabled_policies": True,  # needed to allow branches w/o branch protection
-                "include": [self._get_default_branch(repo), "v[0-9]*"],
+                "include": [f"^{self._get_default_branch(repo)}$", "^v[0-9]*$"],
                 "required_pull_request_reviews": {
                     "dismiss_stale_reviews": True,
                     "require_code_owner_reviews": True,

--- a/org/readme.md
+++ b/org/readme.md
@@ -60,7 +60,7 @@ branch-protection:
             required_approving_review_count: 0 (if project has <=3 approvers) or 1 (if project has >=4 approvers)
             bypass_pull_request_allowances:
               teams: [<WG and WG area bot teams>]
-          include: [ "<default branch>", "v[0-9]*"]
+          include: [ "^<default branch>$", "^v[0-9]*$"]  # note the surrounding ^...$ to avoid matching branches containing 'main' or 'v'
 ```
 
 Limitations:

--- a/org/test_org_management.py
+++ b/org/test_org_management.py
@@ -432,9 +432,9 @@ class TestOrgGenerator(unittest.TestCase):
         pr_reviews = repos_bp["repo1"]["required_pull_request_reviews"]
         self.assertEqual(0, pr_reviews["required_approving_review_count"])
         self.assertListEqual(["wg-wg1-name-bots"], pr_reviews["bypass_pull_request_allowances"]["teams"])
-        self.assertListEqual(["main", "v[0-9]*"], repos_bp["repo1"]["include"])
+        self.assertListEqual(["^main$", "^v[0-9]*$"], repos_bp["repo1"]["include"])
         # other default branch
-        self.assertListEqual(["defbranch", "v[0-9]*"], repos_bp["repo3"]["include"])
+        self.assertListEqual(["^defbranch$", "^v[0-9]*$"], repos_bp["repo3"]["include"])
 
         _wg3 = OrgGenerator._yaml_load(wg3)
         repos_bp = o._generate_wb_branch_protection(_wg3)
@@ -497,7 +497,7 @@ class TestOrgGenerator(unittest.TestCase):
             "cf-deployment", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-cf-deployment-approvers"]["repos"]
         )
         self.assertIn("cf-deployment", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["repos"])
-        self.assertIn("cf-gitbot", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["members"])
+        self.assertIn("ard-wg-gitbot", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["members"])
         self.assertIn("toc", teams)
         self.assertEqual(5, len(teams["toc"]["maintainers"]))
         self.assertIn("community", teams["toc"]["repos"])


### PR DESCRIPTION
- surround branch include patterns by ^...$ to avoid matching branches containing 'main' or 'v'
- fixes #580
- adapt integration test to changed ARD bots