### PR TITLE
Archive migrate_mysql_to_credhub

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1664,6 +1664,7 @@ orgs:
       migrate_mysql_to_credhub:
         description: A go tool to migrate broker data from mysql to credhub
         has_projects: true
+        archived: true
       minimal-env:
         has_projects: true
         private: true

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -115,7 +115,6 @@ areas:
   - cloudfoundry/goshims
   - cloudfoundry/mapfs
   - cloudfoundry/mapfs-release
-  - cloudfoundry/migrate_mysql_to_credhub
   - cloudfoundry/nfsv3driver
   - cloudfoundry/nfsbroker
   - cloudfoundry/nfs-volume-release


### PR DESCRIPTION
As far as we can tell this repo is no longer used. It also needs some dependency updates to resolve CVEs. As it's not used, this is not useful work, so it's better to archive the repo to make is clear that it's no longer maintained.