### PR TITLE
Add cflinuxfs4-compat-release repository

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -724,6 +724,10 @@ orgs:
       cflinuxfs4:
         default_branch: main
         has_projects: true
+      cflinuxfs4-compat-release:
+        default_branch: main
+        description: Cloud Foundry compatibility stack with Ruby and Python based on Ubuntu 22.04 LTS
+        has_projects: true
       cflinuxfs4-release:
         default_branch: main
         description: Cloud Foundry stack based on Ubuntu 22.04 LTS

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -207,6 +207,7 @@ areas:
   - cloudfoundry/cflinuxfs3
   - cloudfoundry/cflinuxfs3-release
   - cloudfoundry/cflinuxfs4
+  - cloudfoundry/cflinuxfs4-compat-release
   - cloudfoundry/cflinuxfs4-release
   - cloudfoundry/stack-auditor
 


### PR DESCRIPTION
This repository is required for the compatibility flaviour of the cflinuxfs4 stack as decidec in the RFC [Proposal for Ruby and Python Removal from the cflinuxfs4 Stack with a Deprecation
Period](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0016-python-and-ruby-removal-from-cf-stack.md).