### PR TITLE
Archive pip-pop repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1816,6 +1816,7 @@ orgs:
         archived: true
         has_projects: true
       pip-pop:
+        archived: true
         has_projects: true
       platform-certification:
         description: 'Tooling for eventual use in CF platform certification '

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -169,7 +169,6 @@ areas:
   - name: Rob Dimsdale-Zucker
     github: robdimsdale
   repositories:
-  - cloudfoundry/pip-pop
   - cloudfoundry/python-buildpack
   - cloudfoundry/python-buildpack-release
 


### PR DESCRIPTION
This PR archives the https://github.com/cloudfoundry/pip-pop repository, as it is no longer used by the buildpacks team.