### PR TITLE
change default ARP repo branches to main

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -994,7 +994,7 @@ orgs:
         description: Simple canary app to test long-running Diego deployments
         has_projects: true
       diff-exporter:
-        default_branch: develop
+        default_branch: main
         has_projects: true
       disaster-recovery-acceptance-tests:
         default_branch: main
@@ -1319,7 +1319,7 @@ orgs:
         has_projects: true
         has_wiki: false
       groot-windows:
-        default_branch: develop
+        default_branch: main
         description: A Garden image plugin for Windows
         has_projects: true
         has_wiki: false
@@ -1358,7 +1358,7 @@ orgs:
         has_projects: false
         has_wiki: false
       hydrator:
-        default_branch: develop
+        default_branch: main
         has_projects: true
       ibm-websphere-liberty-buildpack:
         description: IBM WebSphere Application Server Liberty Buildpack
@@ -2302,7 +2302,7 @@ orgs:
       wg-app-platform-runtime-ci:
         has_projects: true
       winc:
-        default_branch: develop
+        default_branch: main
         description: CLI tool for spawning and running containers on Windows according
           to the OCI specification
         has_projects: true


### PR DESCRIPTION
ARP members have requested for some branches to change, but the automation keeps bringing the old branches back!
