### PR TITLE
Add kpalkov to CFF Contributors

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -330,6 +330,7 @@ contributors:
 - kimago
 - kirederik
 - klakin-pivotal
+- klapkov
 - KlapTrap
 - kmarkwardt-vmware
 - knm3000


### PR DESCRIPTION
@PlamenDoychev nominate @klapkov as CFF Contributor. The nomination was agenda topic and have been discussed during recent ARP WG session (7.June.2023)