### PR TITLE
Add cflinxufs4-compat-release repo and give sophiewigmore admin access

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2313,9 +2313,11 @@ orgs:
         - arjun024
         - brayanhenao
         - ryanmoran
+        - sophiewigmore
         members: []
         privacy: closed
         repos:
+          cflinuxfs4-compat-release: admin
           apt-buildpack: admin
           binary-buildpack: admin
           buildpacks-ci: admin


### PR DESCRIPTION
I will need admin access while I am working on getting initial automation out the door the first release. I may need to amend secrets while we're ironing out any kinks in out automation so it's easier to have the repository access this way

~~I also added an entry for the cflinuxfs4-compat-release here, because I assumed we'd need one.~~