### PR TITLE
fix: CLAW reference

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2388,7 +2388,7 @@ orgs:
         members: []
         privacy: closed
         repos:
-          claw: admin
+          CLAW: admin
           cli-ci: admin
           cli-plugin-repo: admin
           cli: admin


### PR DESCRIPTION
Admin permissions was not properly applied due to case sensitivity?