### PR TITLE
Fix case of CLAW repo in WG charter

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -354,7 +354,7 @@ areas:
   - cloudfoundry/cli-i18n
   - cloudfoundry/cli-ci
   - cloudfoundry/cli-plugin-repo
-  - cloudfoundry/claw
+  - cloudfoundry/CLAW
   - cloudfoundry/cli-docs-scripts
   - cloudfoundry/cli-workstation
   - cloudfoundry/cli-private


### PR DESCRIPTION
Repo name is CLAW (capital letters).
https://github.com/cloudfoundry/CLAW

 Fixes #625