### PR TITLE
Add pcap source code repository

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1786,6 +1786,10 @@ orgs:
         description: A service broker that provides an overview of its service instances
           and bindings. Conforms to the Open Service Broker API standard.
         has_projects: true
+      pcap:
+        default_branch: main
+        description: Sources to enable network analysis for CF app developers
+        has_projects: true
       pcap-release:
         default_branch: main
         description: A BOSH release and CLI to enable network analysis for CF app developers

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -364,6 +364,7 @@ areas:
     github: b1tamara
   repositories:
   - cloudfoundry/haproxy-boshrelease
+  - cloudfoundry/pcap
   - cloudfoundry/pcap-release
 
 ```


### PR DESCRIPTION
Hi,
the networking-extension group already has the repo https://github.com/cloudfoundry/pcap-release bundling the source-code and bosh-related parts when taking network traces from an operator or app developer perspective, see also https://github.com/cloudfoundry/cf-deployment/issues/980. We are in the middle of implementing the bosh-scenario of this stream.

With this PR, we are asking for a new repo `pcap` that should host the go source files of this project to split source and bosh-related parts. This is useful when
* pcap binaries should be added to diego-release for the cf-scenario (https://github.com/cloudfoundry/diego-release/issues/703)
* the sources would be co-located with the bosh-director/agents (an RFC will follow, thx @rkoster)
* code is reused in non-CF-scenarios

Project-config can be similar to pcap-release. Feel free to raise any questions here.

Pinging WG lead @ameowlia for initial feedback.