### PR TITLE
Add Logging and Metrics Bot

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -45,6 +45,8 @@ bots:
   github: tas-runtime-bot
 - name: Networking CI Bot
   github: CFN-CI
+- name: CF Logging and Metrics Bot
+  github: cf-logging-metrics-bot
 config:
   generate_rfc0015_branch_protection_rules: true
 areas:


### PR DESCRIPTION
We've been hitting github rate limits with the existing shared runtime bot. Adding another one to split the workload.