### PR TITLE
Archive resolvconf-manager projects

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1966,8 +1966,10 @@ orgs:
         has_projects: true
       resolvconf-manager:
         has_projects: true
+        archived: true
       resolvconf-manager-index:
         has_projects: true
+        archived: true
       route-emitter:
         allow_merge_commit: false
         description: Registers and unregisters processes running on executors with

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -330,8 +330,6 @@ areas:
   - cloudfoundry/greenhouse-ci
   - cloudfoundry/jumpbox-deployment
   - cloudfoundry/os-conf-release
-  - cloudfoundry/resolvconf-manager
-  - cloudfoundry/resolvconf-manager-index
   - cloudfoundry/sample-windows-bosh-release
   - cloudfoundry/socks5-proxy
   - cloudfoundry/stembuild


### PR DESCRIPTION
When developing the Bionic stemcell, the team originally planned to introduce a wrapper around managing resolv.conf within the agent and BOSH DNS. However, this work was reverted (likely due to backward compatibility concerns) and abandoned. This idea was not incorporated at all into the Jammy stemcells.

As such, we should not continue actively maintaining the associated repositories.

Original implementation story:
https://www.pivotaltracker.com/story/show/167763426

Revert: 
https://www.pivotaltracker.com/n/projects/2238419/stories/168790375 
https://github.com/cloudfoundry/bosh-dns-release/commit/aac14421fd63aa7e266f93cf16d614ec6fce60d4