### PR TITLE
Add emalm as contributor

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -202,6 +202,7 @@ contributors:
 - eirinici
 - ekcasey
 - elsony
+- emalm
 - EngineerBetterCI
 - erabil
 - ericbottard


### PR DESCRIPTION
Looks like https://github.com/cloudfoundry/community/pull/642 removed me from the entire CF GitHub org, since the only team I was on was the TOC team and I wasn't explicitly listed in the contributors file. I believe I meet the contributor criteria based on https://github.com/cloudfoundry/community/commits?author=emalm alone.