### PR TITLE
Add metric store bot to contributors

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -567,6 +567,7 @@ contributors:
 - sunnytoolsmiths
 - suprajanarasimhan
 - suraiyasuliman
+- svcboteos
 - svennam92
 - svkrieger
 - swalchemist


### PR DESCRIPTION
Hi All

Requesting that the bot used my the metric store team be added as a cloud foundry contributor