### PR TITLE
Find the right place for bosh-package-java-release and bosh-package-cf-cli-release

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -117,6 +117,7 @@ areas:
   - cloudfoundry/java-buildpack-system-test
   - cloudfoundry/java-test-applications
   - cloudfoundry/jvmkill
+  - cloudfoundry/bosh-package-java-release
 
 - name: Buildpacks .Net Core
   approvers:
@@ -361,6 +362,7 @@ areas:
   - cloudfoundry/cli-workstation
   - cloudfoundry/cli-private
   - cloudfoundry/cli-pools
+  - cloudfoundry/bosh-package-cf-cli-release
   - cloudfoundry/jsonry
   - cloudfoundry/stack-auditor
   - cloudfoundry/ykk

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -302,9 +302,7 @@ areas:
   - cloudfoundry/bosh-io-worker
   - cloudfoundry/bosh-linux-stemcell-builder
   - cloudfoundry/bosh-openstack-cpi-release
-  - cloudfoundry/bosh-package-cf-cli-release
   - cloudfoundry/bosh-package-golang-release
-  - cloudfoundry/bosh-package-java-release
   - cloudfoundry/bosh-package-nginx-release
   - cloudfoundry/bosh-package-python-release
   - cloudfoundry/bosh-package-ruby-release


### PR DESCRIPTION
With [Consolidate bosh-packages and bosh-io into cloudfoundry github org](https://github.com/cloudfoundry/community/pull/512) the FI WG got two repositories which don't really belong to the WG. This pr suggests a possible move but our intention is to start a discussion to find right place for them. cc @rkoster & @jpalermo 