### PR TITLE
Update branch protection for the CF-on-K8s repositories

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -5,7 +5,7 @@ branch-protection:
     cloudfoundry:
       repos:
         # example repo configured as if the project would belong to ARD WG, area CF Deployment
-        # automation would generate repo/branch config for all repos belonging to a WG unless an explicit configuration exists here 
+        # automation would generate repo/branch config for all repos belonging to a WG unless an explicit configuration exists here
         branchprotection-test:
           protect: true
           enforce_admins: true
@@ -58,7 +58,7 @@ branch-protection:
           allow_deletions: false
           allow_disabled_policies: true
           include: ["^master$"]
-          required_status_checks: 
+          required_status_checks:
             contexts: ["concourse-ci/unit-tests","concourse-ci/acceptance-tests"]
           required_pull_request_reviews:
             dismiss_stale_reviews: true
@@ -73,7 +73,7 @@ branch-protection:
           allow_deletions: false
           allow_disabled_policies: true
           include: ["^main$"]
-          required_status_checks: 
+          required_status_checks:
             contexts: ["concourse-ci/unit-tests","concourse-ci/acceptance-tests"]
           required_pull_request_reviews:
             dismiss_stale_reviews: true
@@ -81,3 +81,32 @@ branch-protection:
             required_approving_review_count: 1
             bypass_pull_request_allowances:
               teams: ["wg-app-runtime-platform-bots"]
+
+        # CF-on-K8s
+        korifi-ci:
+          protect: false
+        cf-k8s-secrets:
+          protect: false
+        korifi:
+          protect: true
+          enforce_admins: true
+          allow_force_pushes: false
+          allow_deletions: false
+          allow_disabled_policies: true
+          include: ["^main$"]
+          required_status_checks:
+            contexts:
+              - "api-tests"
+              - "controllers-tests"
+              - "linter"
+              - "job-task-runner-tests"
+              - "kpack-image-builder-tests"
+              - "statefulset-runner-tests"
+              - "tools-tests"
+              - "Concourse / e2e-tests (pull_request)"
+              - "Concourse / e2e-eks-tests (pull_request)"
+              - "EasyCLA"
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1


### PR DESCRIPTION
This restores the branch protection rules the WG had before turning on `config.generate_rfc0015_branch_protection_rules`. In particular:
* slightly stricter branch protection the `korifi` repository, requiring checks to have passed before merging;
* no protection on `korifi-ci` and `cf-k8s-secrets`.

Not sure if this makes `config.generate_rfc0015_branch_protection_rules` needed at all.