### PR TITLE
[WIP] Add branch protection for FI WG repos

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -55,6 +55,8 @@ bots:
   github: Cryogenics-CI
 - name: bbr-ci
   github: bbr-ci
+config:
+  generate_rfc0015_branch_protection_rules: true
 areas:
 - name: Docs
   approvers:


### PR DESCRIPTION
This is pr is to start the discussion in the FI WG about introducing branch protection rules for all repositories. We should make sure that the recommendation for branch protections are in place:
- [ ] Replace github deploy keys by working group bot users. Branch protection rules enforce PRs for commits with deploy keys (enforce_admins=true).
- [ ] Ensure that all bot users are members of the working group bots team or working group area bots team.
- [ ] Remove all direct repository users in 'Settings > Collaborators and teams'. Repository access shall be governed by the generated teams only.
- [ ] exclude repos w/o source code 

cc @rkoster @jpalermo 