### PR TITLE
Move cf-cli bosh package release to CF cli area in ARI WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -365,6 +365,7 @@ areas:
   - cloudfoundry/stack-auditor
   - cloudfoundry/ykk
   - cloudfoundry/app-runtime-interfaces-infrastructure
+  - cloudfoundry/bosh-package-cf-cli-release
 
 - name: Docs
   approvers:

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -302,7 +302,6 @@ areas:
   - cloudfoundry/bosh-io-worker
   - cloudfoundry/bosh-linux-stemcell-builder
   - cloudfoundry/bosh-openstack-cpi-release
-  - cloudfoundry/bosh-package-cf-cli-release
   - cloudfoundry/bosh-package-golang-release
   - cloudfoundry/bosh-package-java-release
   - cloudfoundry/bosh-package-nginx-release


### PR DESCRIPTION
Ci for this release is being maintained by this working group, so let's make sure to reflect this in the working group charter.