### PR TITLE
Archive silk repo, it was merged into silk-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2141,6 +2141,7 @@ orgs:
         has_projects: true
         private: true
       silk:
+        archived: true
         allow_merge_commit: false
         default_branch: main
         description: a network fabric for containers.  inspired by flannel, designed

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -369,7 +369,6 @@ areas:
   - cloudfoundry/routing-perf-release
   - cloudfoundry/routing-release
   - cloudfoundry/routing-team-checklists
-  - cloudfoundry/silk
   - cloudfoundry/silk-release
 
 - name: Networking-Extensions


### PR DESCRIPTION
We had originally setup silk in an enitre other repo with the intention that it could be imported, used, and extended by other projects. This never happened and now we have a separate repo for `silk` when it is only used in `silk-release`.

We have moved `silk` into `silk-release` and therefore `silk` is no longer necessary.

More details:
- https://github.com/cloudfoundry/silk/issues/52
- https://github.com/cloudfoundry/silk-release/pull/89

[#185149418](https://www.pivotaltracker.com/story/show/185149418)