### PR TITLE
Add approver blora to Docs approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -386,6 +386,8 @@ areas:
     github: snneji
   - name: Ben Klein
     github: fifthposition
+  - name: Lora Boe
+    github: blora
   - name: Ajayan Borys
     github: HenryBorys
   - name: Bob Graczyk

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -151,6 +151,8 @@ areas:
     github: snneji
   - name: Ben Klein
     github: fifthposition
+  - name: Lora Boe
+    github: blora
   - name: Ajayan Borys
     github: HenryBorys
   - name: Bob Graczyk

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -68,6 +68,8 @@ areas:
     github: snneji
   - name: Ben Klein
     github: fifthposition
+-   name: Lora Boe
+    github: blora
   - name: Ajayan Borys
     github: HenryBorys
   - name: Bob Graczyk


### PR DESCRIPTION
I am a new docs writer from VMware and am requesting to become an approver for all docs areas.

This affects 3 working groups and requires approval from the tech leads in each working group:
* App Runtime Platform - @ameowlia
* App Runtime Interfaces - @gerg
* Foundational Infrastructure - @beyhan and/or @rkoster
