### PR TITLE
Disable enforcing branch-protection for admins

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -53,7 +53,7 @@ branch-protection:
           protect: false
         haproxy-boshrelease:
           protect: true
-          enforce_admins: true
+          enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
           allow_disabled_policies: true
@@ -68,7 +68,7 @@ branch-protection:
               teams: ["wg-app-runtime-platform-bots"]
         pcap-release:
           protect: true
-          enforce_admins: true
+          enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
* This disables the following branch-protection rule for the repos `haproxy-boshrelease` and `pcap-release`
  > Do not allow bypassing the above settings
  > The above settings will apply to administrators and custom roles with the “bypass branch protections” permission
* As we have mandatory tests, this setting prevents our bot [CFN-CI](https://github.com/CFN-CI) to push a PR to the main branches. Instead, we get this error when trying to push via the job [shipit](https://github.com/cloudfoundry/haproxy-boshrelease/blob/47c240e45a367399416547348e2c6950cd87d090/ci/pipeline.yml#L337)
  ```
  remote: error: GH006: Protected branch update failed for refs/heads/master.        
  remote: error: 2 of 2 required status checks are expected.        
  To https://github.com/cloudfoundry/haproxy-boshrelease
   ! [remote rejected] HEAD -> master (protected branch hook declined)
  error: failed to push some refs to 'https://github.com/cloudfoundry/haproxy-boshrelease'
  failed with non-rebase error
  ```
* Allowing this CI user to bypass PR creation is not sufficient
* We suggest to soften these rules and avoid more manual work by piping [the respective changes during a relase](https://github.com/cloudfoundry/routing-release/commit/6c2f0d5f035d29068b519541a96996d0cc0af3e1) through a PR/review-process