### PR TITLE
RFC: TOC can stand in for WG leads

### DIFF
--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -10,7 +10,7 @@
 ## Summary
 
 Working Group Leads are in charge of approving and merging PRs for their
-Working Group. When the TOC decideds it is necessary, the TOC MAY make decisions in their stead.
+Working Group. When the TOC decideds it is necessary, the TOC MAY make decisions in their place.
 
 ## Problem
 

--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -1,6 +1,6 @@
 # Meta
 [meta]: #meta
-- Name: TOC Can Stand in for Working Group Leads When They are Absent
+- Name: TOC Can Stand in for Working Group Leads
 - Start Date: 2023-08-28
 - Author(s): Amelia Downs
 - Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
@@ -9,18 +9,17 @@
 
 ## Summary
 
-Working Group leads are in charge of approving and merging PRs for their
-Working Group. If they are absent, the TOC MAY make decisions in their stead.
+Working Group Leads are in charge of approving and merging PRs for their
+Working Group. When the TOC decideds it is necessary, the TOC MAY make decisions in their stead.
 
 ## Problem
 
-Sometimes Working Group leads go on vacation or get sick and are not available
+Sometimes Working Group Leads go on vacation or get sick and are not available
 to review PRs. This can cause progress on their teams to grind to halt until
 the Working Group lead returns.
 
 ## Proposal
 
-The TOC MAY make decisions for a Working Group lead in their absence. This
+When the TOC decideds it is necessary, the TOC MAY make decisions in their stead. This
 includes approving and merging PRs for their Working Group. All actions MUST
 have the approval of a majority of the TOC members.
-

--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -4,7 +4,7 @@
 - Start Date: 2023-08-28
 - Author(s): Amelia Downs
 - Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
-- RFC Pull Request: (fill in with PR link after you submit it)
+- RFC Pull Request: https://github.com/cloudfoundry/community/pull/676
 
 
 ## Summary

--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -15,8 +15,8 @@ Working Group. When the TOC decideds it is necessary, the TOC MAY make decisions
 ## Problem
 
 Sometimes Working Group Leads go on vacation or get sick and are not available
-to review PRs. This can cause progress on their teams to grind to halt until
-the Working Group lead returns.
+to take actions for their working group. This can cause work in the working group to be blocked until
+the Working Group Lead returns.
 
 ## Proposal
 

--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -20,6 +20,6 @@ the Working Group Lead returns.
 
 ## Proposal
 
-When the TOC decideds it is necessary, the TOC MAY make decisions in their stead. This
+When the TOC decides it is necessary, the TOC MAY make decisions in their stead. This
 includes approving and merging PRs for their Working Group. All actions MUST
 have the approval of a majority of the TOC members.

--- a/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
+++ b/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md
@@ -1,0 +1,26 @@
+# Meta
+[meta]: #meta
+- Name: TOC Can Stand in for Working Group Leads When They are Absent
+- Start Date: 2023-08-28
+- Author(s): Amelia Downs
+- Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
+- RFC Pull Request: (fill in with PR link after you submit it)
+
+
+## Summary
+
+Working Group leads are in charge of approving and merging PRs for their
+Working Group. If they are absent, the TOC MAY make decisions in their stead.
+
+## Problem
+
+Sometimes Working Group leads go on vacation or get sick and are not available
+to review PRs. This can cause progress on their teams to grind to halt until
+the Working Group lead returns.
+
+## Proposal
+
+The TOC MAY make decisions for a Working Group lead in their absence. This
+includes approving and merging PRs for their Working Group. All actions MUST
+have the approval of a majority of the TOC members.
+


### PR DESCRIPTION
🚀 [Link for easy viewing.](https://github.com/cloudfoundry/community/blob/toc-stand-in-for-wg-lead-rfc/toc/rfc/rfc-draft-toc-stand-in-for-wg-lead.md)