### PR TITLE
move bosh-package-cf-cli-release to cli team from bosh team

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -375,6 +375,7 @@ areas:
   - cloudfoundry/stack-auditor
   - cloudfoundry/ykk
   - cloudfoundry/app-runtime-interfaces-infrastructure
+  - cloudfoundry/bosh-package-cf-cli-release
 
 - name: Java Tools
   approvers:

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -278,7 +278,6 @@ areas:
   - cloudfoundry/bosh-io-worker
   - cloudfoundry/bosh-linux-stemcell-builder
   - cloudfoundry/bosh-openstack-cpi-release
-  - cloudfoundry/bosh-package-cf-cli-release
   - cloudfoundry/bosh-package-golang-release
   - cloudfoundry/bosh-package-java-release
   - cloudfoundry/bosh-package-nginx-release


### PR DESCRIPTION
The https://github.com/cloudfoundry/bosh-package-cf-cli-release previously lived in a bosh-packages org.  When it was moved to the cloudfoundry org, it was given to the bosh team.  The bosh team has never managed this repo and was surprised by being asked for help with.  Since it was previously managed by the cf cli team, this pr moves the repo to their purview.  We could leave both teams as owners if we feel like it, but I suspect the bosh team has little interest in the repo

cc @cloudfoundry/wg-foundational-infrastructure-vm-deployment-lifecycle-bosh-approvers and @cloudfoundry/wg-app-runtime-interfaces-cli-approvers as this move would need to be approved by both groups