### PR TITLE
Promote Michael Oleske to CLI approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -350,6 +350,8 @@ areas:
     github: jdgonzaleza
   - name: Ryker Reed
     github: reedr3
+  - name: Michael Oleske
+    github: moleske
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge
@@ -357,8 +359,6 @@ areas:
     github: ccjaimes
   - name: Pete Levine
     github: PeteLevineA
-  - name: Michael Oleske
-    github: moleske
   - name: Shwetha Guraraj
     github: gururajsh
   repositories:


### PR DESCRIPTION
For many years, Michael made valuable contributions to the CLI. I trust Michaels's judgment and am confident he has sufficient expertise to decide what suits this project.