### PR TITLE
Promote Cristhian Camilo Peña  as CLI approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -350,11 +350,11 @@ areas:
     github: jdgonzaleza
   - name: Ryker Reed
     github: reedr3
+  - name: Christhian
+    github: ccjaimes
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge
-  - name: Christhian
-    github: ccjaimes
   - name: Pete Levine
     github: PeteLevineA
   - name: Michael Oleske


### PR DESCRIPTION
Cristian has contributed to CF CLI for many years and is familiar with this project. It would be a good idea to promote him as an approver.