### PR TITLE
Archive repository bosh-package-java-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -312,6 +312,7 @@ orgs:
         description: Java release for OpenJDK for use with `bosh vendor-package`
         default_branch: main
         has_projects: false
+        archived: true
       bosh-package-nginx-release:
         description: Nginx release for use with `bosh vendor-package`
         default_branch: main

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -279,7 +279,6 @@ areas:
   - cloudfoundry/bosh-linux-stemcell-builder
   - cloudfoundry/bosh-openstack-cpi-release
   - cloudfoundry/bosh-package-golang-release
-  - cloudfoundry/bosh-package-java-release
   - cloudfoundry/bosh-package-nginx-release
   - cloudfoundry/bosh-package-python-release
   - cloudfoundry/bosh-package-ruby-release


### PR DESCRIPTION
Based on the discussions in https://github.com/cloudfoundry/community/pull/653 the decision was taken to archive the `bosh-package-java-release` repository. The only user of it is the App Autoscaler Area from the ARI WG but they are in favour to [package Java themself](https://github.com/cloudfoundry/community/pull/653#issuecomment-1723409747) instead of maintaining `bosh-package-java-release` repository.