### PR TITLE
parsable-working-groups.sh now only iterates over <wg>.md files once

### DIFF
--- a/toc/working-groups/parsable-working-groups.sh
+++ b/toc/working-groups/parsable-working-groups.sh
@@ -9,10 +9,10 @@ pushd $repo_root/toc/working-groups >/dev/null
 for group in $(ls ../*.md | grep -v -e ROLES -e CHANGEPLAN -e PRINCIPLES -e GOVERNANCE); do
     cat ${group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
         ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
-    for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
-          cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
-                ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
-    done
 done
 
+for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
+      cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
+            ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
+done
 


### PR DESCRIPTION
Previously, it would loop through this once per non-ignored file in the ${repo_root}/toc directory, resulting in duplication of group definitions in the generated json.