### PR TITLE
Remove Abil Dermendzhiev

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -5,7 +5,6 @@ contributors:
 - a-sudarsanan
 - aaronshurley
 - ab-pivot
-- abdermendz
 - AbelHu
 - abg
 - abh1kg

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -408,8 +408,6 @@ areas:
     github: ddonchev
   - name: Ikasarov
     github: ikasarov
-  - name: Abil Dermendzhiev
-    github: abdermendz
   - name: Velizar Kalapov
     github: vkalapov
   - name: Nikolay Valchev


### PR DESCRIPTION
Abil is no longer part of the MultiApps team