### PR TITLE
Fix RFC generation script to look only into the RFC file names

### DIFF
--- a/toc/rfc/assign-rfc-number.sh
+++ b/toc/rfc/assign-rfc-number.sh
@@ -27,7 +27,7 @@ NOPUSH=${NOPUSH:-}
 #
 
 generate_id() {
-  id="$(find "$script_dir" -maxdepth 2 -type f | sed 's/[^0-9]*//' | sed -E 's|^([[:digit:]]{4})-.*$|\1|' | sort | tail -n 1  |  sed 's/^0*//')"
+  id="$(find "$script_dir" -maxdepth 2 -type f -exec basename {} \; | sed 's/[^0-9]*//' | sed -E 's|^([[:digit:]]{4})-.*$|\1|' | sort | tail -n 1 | sed 's/^0*//')"
   ((id++))
   printf "%04d" "${id}"
 }


### PR DESCRIPTION
List with `find` only the RFC file name because the path could have digits which breaks the replace logic