### PR TITLE
Add Klaus to UAA

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -656,3 +656,4 @@ contributors:
 - adrianhoelzl-sap
 - radoslav-tomov
 - VRBogdanov
+- klaus-sap

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -123,6 +123,8 @@ areas:
   reviewers:
   - name: Adrian Hoelzl
     github: adrianhoelzl-sap
+  - name: Klaus Kiefer
+    github: klaus-sap
   repositories:
   - cloudfoundry/cf-identity-acceptance-tests-release
   - cloudfoundry/cf-uaa-lib


### PR DESCRIPTION
Please add https://github.com/klaus-sap

He will participate in UAA contributes, he did some PR in the past

https://github.com/search?q=repo%3Acloudfoundry%2Fuaa+klaus-sap&type=pullrequests