### PR TITLE
Remove will-gant as contributor

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -626,7 +626,6 @@ contributors:
 - wayneadams
 - WeiQuan0605
 - weymanf
-- will-gant
 - willmadison
 - winkingturtle-vmw
 - xandroc


### PR DESCRIPTION
According to [rfc-0008-role-change-process](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0008-role-change-process.md), @will-gant has 2 weeks time to object the removal.

I triggered the removal because the org automation fails since 20.9. which might be caused when trying to invite Will to the cloudfoundry org which seems to fail for unknown reason.