### PR TITLE
Archive repository identity-ci

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1434,6 +1434,7 @@ orgs:
         description: where everything else lives
         has_projects: true
         private: true
+        archived: true
       identity-tools:
         description: 'Cloud Foundry - the open platform as a service project '
         has_projects: true


### PR DESCRIPTION
This repository has been moved to https://github.com/pivotal/uaa-ci because it is a private repo containing private information. This is the result of the discussion in https://github.com/cloudfoundry/community/pull/421 and I clarified this with @bruce-ricard. To speed up things I'm opening this pr.