### PR TITLE
Promote chombium to ARP WG Logging & Metrics approver

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -229,9 +229,9 @@ areas:
     github: winkingturtle-vmw
   - name: Rebecca Roberts
     github: rroberts2222
-  reviewers:
   - name: Jovan Kostovski
     github: chombium
+  reviewers:
   - name: Felix Hambrecht
     github: fhambrec
   repositories:


### PR DESCRIPTION
Promote `chombium` to ARP WG Logging & Metrics approver

I'd like to be added as an approver in the Logging & Metrics working group.

I've been contributing to Cloud Foundry with focus on Logging and Metrics since mid 2020. I contribute to the GitHub repositories related to Loggregator and share the things which I know and learn Loggregator either on Slack or by enriching the Loggregator's documentation.

@ameowlia would you be willing to nominate me?


## Significant PR's Authored:
- [Add optional mTLS for Log-Cache](https://github.com/cloudfoundry/log-cache-release/pull/96)
- [Adding support for syslog+mtls drains in the syslog-agent](https://github.com/cloudfoundry/loggregator-agent-release/pull/119) which was succeded by the rework by @Benjamintf1 in [Mtls app drains](https://github.com/cloudfoundry/loggregator-agent-release/pull/177)
- [Add drain scope and url tags to syslog egress metrics](https://github.com/cloudfoundry/loggregator-agent-release/pull/123)
- [Add app-id and drain url in the error message](https://github.com/cloudfoundry/loggregator-agent-release/pull/212)
- [Add error messages for better traceability of filtered out syslog drain bindings](https://github.com/cloudfoundry/loggregator-agent-release/pull/216)
- [Add extended-key-usage for the cc_logcache_tls](https://github.com/cloudfoundry/cf-deployment/pull/1108)
- [Gorouter emits way too many metrics](https://github.com/cloudfoundry/gorouter/pull/275) - I worked on this together with @stefanlay
- [CF Loggregator / Observability Architecture Needs a Big Picture](https://github.com/cloudfoundry/docs-loggregator/issues/74) - I'm currently working on a PR with documentation of the observability of Loggregator
- [add missing metrics details](https://github.com/cloudfoundry/docs-dev-guide/pull/491) A [Slack thread](https://cloudfoundry.slack.com/archives/CUW93AF3M/p1687425870546099) turned out extension of the CF's dev guide. PR by @anita-flegg 
- Of course: I've also done other PRs to the GitHub repositories from the Logging and Metrics group

## Other Related Work:
- [Deep Dive: Full Speed Ahead: Tales of Running Loggregator at its Scaling Limits with High Log throughput and Minimal Log Loss](https://www.youtube.com/watch?v=tzcNOhRtbWw) - CF Summit 2021 Talk about monitoring Loggregator
- [Loggregator Load Test 2021](https://cloudfoundry.slack.com/archives/CUW93AF3M/p1626876673001000)
- [Loggregator Load Test 2022](https://cloudfoundry.slack.com/archives/CUW93AF3M/p1652697689759769) - Load test after the spit of Doppler and Log Cache to separate VM instances
- I'm active on Slack and help CF users solve their Loggregator problems
- PR reviews and discussions in various GitHub repositories in Logging and Metrics, cf-deployment, Diego, CAPI where there is something to do with logs and metrics



Best Regards,

Jovan

cc @ctlong 