### PR TITLE
chore: Officially archive the cf-drain-cli

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -550,6 +550,7 @@ orgs:
         default_branch: main
         has_projects: true
       cf-drain-cli:
+        archived: true
         allow_merge_commit: false
         default_branch: main
         description: CF CLI plugin to create syslog drains

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -236,7 +236,6 @@ areas:
     github: fhambrec
   repositories:
   - cloudfoundry/bosh-system-metrics-forwarder-release
-  - cloudfoundry/cf-drain-cli
   - cloudfoundry/dropsonde
   - cloudfoundry/dropsonde-protocol
   - cloudfoundry/dropsonde-protocol-js


### PR DESCRIPTION
This plugin is no longer maintained, and [the repo](https://github.com/cloudfoundry/cf-drain-cli) is already archived. We should mark it as such.