### PR TITLE
Archive cflinuxfs3 and cflinuxfs3-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -778,9 +778,11 @@ orgs:
         archived: true
         has_projects: true
       cflinuxfs3:
+        archived: true
         default_branch: main
         has_projects: true
       cflinuxfs3-release:
+        archived: true
         default_branch: main
         description: Cloud Foundry stack based on Ubuntu 18.04 LTS
         has_projects: true

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -205,8 +205,6 @@ areas:
   - name: Rob Dimsdale-Zucker
     github: robdimsdale
   repositories:
-  - cloudfoundry/cflinuxfs3
-  - cloudfoundry/cflinuxfs3-release
   - cloudfoundry/cflinuxfs4
   - cloudfoundry/cflinuxfs4-compat-release
   - cloudfoundry/cflinuxfs4-release


### PR DESCRIPTION
We would like to officially archive the [cflinuxfs3](https://github.com/cloudfoundry/cflinuxfs3) and [cflinuxfs3-release](https://github.com/cloudfoundry/cflinuxfs3-release) repositories, as we have not released since June and `cflinuxfs4` is up and running.