### PR TITLE
Add kathap as capi approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -291,6 +291,8 @@ areas:
     github: svkrieger
   - name: Tim Downey
     github: tcdowney
+  - name: Katharina Przybill
+    github: kathap
   reviewers:
   - name: Al Berez
     github: a-b
@@ -298,8 +300,6 @@ areas:
     github: xandroc
   - name: David Alvarado
     github: dalvarado
-  - name: Katharina Przybill
-    github: kathap
   - name: Evan Farrar
     github: evanfarrar
   - name: Daniel Felipe Ochoa


### PR DESCRIPTION
### About Me
I'm a DevOps engineer at SAP working together with @svkrieger, @philippthun, @FloThinksPi, @jochenehret, @stephanme and @johha on operating and improving Capi and related projects.


### Contributions
Over the past approximately 22 months, I have actively participated in various contributions and discussions, which has equipped me with the qualifications necessary to become an approver for Capi.


### Issues
Docker's registry password: [cloudfoundry/cloud_controller_ng/issues/3304](https://github.com/cloudfoundry/cloud_controller_ng/issues/3304)


### cloud_controller_ng PRs (newest first)  
v3 should allow to update docker registry credentials: [cloudfoundry/cloud_controller_ng/pull/3467](https://github.com/cloudfoundry/cloud_controller_ng/pull/3467)  
Adapt response handling for:    
- /v3/service_route_binding/:guid [cloudfoundry/cloud_controller_ng/pull/3469](https://github.com/cloudfoundry/cloud_controller_ng/pull/3469)    
- /v3/service_credential_bindings/:guid/parameters: [cloudfoundry/cloud_controller_ng/pull/3465](https://github.com/cloudfoundry/cloud_controller_ng/pull/3465)  
- /v3/service_route_binding/:guid/parameters: [cloudfoundry/cloud_controller_ng/pull/3443](https://github.com/cloudfoundry/cloud_controller_ng/pull/3443)  

Moving spec file (minor): [cloudfoundry/cloud_controller_ng/pull/3447](https://github.com/cloudfoundry/cloud_controller_ng/pull/3447)  
More aggressive cleanup of failed delayed jobs: [cloudfoundry/cloud_controller_ng/pull/3346](https://github.com/cloudfoundry/cloud_controller_ng/pull/3346)  
Ignore paginated_collection_renderer logs: [cloudfoundry/cloud_controller_ng/pull/3271](https://github.com/cloudfoundry/cloud_controller_ng/pull/3271)  
Exclude events table from using window function for pagination: [cloudfoundry/cloud_controller_ng/pull/3117](https://github.com/cloudfoundry/cloud_controller_ng/pull/3117)  
Raise an exception if user can read globally: [cloudfoundry/cloud_controller_ng/pull/3009](https://github.com/cloudfoundry/cloud_controller_ng/pull/3009)  
Reduce db queries for /organizations/:guid/domains: [cloudfoundry/cloud_controller_ng/pull/2997](https://github.com/cloudfoundry/cloud_controller_ng/pull/2997)  
Remove unnecessary db query as admin user for:  
- organization_quotas: [cloudfoundry/cloud_controller_ng/pull/2995](https://github.com/cloudfoundry/cloud_controller_ng/pull/2995)  
- update_route_destinations: [cloudfoundry/cloud_controller_ng/pull/2986](https://github.com/cloudfoundry/cloud_controller_ng/pull/2986)  

Ignore sequel_pg logs: [cloudfoundry/cloud_controller_ng/pull/2982](https://github.com/cloudfoundry/cloud_controller_ng/pull/2982)  
Add an unique index to service_instance_operations: [cloud_controller_ng/pull/2929](https://github.com/cloudfoundry/cloud_controller_ng/pull/2929)  
Add delete on cascade to fk_svc_inst_op_svc_instance_id: [cloud_controller_ng/pull/2905](https://github.com/cloudfoundry/cloud_controller_ng/pull/2905)  
Add index for attempts in delayed_jobs table (co-author): [cloudfoundry/cloud_controller_ng/pull/2687](https://github.com/cloudfoundry/cloud_controller_ng/pull/2687)  
Add index for delayed_job_guid in jobs table: [cloudfoundry/cloud_controller_ng/pull/2684](https://github.com/cloudfoundry/cloud_controller_ng/pull/2684)  
Improve performance when roles are queried by admin user: [cloud_controller_ng/pull/2664](https://github.com/cloudfoundry/cloud_controller_ng/pull/2664)  
Adapt presenter_args function: [cloudfoundry/cloud_controller_ng/pull/2650](https://github.com/cloudfoundry/cloud_controller_ng/pull/2650)  
Reduce db calls in /v3/domains: [cloudfoundry/cloud_controller_ng/pull/2638](https://github.com/cloudfoundry/cloud_controller_ng/pull/2638)  
Reduce db calls in /v3/security_groups and /v3/space_quotas/: [cloudfoundry/cloud_controller_ng/pull/2624](https://github.com/cloudfoundry/cloud_controller_ng/pull/2624)  


### capi-release  
The failed_jobs cleanup job should run more often than once per day: [cloudfoundry/capi-release/pull/332](https://github.com/cloudfoundry/capi-release/pull/332)  

### cf-performance-tests  
Performance tests for v3/audit_events: [cloudfoundry/cf-performance-tests/pull/25](https://github.com/cloudfoundry/cf-performance-tests/pull/25)  
Performance tests for v3 service_plans (co-author): [cloudfoundry/cf-performance-tests/pull/8](https://github.com/cloudfoundry/cf-performance-tests/pull/8)  

### Slack Conversations
Options for update docker credentials in v3: https://cloudfoundry.slack.com/archives/C07C04W4Q/p1698765593144919