### PR TITLE
Update audit event names in readiness healthcheck RFC

### DIFF
--- a/toc/rfc/rfc-0020-readiness-healthchecks.md
+++ b/toc/rfc/rfc-0020-readiness-healthchecks.md
@@ -157,11 +157,14 @@ to route pool". When AI readiness healthcheck fails a log line is printed to AI
 logs: "Container failed the readiness health check. Container marked not ready
 and removed from route pool".
 
-#### App events
+#### App Audit events
 
-When AI readiness healthcheck succeeds a new application event is emitted:
-"app.ready". When AI readiness healthcheck fails a new event is emitted:
-"app.notready".
+When the liveness healthchecks fail, it results in the following audit events:
+`audit.app.process.crash` and `audit.app.process.rescheduling`.
+
+Similarly, when AI readiness healthcheck succeeds a new application event should be emitted:
+`audit.app.process.ready`. And when AI readiness healthcheck fails a new event should be emitted:
+`audit.app.process.notready`.
 
 ### Open Questions
 * What metrics would be helpful for app devs and operators?

--- a/toc/rfc/rfc-0020-readiness-healthchecks.md
+++ b/toc/rfc/rfc-0020-readiness-healthchecks.md
@@ -159,8 +159,7 @@ and removed from route pool".
 
 #### App Audit Events
 
-When the liveness healthchecks fail, it results in the following audit events:
-`audit.app.process.crash` and `audit.app.process.rescheduling`.
+When a liveness healthcheck fails, it results in the `audit.app.process.crash` audit event.
 
 Similarly, when an AI readiness healthcheck succeeds an `audit.app.process.ready` event should be emitted.
 And when an AI readiness healthcheck fails an `audit.app.process.notready` event should be emitted.

--- a/toc/rfc/rfc-0020-readiness-healthchecks.md
+++ b/toc/rfc/rfc-0020-readiness-healthchecks.md
@@ -157,7 +157,7 @@ to route pool". When AI readiness healthcheck fails a log line is printed to AI
 logs: "Container failed the readiness health check. Container marked not ready
 and removed from route pool".
 
-#### App Audit events
+#### App Audit Events
 
 When the liveness healthchecks fail, it results in the following audit events:
 `audit.app.process.crash` and `audit.app.process.rescheduling`.

--- a/toc/rfc/rfc-0020-readiness-healthchecks.md
+++ b/toc/rfc/rfc-0020-readiness-healthchecks.md
@@ -162,9 +162,8 @@ and removed from route pool".
 When the liveness healthchecks fail, it results in the following audit events:
 `audit.app.process.crash` and `audit.app.process.rescheduling`.
 
-Similarly, when AI readiness healthcheck succeeds a new application event should be emitted:
-`audit.app.process.ready`. And when AI readiness healthcheck fails a new event should be emitted:
-`audit.app.process.notready`.
+Similarly, when an AI readiness healthcheck succeeds an `audit.app.process.ready` event should be emitted.
+And when an AI readiness healthcheck fails an `audit.app.process.notready` event should be emitted.
 
 ### Open Questions
 * What metrics would be helpful for app devs and operators?


### PR DESCRIPTION
Rename app process audit events to better match the liveness healthcheck