### PR TITLE
Add bosh-ali-storage-cli project

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -172,6 +172,10 @@ orgs:
         description: Go CLI for Azure storage
         has_projects: true
         default_branch: main
+      bosh-ali-storage-cli:
+        description: Go CLI for Alibaba storage
+        has_projects: true
+        default_branch: main
       bosh-backup-and-restore:
         has_projects: true
         homepage: https://docs.cloudfoundry.org/bbr

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -251,6 +251,7 @@ areas:
   - cloudfoundry/bosh-aws-light-stemcell-builder
   - cloudfoundry/bosh-azure-cpi-release
   - cloudfoundry/bosh-azure-storage-cli
+  - cloudfoundry/bosh-ali-storage-cli
   - cloudfoundry/bosh-bbl-ci-envs
   - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-bootloader-ci-envs


### PR DESCRIPTION
- This project allows BOSH to use Alibaba blobstores. Same as bosh-s3cli allows BOSH to use AWS blobstores.