### PR TITLE
Added Cryogenics-CI to the bot group

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -49,6 +49,8 @@ bots:
   github: cf-logging-metrics-bot
 - name: Metric Store Bot
   github: svcboteos
+- name: Cryogenics CI bot
+  github: Cryogenics-CI
 config:
   generate_rfc0015_branch_protection_rules: true
   github_project_sync:


### PR DESCRIPTION
This account is a bot account used by the cryogenics team for CI related activities.

This PR adds this user to the Bot grup.