### PR TITLE
Remove tarpinian from contributors

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -584,7 +584,6 @@ contributors:
 - tanzeeb
 - tanzu-backstage-bot
 - Tallicia
-- tarpinian
 - tas-runtime-bot
 - tcdowney
 - teddyking


### PR DESCRIPTION
Org automation fails because @tarpinian is not a cloudfoundry org member (anymore) and rejected the org invitation (this is my assumption at least).
https://github.com/cloudfoundry/community/actions/runs/7110369565/job/19356764596

According to [rfc-0008-role-change-process](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0008-role-change-process.md), @tarpinian has 2 weeks time to object the removal. In order to get the org automation working again, I propose to merge this PR right away and offer a fastlane for re-adding in case @tarpinian objects.
