### PR TITLE
service-manangement-wg: Add temporary group for area bot with admin permissions

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2479,3 +2479,20 @@ orgs:
           haproxy-boshrelease: admin
           pcap-release: admin
           pcap: admin
+      temp-sm-csb-bots-admins:
+        description: "Temporary team to allow for bots driven dependency bumps until we implement another strategy"
+        maintainers:
+          - pivotal-marcela-campo
+        members:
+          - servicesenablement
+        privacy: closed
+        repos:
+          cloud-service-broker: admin
+          csb-brokerpak-azure: admin
+          csb-brokerpak-aws: admin
+          csb-brokerpak-gcp: admin
+          jdbctestapp: admin
+          upgrade-all-services-cli-plugin: admin
+          terraform-provider-csbpg: admin
+          terraform-provider-csbmysql: admin
+          terraform-provider-csbsqlserver: admin

--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -563,6 +563,7 @@ contributors:
 - sebGilR
 - selzoc
 - services-api-ci
+- servicesenablement
 - sethboyles
 - sg038444
 - shamus


### PR DESCRIPTION
This bot bumps dependencies regularly and requires admin credentials. We are putting this group in place until we are able to implement another strategy (e.g. PR workflow).