### PR TITLE
remove members who have left VMware

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -79,8 +79,6 @@ contributors:
 - Birdrock
 - bkeelapudi
 - blgm
-- blora1
-- bobbygeeze
 - bonzofenix
 - bosh-admin-bot
 - bosh-ci-push-pull

--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -48,10 +48,6 @@ areas:
     github: fifthposition
   - name: Ajayan Borys
     github: HenryBorys
-  - name: Bob Graczyk
-    github: bobbygeeze
-  - name: Lora Boe
-    github: blora1
 
   repositories:
   - cloudfoundry/docs-book-cloudfoundry


### PR DESCRIPTION
Bob G and Lora B were contractors with the VMware TAS group, and they both left when Broadcom took over.