### PR TITLE
Add default branch for otel-collector-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1860,6 +1860,7 @@ orgs:
           in Vancouver '
         has_projects: true
       otel-collector-release:
+        default_branch: main
         description: BOSH release for the OpenTelemetry Collector
         has_projects: false
       overview-broker:


### PR DESCRIPTION
Default branch for otel-collector-release is main.

Because the default branch assumed by the branch protection automation is `master`, if we don't set this property we don't get any branch protection on our default branch in the otel-collector-release.