### PR TITLE
add bosh-apt-resources repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -176,6 +176,10 @@ orgs:
         description: Go CLI for Alibaba storage
         has_projects: true
         default_branch: main
+      bosh-apt-resources:
+        description: Builds debian packages for public bosh apt repository
+        has_projects: false
+        has_wiki: false
       bosh-backup-and-restore:
         has_projects: true
         homepage: https://docs.cloudfoundry.org/bbr

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -252,6 +252,7 @@ areas:
   - cloudfoundry/bosh-azure-cpi-release
   - cloudfoundry/bosh-azure-storage-cli
   - cloudfoundry/bosh-ali-storage-cli
+  - cloudfoundry/bosh-apt-resources
   - cloudfoundry/bosh-bbl-ci-envs
   - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-bootloader-ci-envs


### PR DESCRIPTION
add a repo for the bosh-apt-resources.

this repository wil hold the pipeline and its scripts to create and maintain a apt repository
that will include the
- bosh-cli
- bosh-bootloader cli
- etc