### PR TITLE
Add Pranay Raj

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -518,6 +518,7 @@ contributors:
 - rosenhouse
 - roshan-a
 - routing-ci
+- rpranay1
 - rroberts2222
 - rszumlakowski
 - runtime-ci


### PR DESCRIPTION
Pranay will be taking over metric store product and needs to be added as a cloudfoundry contributor.