### PR TITLE
Add new Metric Store members

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -18,6 +18,7 @@ contributors:
 - acrmp
 - acvwilson
 - addytripathi
+- aditya267vmware
 - adobley
 - aduffeck
 - advpetc
@@ -129,6 +130,7 @@ contributors:
 - cf-zapier
 - cfdocs-bot
 - cfryanr
+- chaitanyamullangi
 - chaomonica
 - christianang
 - christo4ferris
@@ -171,6 +173,7 @@ contributors:
 - devtdeng
 - dgolds
 - dhrapson
+- dibya1947
 - djac
 - djavos-bot
 - dlresende
@@ -187,11 +190,13 @@ contributors:
 - draganm
 - drich10
 - dsabeti
+- dsanand22
 - dsboulder
 - dsharp-pivotal
 - dsyer
 - dtillman
 - dtimm
+- dubeyshefali
 - dumez-k
 - ebroberson
 - edespino
@@ -296,6 +301,7 @@ contributors:
 - jkjell
 - jkonicki
 - jmarrero
+- jmervinnirma
 - jncd
 - jochenehret
 - joeeltgroth
@@ -316,8 +322,10 @@ contributors:
 - julian-hj
 - Justin-W
 - k1tm
+- kabathla
 - KaiHofstetter
 - kaleo211
+- karthikseshadri
 - kartiklunkad26
 - kathap
 - kauana
@@ -338,6 +346,7 @@ contributors:
 - knm3000
 - kohara88
 - korifi-bot
+- kpujadev
 - kreinecke
 - kriscott
 - krook
@@ -356,6 +365,7 @@ contributors:
 - loganloganlogan
 - lterminasyan
 - lwoydziak
+- m-thavaf
 - maheshkumarvs
 - malba
 - malik-altaf
@@ -402,12 +412,14 @@ contributors:
 - mrdavidlaing
 - mrosecrance
 - msmykowski
+- mukeshkhicher-br
 - mvach
 - mvalliath
 - myeghiazarya
 - N00BEST
 - n4wei
 - nader-ziada
+- nakulogale-cb
 - nand2
 - natalieparellano
 - navdeep-pama
@@ -484,6 +496,7 @@ contributors:
 - qibobo
 - qu1queee
 - rade
+- radhavmwtnz
 - radito3
 - ragaskar
 - rahulkj
@@ -516,11 +529,13 @@ contributors:
 - rosenhouse
 - roshan-a
 - routing-ci
+- rpranay1
 - rroberts2222
 - rszumlakowski
 - runtime-ci
 - ryanwittrup
 - s4heid
+- saloni-sshah
 - salzmannsusan
 - sampeinado
 - Samze
@@ -535,11 +550,14 @@ contributors:
 - selzoc
 - services-api-ci
 - sethboyles
+- sg038444
 - shamus
 - Shanfan
 - shanks3012
 - shaun7pan
 - shilpachandrashekara
+- shrisha-c
+- siddarthalk
 - silvestre
 - simonjjones
 - simonleung8
@@ -554,6 +572,7 @@ contributors:
 - squeedee
 - ssapra
 - ssisil
+- ssunka
 - st3v
 - staylor14
 - stefanlay

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -272,6 +272,44 @@ areas:
   approvers:
   - name: Jeanette Booher
     github: jbooherl
+  - name: Aditya Choudhary
+    github: aditya267vmware
+  - name: Chaitanya Krishna Mullangi
+    github: chaitanyamullangi
+  - name: Dibyajyoti Mohapatra
+    github: dibya1947
+  - name: Kanika Bathla
+    github: kabathla
+  - name: Karthik Seshadri
+    github: karthikseshadri
+  - name: Mervin Nirmal John M W
+    github: jmervinnirma
+  - name: Mohammed Thavaf A R
+    github: m-thavaf
+  - name: Mukesh Khicher
+    github: mukeshkhicher-br
+  - name: Nakul Ogale
+    github: nakulogale-cb
+  - name: Pranay Raj
+    github: rpranay1
+  - name: Puja Kumari
+    github: kpujadev
+  - name: Radhakrishnan Devarajan
+    github: radhavmwtnz
+  - name: Saloni Shah
+    github: saloni-sshah
+  - name: Sanand Dange
+    github: dsanand22
+  - name: Shefali Dubey
+    github: dubeyshefali
+  - name: Shrisha Chandrashekar
+    github: shrisha-c
+  - name: Siddartha Laxman Karibhimanvar
+    github: siddarthalk
+  - name: Srinivas Sunka
+    github: ssunka
+  - name: Sudharsan G V
+    github: sg038444
   - name: Hovhannes Manukyan
     github: hmanukyanVMw
   - name: Gevorg Gevorgyan


### PR DESCRIPTION
Updated to add all the new members of metric store and removing the members that were not asked to continue with Broadcom.