### PR TITLE
Enable merge commits in diego/garden/netwrk repos

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -67,17 +67,14 @@ orgs:
         archived: true
         has_projects: true
       archiver:
-        allow_merge_commit: false
         description: Utilities for extracting and compressing tgz and zip files.
         has_issues: false
         has_projects: true
       auction:
-        allow_merge_commit: false
         description: Auction encodes Diego's long-running-process distribution algorithm
         has_issues: false
         has_projects: true
       auctioneer:
-        allow_merge_commit: false
         description: Runs diego auctions
         has_issues: false
         has_projects: true
@@ -94,12 +91,10 @@ orgs:
         description: a concourse resource for manipulating bbl states
         has_projects: true
       bbs:
-        allow_merge_commit: false
         description: Internal API to access the database for Diego.
         has_issues: false
         has_projects: true
       benchmarkbbs:
-        allow_merge_commit: false
         description: Diego BBS Benchmark
         has_issues: false
         has_projects: true
@@ -465,12 +460,10 @@ orgs:
         has_projects: true
         private: true
       bytefmt:
-        allow_merge_commit: false
         description: Human readable byte formatter
         has_issues: false
         has_projects: true
       cacheddownloader:
-        allow_merge_commit: false
         description: A cached HTTP blob downloader
         has_issues: false
         has_projects: true
@@ -535,7 +528,6 @@ orgs:
         default_branch: main
         has_projects: true
       certsplitter:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       cf-acceptance-tests:
@@ -644,7 +636,6 @@ orgs:
         has_wiki: false
         private: true
       cf-networking-helpers:
-        allow_merge_commit: false
         default_branch: main
         description: Shared libraries for the CF Networking team
         has_projects: false
@@ -655,7 +646,6 @@ orgs:
           area of CF
         has_projects: true
       cf-networking-release:
-        allow_merge_commit: false
         default_branch: develop
         description: Container Networking for CloudFoundry
         has_projects: true
@@ -678,7 +668,6 @@ orgs:
         default_branch: main
         has_projects: true
       cf-routing-test-helpers:
-        allow_merge_commit: false
         default_branch: main
         has_projects: true
       cf-slackin:
@@ -693,7 +682,6 @@ orgs:
         default_branch: main
         has_projects: true
       cf-tcp-router:
-        allow_merge_commit: false
         default_branch: main
         description: TCP Router repository for Cloud Foundry
         has_projects: true
@@ -762,7 +750,6 @@ orgs:
       cfcd-prep:
         has_projects: true
       cfdot:
-        allow_merge_commit: false
         description: A command-line tool to interact with a Cloud Foundry Diego deployment.
         has_issues: false
         has_projects: true
@@ -779,7 +766,6 @@ orgs:
         has_projects: true
         private: true
       cfhttp:
-        allow_merge_commit: false
         description: Wrapper for official go http package
         has_issues: false
         has_projects: true
@@ -843,7 +829,6 @@ orgs:
         has_projects: true
         has_wiki: false
       clock:
-        allow_merge_commit: false
         default_branch: main
         description: time provider & rich fake for Go
         has_issues: false
@@ -898,7 +883,6 @@ orgs:
         default_branch: main
         has_projects: true
       consuladapter:
-        allow_merge_commit: false
         description: Consul client adapter and test cluster runner
         has_issues: false
         has_projects: true
@@ -961,7 +945,6 @@ orgs:
         archived: true
         has_projects: true
       debugserver:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       delayed_job_sequel:
@@ -1011,7 +994,6 @@ orgs:
         has_projects: true
         private: true
       diego-acceptance:
-        allow_merge_commit: false
         description: Diego PM acceptance notes and tools
         has_projects: true
         private: true
@@ -1026,16 +1008,13 @@ orgs:
         description: Diego Architectural Design Musings and Explications
         has_projects: true
       diego-dockerfiles:
-        allow_merge_commit: false
         has_issues: false
         has_projects: false
         has_wiki: false
       diego-logging-client:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       diego-notes:
-        allow_merge_commit: false
         description: Diego Notes
         has_projects: true
       diego-perf-release:
@@ -1043,12 +1022,10 @@ orgs:
           a Diego(+Runtime) deployment
         has_projects: true
       diego-release:
-        allow_merge_commit: false
         default_branch: develop
         description: BOSH Release for Diego
         has_projects: true
       diego-ssh:
-        allow_merge_commit: false
         description: Access Diego containers with ssh
         has_issues: false
         has_projects: true
@@ -1056,7 +1033,6 @@ orgs:
         description: Diego Stress Tests
         has_projects: true
       diego-team:
-        allow_merge_commit: false
         description: Checklists for the Diego team
         has_projects: true
         private: true
@@ -1083,11 +1059,9 @@ orgs:
       docker_driver_integration_tests:
         has_projects: true
       dockerapplifecycle:
-        allow_merge_commit: false
         description: Code that runs inside of containers, for docker-based apps
         has_projects: true
       dockerdriver:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       docs-bbr:
@@ -1171,11 +1145,9 @@ orgs:
         has_projects: true
         private: true
       durationjson:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       ecrhelper:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       eirini:
@@ -1218,13 +1190,11 @@ orgs:
         has_projects: true
         archived: true
       eventhub:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       example-sidecar-buildpack:
         has_projects: true
       executor:
-        allow_merge_commit: false
         description: thy will be done
         has_issues: false
         has_projects: true
@@ -1238,7 +1208,6 @@ orgs:
       filelock:
         has_projects: true
       fileserver:
-        allow_merge_commit: false
         description: 'Bob Loblaw''s file server '
         has_issues: false
         has_projects: true
@@ -1379,7 +1348,6 @@ orgs:
         archived: true
         has_projects: true
       gorouter:
-        allow_merge_commit: false
         default_branch: main
         description: CF Router
         has_projects: true
@@ -1421,7 +1389,6 @@ orgs:
         description: A BOSH release for haproxy (based on cf-release's haproxy job)
         has_projects: true
       healthcheck:
-        allow_merge_commit: false
         description: Common healthcheck for buildpacks and docker
         has_issues: false
         has_projects: true
@@ -1470,7 +1437,6 @@ orgs:
         has_wiki: false
         private: true
       inigo:
-        allow_merge_commit: false
         description: diego integration tests
         has_issues: false
         has_projects: true
@@ -1576,7 +1542,6 @@ orgs:
         default_branch: main
         has_projects: false
       lager:
-        allow_merge_commit: false
         description: An opinionated logger for Go.
         has_projects: true
       lamb-ci-tools:
@@ -1609,15 +1574,12 @@ orgs:
         archived: true
         has_projects: true
       localdriver:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       localip:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       locket:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       log-cache:
@@ -1775,13 +1737,11 @@ orgs:
       mysql-monitoring-release:
         has_projects: true
       nats-release:
-        allow_merge_commit: false
         default_branch: develop
         has_projects: true
       netplugin-shim:
         has_projects: true
       networking-oss-deployments:
-        allow_merge_commit: false
         default_branch: main
         description: bbl state store for networking oss deployments
         has_projects: true
@@ -1852,7 +1812,6 @@ orgs:
         archived: true
         has_projects: true
       operationq:
-        allow_merge_commit: false
         description: processes multiple queues in parallel
         has_issues: false
         has_projects: true
@@ -1988,7 +1947,6 @@ orgs:
         has_projects: true
         private: true
       rep:
-        allow_merge_commit: false
         description: Representative bids on tasks and schedules them on an associated
           Executor
         has_issues: false
@@ -2000,28 +1958,23 @@ orgs:
         has_projects: true
         archived: true
       route-emitter:
-        allow_merge_commit: false
         description: Registers and unregisters processes running on executors with
           the gorouter
         has_issues: false
         has_projects: true
       route-registrar:
-        allow_merge_commit: false
         default_branch: main
         description: A standalone executable written in golang that continuously broadcasts
           a route using NATS to the CF router.
         has_projects: true
       routing-acceptance-tests:
-        allow_merge_commit: false
         default_branch: main
         has_projects: true
       routing-api:
-        allow_merge_commit: false
         default_branch: main
         has_projects: false
         has_wiki: false
       routing-api-cli:
-        allow_merge_commit: false
         default_branch: main
         has_projects: true
       routing-ci:
@@ -2035,18 +1988,15 @@ orgs:
         has_projects: true
         private: true
       routing-info:
-        allow_merge_commit: false
         default_branch: main
         description: Routing information helpers for CF / Diego
         has_projects: true
       routing-perf-release:
-        allow_merge_commit: false
         default_branch: main
         description: A BOSH release for routing performance tests
         has_projects: false
         has_wiki: false
       routing-release:
-        allow_merge_commit: false
         default_branch: develop
         description: This is the BOSH release for cloud foundry routers
         has_projects: true
@@ -2172,7 +2122,6 @@ orgs:
           for Cloud Foundry.
         has_projects: true
       silk-release:
-        allow_merge_commit: false
         default_branch: develop
         description: Silk - CNI plugin BOSH release for Cloud Foundry
         has_projects: true
@@ -2319,7 +2268,6 @@ orgs:
       test-log-emitter-release:
         has_projects: true
       tlsconfig:
-        allow_merge_commit: false
         description: build tls configurations
         has_projects: false
         has_wiki: false
@@ -2396,12 +2344,10 @@ orgs:
         has_projects: true
         has_wiki: false
       vizzini:
-        allow_merge_commit: false
         description: 'Vizzini: Inconceivable Tests'
         has_issues: false
         has_projects: true
       volman:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       volume-mount-options:
@@ -2448,7 +2394,6 @@ orgs:
         default_branch: develop
         has_projects: true
       workpool:
-        allow_merge_commit: false
         has_issues: false
         has_projects: true
       yagnats:


### PR DESCRIPTION
This commit removes the restrictions on using the `Merge commit` strategy to accept PRs in the repos managed by the following working groups:
- Diego
- Garden Containers
- Networking

My understanding is that at some point someone manually disabled merge commits for (some of) our repos because they felt like it. This happened before the repo settings were managed by the TOC / the cf community repo tooling, then these settings were persisted. This config will enable merge commits so we don't have to rebase or squash every single PR.