### PR TITLE
Archive garden-windows-ci repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1266,6 +1266,7 @@ orgs:
         private: true
       garden-windows-ci:
         has_projects: true
+        archived: true
       garden-windows-tools-release:
         has_projects: true
       git-release-notes:

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -192,7 +192,6 @@ areas:
   - cloudfoundry/garden-performance-acceptance-tests
   - cloudfoundry/garden-runc-release
   - cloudfoundry/garden-wiki
-  - cloudfoundry/garden-windows-ci
   - cloudfoundry/garden-windows-tools-release
   - cloudfoundry/groot
   - cloudfoundry/groot-windows


### PR DESCRIPTION
Recently we had some issues with the windows-rootfs pipeline failing because of its references to both [garden-windows-ci](https://github.com/cloudfoundry/garden-windows-ci) and the [WG CI repo](https://github.com/cloudfoundry/wg-app-platform-runtime-ci). The conflict arose because we have some opsfiles that have the same name, but different functionality. We were able to fix this by removing the bad opsfile, but it would be better if we had one source of truth for our CI pipelines.

Since `garden-windows-ci` is no longer referenced by our pipelines and the relevant files are now in the WG CI repo, we should archive `garden-windows-ci`.