### PR TITLE
Archive garden-dockerfiles

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1247,6 +1247,7 @@ orgs:
         has_projects: true
       garden-dockerfiles:
         has_projects: true
+        archived: true
       garden-dotfiles:
         has_projects: true
       garden-dotfiles-archived:


### PR DESCRIPTION
https://github.com/cloudfoundry/wg-app-platform-runtime-ci has been created to aggregate all docker images and pipelines in the Application Runtime Group.