### PR TITLE
Clean roles of removed users

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2412,7 +2412,6 @@ orgs:
         maintainers:
         - arjun024
         - brayanhenao
-        - ryanmoran
         - sophiewigmore
         members: []
         privacy: closed


### PR DESCRIPTION
ryanmoran has been removed from the cloudfoundry org with this [pr](https://github.com/cloudfoundry/community/pull/719). The is still a role assigned to him which fails the org automation