### PR TITLE
Add Vulnerability Management WG contributors

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -265,6 +265,7 @@ contributors:
 - ifindlay-cci
 - IgorBelyi
 - ihcsim
+- ijzerman
 - ikasarov
 - ilackarms
 - iplay88keys
@@ -544,6 +545,7 @@ contributors:
 - simonjjones
 - simonleung8
 - skibum55
+- skhushboo-vm
 - smoser-ibm
 - snneji
 - Soha-Albaghdady


### PR DESCRIPTION
With [pr](https://github.com/cloudfoundry/community/pull/746) we introduced roles yaml for the VM WG. We missed to add the members as contributors with that pr.