### PR TITLE
[ARI] Add Stephan as ARI Execution Lead

### DIFF
--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -81,6 +81,7 @@ The GitHub repos this WG manages in the `cloudfoundry` GitHub organization are t
 | &nbsp;                                                   | Leads            | Company | Profile                                  |
 | -------------------------------------------------------- | ---------------- | ------- | ---------------------------------------- |
 | <img width="30px" src="https://github.com/Gerg.png"> | Greg Cobb     | VMware  | [@Gerg](https://github.com/Gerg) |
+| <img width="30px" src="https://github.com/stephanme.png"> | Stephan Merker     | SAP  | [@stephanme](https://github.com/stephanme) |
 
 
 ## App Runtime Platform

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -35,8 +35,8 @@ Components from the App Autoscaler, CAPI, CLI, Java Tools, MultiApps, and Notifi
 ```yaml
 name: App Runtime Interfaces
 execution_leads:
-- name: Greg Cobb
-  github: gerg
+- name: Stephan Merker
+  github: stephanme
 technical_leads:
 - name: Greg Cobb
   github: gerg


### PR DESCRIPTION
As I announced in the most recent TOC meeting, I will be going on parental leave for 3 months, scheduled to begin in early February. To help keep ARI running smoothly while I'm out, it's important to have someone in the lead role, either provisionally or permanently as a co-lead.

ARI is a large and diverse working group, and I believe it would be valuable going forward to have a dedicated execution lead, even after I return from my leave. 

To fill this role, I nominate @stephanme. Stephan has been an active participant in the working group for a long time, most notably via his contributions to the CAPI area and the monthly CAPI office hours. You may also know him from his position on the CFF TOC 😄.