### PR TITLE
Remove individual repo access via github action

### DIFF
--- a/.github/workflows/remove-individual-access.yml
+++ b/.github/workflows/remove-individual-access.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: community
-      - name: Generate github org configuration
+      - name: Remove individual access to repos
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |

--- a/.github/workflows/remove-individual-access.yml
+++ b/.github/workflows/remove-individual-access.yml
@@ -23,6 +23,6 @@ jobs:
           community/org/generate_working_group_projects_sync_config.sh | jq -r .[].repositories[].name | grep -E "^cloudfoundry/" | while read -r repo; do
               gh api "repos/${repo}/collaborators?affiliation=direct" | jq -r .[].login | while read -r user; do
                   echo "remove ${user} from ${repo}"
-                  # gh api -X delete "/repos/${repo}/collaborators/${user}"
+                  gh api -X delete "/repos/${repo}/collaborators/${user}"
               done
           done


### PR DESCRIPTION
You can see a dry run of the github action [here](https://github.com/cloudfoundry/community/actions/runs/7576159899/job/20634338969). It prints out everyone who will have their access removed.

fixes #528  