### PR TITLE
Run peribolos and branchprotector in separate jobs

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -9,7 +9,7 @@ on:
       - 'toc/working-groups/*.md'
       - '.github/workflows/org-management.yml'
   schedule:
-    - cron: '0 */5 * * *'
+    - cron: '0 */7 * * *'
 
 jobs:
   peribolos:
@@ -73,6 +73,47 @@ jobs:
             --fix-team-members
             --fix-team-repos
             --allow-repo-archival
+  branchprotector:
+    needs: peribolos
+    runs-on: ubuntu-latest
+    concurrency:
+      group: peribolos
+    services:
+      ghproxy:
+        image: rkoster/ghproxy
+        options: >-
+          --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly
+          --mount type=bind,source=/etc/group,target=/etc/group,readonly
+        ports:
+          - 8888:8888
+        volumes:
+          - ${{ github.workspace }}/ghproxy-cache:/cache
+    steps:
+      - name: ghproxy-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ghproxy-cache
+          key: ghproxy-cache-${{ github.run_number }}
+          restore-keys: |
+            ghproxy-cache-
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - uses: actions/checkout@v3
+        with:
+          path: community
+      - name: Generate github org configuration
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r community/org/requirements.txt
+          python community/org/org_management.py -o cloudfoundry.out.yml -b branchprotection.out.yml
+      - name: write github private key
+        run: |
+          echo "${GH_PRIVATE_KEY}" > private_key
+          echo "${GH_TOKEN}" > token
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
       - name: branchprotector
         id: branchprotector
         uses: docker://gcr.io/k8s-prow/branchprotector


### PR DESCRIPTION
- combined runtime exceeds 6h, the max possible runtime of a github action  job
- reduce scheduled frequency