### PR TITLE
Remove garden-dockerfiles from Runtime

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -186,7 +186,6 @@ areas:
   - cloudfoundry/garden
   - cloudfoundry/garden-ci
   - cloudfoundry/garden-ci-artifacts-release
-  - cloudfoundry/garden-dockerfiles
   - cloudfoundry/garden-dotfiles
   - cloudfoundry/garden-integration-tests
   - cloudfoundry/garden-performance-acceptance-tests


### PR DESCRIPTION
garden-dockerfiles is being archived and should be removed from the Runtime WG

https://github.com/cloudfoundry/community/pull/751