### PR TITLE
Archive the vanta-blackbox-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2343,6 +2343,7 @@ orgs:
       usn-resource:
         has_projects: true
       vantablackbox-release:
+        archived: true
         has_projects: true
       vcap-common:
         archived: true

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -203,7 +203,6 @@ areas:
   - cloudfoundry/netplugin-shim
   - cloudfoundry/test-log-emitter
   - cloudfoundry/test-log-emitter-release
-  - cloudfoundry/vantablackbox-release
   - cloudfoundry/winc
   - cloudfoundry/winc-release
   - cloudfoundry/windows-regression-tests


### PR DESCRIPTION
👋 We're cleaning up old things that aren't used anymore. The vantablackbox-release was a release that would submit metrics from the Garden team's long-running environments to WaveFront. Those environments don't exist anymore, nor do the WaveFront dashboards. We do not believe anyone else is using this boshrelease, as it's not listed in bosh.io, and has had no substantive activity in 4 years aside.

We would like to archive it please.