### PR TITLE
Bump version of github actions

### DIFF
--- a/.github/workflows/org-inactive-user-management.yml
+++ b/.github/workflows/org-inactive-user-management.yml
@@ -12,10 +12,10 @@ jobs:
   org-config-generation-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: community
       - name: Clean inactive github org users
@@ -29,7 +29,7 @@ jobs:
           INACTIVE_USER_MANAGEMENT_TAG_USERS: ${{ secrets.INACTIVE_USER_MANAGEMENT_TAG_USERS }}
       - name: Create Pull Request
         if: ${{ steps.uds.outputs.inactive_users_pr_description }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           path: community
           add-paths: org/contributors.yml

--- a/.github/workflows/org-management-check-prs.yml
+++ b/.github/workflows/org-management-check-prs.yml
@@ -10,10 +10,10 @@ jobs:
   org-config-generation-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: community
       - name: Generate github org configuration

--- a/.github/workflows/org-management-peribolos-dump.yml
+++ b/.github/workflows/org-management-peribolos-dump.yml
@@ -19,13 +19,13 @@ jobs:
           - ${{ github.workspace }}/ghproxy-cache:/cache
     steps:
       - name: ghproxy-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/ghproxy-cache
           key: ghproxy-cache-${{ github.run_number }}
           restore-keys: |
             ghproxy-cache-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full clone so a PR can be created if needed
           path: community
@@ -44,7 +44,7 @@ jobs:
           # args: --dump-full --dump cloudfoundry --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key > org/cloudfoundry.yml
           args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-token-path=token > community/org/cloudfoundry.yml"
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           path: community
           add-paths: org/cloudfoundry.yml

--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -28,16 +28,16 @@ jobs:
           - ${{ github.workspace }}/ghproxy-cache:/cache
     steps:
       - name: ghproxy-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/ghproxy-cache
           key: ghproxy-cache-${{ github.run_number }}
           restore-keys: |
             ghproxy-cache-
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: community
       - name: Generate github org configuration
@@ -90,16 +90,16 @@ jobs:
           - ${{ github.workspace }}/ghproxy-cache:/cache
     steps:
       - name: ghproxy-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/ghproxy-cache
           key: ghproxy-cache-${{ github.run_number }}
           restore-keys: |
             ghproxy-cache-
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: community
       - name: Generate github org configuration

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -8,7 +8,7 @@ jobs:
   configs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: matrix
         run: |
           echo "::set-output name=matrix::$(./org/generate_working_group_projects_sync_config.sh)"

--- a/.github/workflows/remove-individual-access.yml
+++ b/.github/workflows/remove-individual-access.yml
@@ -10,7 +10,7 @@ jobs:
   remove-individual-access-to-repos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: community
       - name: Remove individual access to repos


### PR DESCRIPTION
To get rid of deprecated nodejs 16.

- checkout: v3->v4
- cache: v3->v4
- setup-python: v4->v5
- create-pull-request: v4->v5