### PR TITLE
Allow org automation to delete up to 80% of users

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -62,6 +62,7 @@ jobs:
             --github-endpoint http://ghproxy:8888
             --required-admins=thelinuxfoundation
             --min-admins=5
+            --maximum-removal-delta=0.8
             --github-app-id=${{ secrets.GH_APP_ID }}
             --github-app-private-key-path=private_key
             --require-self=false


### PR DESCRIPTION
With (Inactive users to be deleted)[https://github.com/cloudfoundry/community/pull/736] we want to clean inactive users. This is the first run and it calculated over 400 users. The org automation doesn't allow to delete so many users at onance. This will re-configure the limit temporarily and I will revert it after the inactive users are deleted