### PR TITLE
Adds CI bot to working group

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -55,6 +55,8 @@ bots:
   github: Cryogenics-CI
 - name: bbr-ci
   github: bbr-ci
+- name: mysql-ci
+  github: pcf-core-services-writer
 areas:
 - name: Credential Management (Credhub)
   approvers:


### PR DESCRIPTION
For service account / bot, pcf-core-services-writer

To be used by the MySQL for TAS team in tile development

This account is already listed as a contributor in the [org](https://github.com/cloudfoundry/community/blob/eb170544bf1556a8d18631c7ad49b59146fce536/org/contributors.yml#L447C3-L447C27)

Authored-by: Ryan Wittrup <rwittrup@vmware.com>