### PR TITLE
[ARI] Add temp autoscaler team for managing GitHub secrets

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2470,6 +2470,19 @@ orgs:
           multiapps: admin
           multiapps-controller: admin
           multiapps-cli-plugin: admin
+      temp-autoscaler-admins:
+        description: "Temporary team for managing autoscaler secrets until we have a permanent plan."
+        maintainers:
+        - asalan316
+        - silvestre
+        - joergdw
+        - olivermautschke
+        members: []
+        privacy: closed
+        repos:
+          app-autoscaler-release: admin
+          app-autoscaler-cli-plugin: admin
+          app-runtime-interfaces-infrastructure: admin
       temp-arp-networking-admins:
         description: "Temporary team for managing GitHub integrations for automation/concourse."
         maintainers:

--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2470,7 +2470,7 @@ orgs:
           multiapps: admin
           multiapps-controller: admin
           multiapps-cli-plugin: admin
-      temp-autoscaler-admins:
+      temp-ari-autoscaler-admins:
         description: "Temporary team for managing autoscaler secrets until we have a permanent plan."
         maintainers:
         - asalan316


### PR DESCRIPTION
Without admin access we can no longer maintain GitHub Actions secrets.

Prior art for admin override teams: #441 + #691
