### PR TITLE
Fix path to `contributions-for-user.sh` in example

### DIFF
--- a/toc/ROLES.md
+++ b/toc/ROLES.md
@@ -303,7 +303,7 @@ approver in an OWNERS file:
 The [contributions-for-user.sh script](https://github.com/cloudfoundry/community/blob/main/toc/working-groups/contributions-for-user.sh) can be used to help gather information from GitHub related to Issues, PRs, and code contributions. It requires the `gh` CLI, and for users to authenticate with credentials allowing Gist creation:
 
 ```
-./working-groups/contributions-for-user.sh <github username> <working group name>
+./toc/working-groups/contributions-for-user.sh <github username> <working group name>
 ```
 
 - Nominated by a WG lead (with no objections from other leads).


### PR DESCRIPTION
The path to the `contributions-for-user.sh` in the example is incorrect. Somehow, the `toc`-part of the path got forgotten. 

Seems like it has been incorrect since the very beginning https://github.com/cloudfoundry/community/commit/2811084347889fadfa3b67690756abf181bf49be#diff-2c9392e9eed3703463a000f2347fe3b461873b8b7ba8086fe6c2c5f955521ea5R306.  