### PR TITLE
Add `salzmannsusan` to approvers of `Autoscaler`

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2477,6 +2477,7 @@ orgs:
         - silvestre
         - joergdw
         - olivermautschke
+        - salzmannsusan
         members: []
         privacy: closed
         repos:

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -60,9 +60,9 @@ areas:
     github: joergdw
   - name: Oliver Mautschke
     github: olivermautschke
-  reviewers:
   - name: Susanne Salzmann
     github: salzmannsusan
+  reviewers:
   - name: Sumit Kulhadia
     github: kulhadia
   - name: Josua Geiger


### PR DESCRIPTION
`salzmannsusan` is part of an internal SAP team which is heavily involved in the development of [`cloudfoundry/app-autoscaler-release`](https://github.com/cloudfoundry/app-autoscaler-release). 

Here are her contributions in the `App Runtime Interfaces` working group (assembled with [`./toc/working-groups/contributions-for-user.sh`](https://github.com/cloudfoundry/community/blob/main/toc/working-groups/contributions-for-user.sh)

| Working Group                | Area                            | Contributions                                                       |
|------------------------------|---------------------------------|---------------------------------------------------------------------|
| App Runtime Interfaces       | Autoscaler                      | https://gist.github.com/geigerj0/be54a6a0c529b25ba9608f087f555793   |