### PR TITLE
Add svcboteos to contributors

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -202,6 +202,7 @@ contributors:
 - stefanlay
 - strehle
 - suprajanarasimhan
+- svcboteos
 - svkrieger
 - swalchemist
 - swati1102


### PR DESCRIPTION
This CI bot is used to bump [metric-store-release](https://github.com/cloudfoundry/metric-store-release) when we are about to do a new release.

It is already a part of the App Runtime Platform bots group