### PR TITLE
Remove @gcapizzi and @kieron-dev from their WGs

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -79,7 +79,6 @@ contributors:
 - fifthposition
 - FloThinksPi
 - ForestEckhardt
-- gcapizzi
 - genevieve
 - geofffranks
 - georgethebeatle
@@ -114,7 +113,6 @@ contributors:
 - kevin-ortega
 - KevinJCross
 - Kiemes
-- kieron-dev
 - kimago
 - klakin-pivotal
 - klapkov

--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -118,10 +118,11 @@ The GitHub repos this WG manages in the `cloudfoundry` GitHub organization are t
 | Meeting Notes              | [Google Doc](https://docs.google.com/document/d/1ULNBEjlrNAgn3ko9y8ZJfwI7mw5-oofYdjl-dhkEoDA/edit)  |
 | Slack Channel              | [&#x23;korifi-dev](https://cloudfoundry.slack.com/archives/C0297673ASK) |
 
-| &nbsp;                                                   | Leads            | Company | Profile                                 |
-| -------------------------------------------------------- | ---------------- | ------- | --------------------------------------- |
-| <img width="30px" src="https://github.com/georgethebeatle.png"> | Georgi Sabev       | SAP  | [@georgethebeatle](https://github.com/georgethebeatle) |
-| <img width="30px" src="https://github.com/gcapizzi.png"> | Giuseppe Capizzi       | VMware  | [@gcapizzi](https://github.com/gcapizzi) |
+| &nbsp;                                                          | Leads           | Company | Profile                                                |
+| --------------------------------------------------------------- | --------------- | ------- | ------------------------------------------------------ |
+| <img width="30px" src="https://github.com/georgethebeatle.png"> | Georgi Sabev    | SAP     | [@georgethebeatle](https://github.com/georgethebeatle) |
+| <img width="30px" src="https://github.com/Birdrock.png">        | Andrew Wittrock | VMware  | [@Birdrock](https://github.com/Birdrock)               |
+| <img width="30px" src="https://github.com/davewalter.png">      | Dave Walter     | VMware  | [@davewalter](https://github.com/davewalter)           |
 
 
 ## Docs

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -148,12 +148,8 @@ areas:
   approvers:
   - name: Danail Branekov
     github: danail-branekov
-  - name: Giuseppe Capizzi
-    github: gcapizzi
   - name: George
     github: georgethebeatle
-  - name: Kieron Browne
-    github: kieron-dev
   - name: Geoff Franks
     github: geofffranks
   - name: Josh Russett

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -55,12 +55,8 @@ areas:
     github: clintyoshimura
   - name: Danail Branekov
     github: danail-branekov
-  - name: Giuseppe Capizzi
-    github: gcapizzi
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Kieron Browne
-    github: kieron-dev
   - name: Matt Royal
     github: matt-royal
   - name: Tim Downey


### PR DESCRIPTION
This also updates `WORKING-GROUPS.md` with the new leads.