### PR TITLE
Add the bosh-windows-ci bot to the FIWG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -43,6 +43,8 @@ technical_leads:
 bots:
 - name: bosh-admin-bot
   github: bosh-admin-bot
+- name: bosh-windows-ci
+  github: bosh-windows-ci
 - name: cf-gitbot
   github: cf-gitbot
 - name: runtime-bot


### PR DESCRIPTION
Moving the bosh-windows-ci bot to the Foundational Infrastructure Working Group. This bot creates the releases for stembuild.