### PR TITLE
move benjamintf1 to approver for capi

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -293,6 +293,8 @@ areas:
     github: tcdowney
   - name: Katharina Przybill
     github: kathap
+  - name: Ben Fuller
+    github: Benjamintf1
   reviewers:
   - name: Al Berez
     github: a-b
@@ -312,8 +314,6 @@ areas:
     github: reedr3
   - name: George Gelashvili
     github: pivotalgeorge
-  - name: Ben Fuller
-    github: Benjamintf1
   - name: Cristhian Peña
     github: ccjaimes
   bots:


### PR DESCRIPTION
Hi. Long time contributor to cf. 

I've collected a few Capi Contributions:

1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3270
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3098
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/2900
1. https://github.com/cloudfoundry/capi-release/pull/266
1. https://github.com/cloudfoundry/capi-release/pull/73#issuecomment-413235080
1. https://github.com/cloudfoundry/capi-release/pull/163#issuecomment-606735820
1. https://github.com/cloudfoundry/capi-release/pull/94
1. worked with Michael Oleske on updating the capi certs for capi. 
1. https://cloudfoundry.slack.com/archives/C07C04W4Q/p1680196229614289
1. https://cloudfoundry.slack.com/archives/C07C04W4Q/p1540491354000100
1. https://cloudfoundry.slack.com/archives/C07C04W4Q/p1522165747000724
1. https://github.com/cloudfoundry/capi-ci/pull/41
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3450
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3461
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3503
1. https://github.com/cloudfoundry/cloud_controller_ng/pull/3659

And I'm looking to be more involved in capi work in the future. 