### PR TITLE
Add xiaozhu36 as approver

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -238,6 +238,8 @@ areas:
     github: selzoc
   - name: Matthias Vach
     github: mvach
+  - name: He Guimin
+    github: xiaozhu36
   reviewers:
   - name: Ahmed Hassanin
     github: a-hassanin


### PR DESCRIPTION
xiaozhu36 is the maintainer of repo [bosh-alicloud-cpi-release](https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release) and [stemcells-alicloud-index](https://github.com/cloudfoundry/stemcells-alicloud-index). As the cloudfoundry 
org requirements [pr](https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/issues/168), the two repos will move to cloudfoundry.