### PR TITLE
Move Ali Cloud CPI repo to cloudfoundry GH org

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -167,6 +167,10 @@ orgs:
         description: Go CLI for Azure storage
         has_projects: true
         default_branch: main
+      bosh-alicloud-cpi-release:
+        description: BOSH Alibaba CPI
+        has_projects: true
+        default_branch: main
       bosh-ali-storage-cli:
         description: Go CLI for Alibaba storage
         has_projects: true

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -320,6 +320,12 @@ areas:
   - cloudfoundry/windows-utilities-release
   - cloudfoundry/windows-utilities-tests
   - cloudfoundry/yagnats
+- name: Ali Cloud VM deployment lifecycle (BOSH)
+  approvers:
+  - name: He Guimin
+    github: xiaozhu36
+  repositories:
+  - cloudfoundry/bosh-alicloud-cpi-release
 config:
   github_project_sync:
     mapping:


### PR DESCRIPTION
Current home of the [bosh-alicloud-cpi-release](https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release) repository is the [cloudfoundry-incubator](https://github.com/cloudfoundry-incubator), which will be discontinued and deleted. That is why we should move the bosh-alicloud-cpi-release, which is still actively used and not any more in incubation the the Cloud Foundry GH organization.

This addresses the issue https://github.com/cloudfoundry-incubator/bosh-alicloud-cpi-release/issues/168 and should replace the open pr https://github.com/cloudfoundry/community/pull/797.