### PR TITLE
Fix default branch of bosh-ali-cloud-cpi repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -170,7 +170,7 @@ orgs:
       bosh-alicloud-cpi-release:
         description: BOSH Alibaba CPI
         has_projects: true
-        default_branch: main
+        default_branch: master
       bosh-ali-storage-cli:
         description: Go CLI for Alibaba storage
         has_projects: true


### PR DESCRIPTION
Our org [automation](https://github.com/cloudfoundry/community/actions/workflows/org-management.yml) is failing. This is an attempt to fix it. People also complained about missing approver rights https://github.com/cloudfoundry/bosh-alicloud-cpi-release/issues/168#issuecomment-2041278254