### PR TITLE
split go-uaa

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -135,11 +135,36 @@ areas:
   - cloudfoundry/identity-tools
   - cloudfoundry/omniauth-uaa-oauth2
   - cloudfoundry/uaa
-  - cloudfoundry/go-uaa
   - cloudfoundry/uaa-cli
   - cloudfoundry/uaa-key-rotator
   - cloudfoundry/uaa-release
   - cloudfoundry/uaa-singular
+- name: Identity and Auth (UAA) Go Client
+  approvers:
+  - name: Joe Fitzgerald
+    github: joefitzgerald
+  - name: Peter Chen
+    github: peterhaochen47
+  - name: Bruce Ricard
+    github: bruce-ricard
+  - name: Markus Strehle
+    github: strehle
+  - name: Hongchol Sinn
+    github: hsinn0
+  - name: Danny Faught
+    github: swalchemist
+  - name: Florian Tack
+    github: tack-sap
+  - name: Torsten Luh
+    github: torsten-sap
+  - name: Alicia Yingling
+    github: Tallicia
+  - name: Adrian Hoelzl
+    github: adrianhoelzl-sap
+  - name: Klaus Kiefer
+    github: klaus-sap
+  repositories:
+  - cloudfoundry/go-uaa
 - name: Integrated Databases (Mysql / Postgres)
   approvers:
   - name: Andrew Garner


### PR DESCRIPTION
Per the instructions in https://github.com/cloudfoundry/community/pull/801#issuecomment-2042393959, this splits go-uaa from the rest of the UAA repos so that I can continue to merge PRs as the original author and maintainer of the library.

/cc @strehle 