### PR TITLE
fix(app-autoscaler-release): allow admins to bypass required status checks

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -114,7 +114,7 @@ branch-protection:
         # App-Autoscaler
         app-autoscaler-release:
           protect: true
-          enforce_admins: true
+          enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
# Problem
The release pipeline of `app-autoscaler-release` is broken because the CI-user is no longer allowed to push directly to `main` since all required status checks must pass.


```bash
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: error: Changes must be made through a pull request. 11 of 11 required status checks are expected.  
```
https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/app-autoscaler/pipelines/app-autoscaler-release/jobs/release/builds/30#L65f9ea50:12:13


The problem is more or less the same as this here https://github.com/cloudfoundry/community/pull/674.

# Solution
Allow admins to bypass the required status checks