### PR TITLE
RFC: Distribute official CF container images using Github Packages instead of DockerHub

### DIFF
--- a/toc/rfc/rfc-draft-use-github-packages-container-registry-instead-of-dockerhub.md
+++ b/toc/rfc/rfc-draft-use-github-packages-container-registry-instead-of-dockerhub.md
@@ -1,0 +1,37 @@
+# Meta
+[meta]: #meta
+- Name: Distribute Public Community Images using Github Packages Container Registry instead of DockerHub
+- Start Date: 2024-04-18
+- Author(s): @tcdowney
+- Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
+- RFC Pull Request: (fill in with PR link after you submit it)
+
+
+## Summary
+
+Move away from DockerHub and distribute official Cloud Foundry container images using the [Github Packages](https://github.com/features/packages) [Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). This RFC is primarily concerned with public container images that are published for the Cloud Foundry community.
+
+## Terminology
+
+* **Community Image -** A public container image that is intended to be consumed by members of the Cloud Foundry community.  Some examples are the `cloudfoundry/cli` and `cloudfoundry/cflinuxfs4` images that are published by the CLI and Buildpacks teams.
+* **Team Image -** A container image that a team publishes for its own internal use (e.g. for use in CI). These images may or may not be public.
+
+## Problem
+
+Currently some working groups distribute container images for consumption by the Cloud Foundry community through the [CloudFoundry DockerHub org](https://hub.docker.com/repositories/cloudfoundry).
+
+Managing DockerHub accounts adds additional overhead to the release processes for these teams. By switching to using Github Packages, teams can use their existing Github accounts to publish images.
+
+It is also unclear what the long-term costs of using DockerHub will be. I believe that the `cloudfoundry` org is currently covered by the [Docker-sponsored Open Source program](https://docs.docker.com/trusted-content/dsos-program/), but [Github Package usage is free for public packages](https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages#about-billing-for-github-packages).
+
+## Proposal
+
+### Deprecation Period
+A deprecation period of 3 months *MUST* be communicated through the cf-dev mailing list and via the READMEs of the images on DockerHub. References to the DockerHub images *MUST* be updated in documentation and code repository READMEs. Community images will continue to be published to DockerHub during this period. Old Community Images *MUST* not be deleted, but the floating tags (i.e. `latest`) *MUST* be deleted to alert consumers that they are no longer using updated versions of the images.
+
+### Community Images
+Teams *MUST* begin publishing new Community Images to the Cloud Foundry Organizations [Github Packages repository](https://github.com/orgs/cloudfoundry/packages) and during the deprecation window teams *MUST* continue to publish images to DockerHub. Once the deprecation period has ended teams *MUST* no longer publish new Community Images to DockerHub. 
+
+### Internal Images
+This RFC is primarily concerned with public Community Images, but generally teams *SHOULD* migrate their Team Images off of DockerHub to Github Container Registry or to registries aligned with their existing IaaS accounts (e.g. a team that uses GCP may use Google Artifact Registry).
+


### PR DESCRIPTION
### Update
After some discussion we feel the best way forward is for teams to continue using DockerHub, but via working-group associated accounts that make it easier for collaboration across organizations.

See this comment:
https://github.com/cloudfoundry/community/pull/815#issuecomment-2085723716

---

Teams have recently been dealing with some toil around the accounts that we use to publish images to DockerHub and this has got us rethinking our usage of it a bit. In conversations on [Slack](https://cloudfoundry.slack.com/archives/C02LR0XCV3M/p1713421244243789?thread_ts=1706014252.635429&cid=C02LR0XCV3M) as well as synchronously with members of the community (@ameowlia and @rkoster 😁) it has been suggested that we switch over to Github Container Registry or Google Artifact Registry.

This is simple enough for images that are used internally by the teams themselves, but a bit more impactful for images that are meant to be consumed by the CF community. Images like [cloudfoundry/cli](https://hub.docker.com/repository/docker/cloudfoundry/cli/general) or [cloudfoundry/cflinuxfs4](https://hub.docker.com/repository/docker/cloudfoundry/cflinuxfs4/general). Some of these were [explicitly requested](https://github.com/cloudfoundry/cli/issues/1578) by the community, after all.

The purpose of this draft RFC is to provide a place to discuss this issue further and consider moving off of DockerHub in a way that causes minimal disruption for the community.

[Readable Preview](https://github.com/cloudfoundry/community/blob/f07c1d71a26d6ca92511fb31c0f443d315d7b7c1/toc/rfc/rfc-draft-use-github-packages-container-registry-instead-of-dockerhub.md)