### PR TITLE
fix(app-autoscaler-release): allow stale reviews

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -132,7 +132,7 @@ branch-protection:
             - "Build suite=test, postgres=15"
             - "CodeQL"
           required_pull_request_reviews:
-            dismiss_stale_reviews: true
+            dismiss_stale_reviews: false
             require_code_owner_reviews: true
             required_approving_review_count: 1
             bypass_pull_request_allowances:


### PR DESCRIPTION
# Problem
Dismissing stale reviews makes the life of a developer much harder, for example one always needs to get another approval after merging latest main.

# Solution
Allow stale reviews! 

`app-autoscaler-release` has only a handful active maintainers which are well known so the risk of having people pushing malicious code after a review and merging it is super low. If This situation changes, we can always go back dismissing stale reviews.