### PR TITLE
add cnbapplifecycle repo

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -866,6 +866,10 @@ orgs:
       cnb2cf:
         archived: true
         has_projects: true
+      cnbapplifecycle:
+        description: Lifecycle to create apps using Cloud Native Buildpacks
+        has_projects: false
+        has_wiki: false
       commandrunner:
         has_projects: true
       community:

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -103,6 +103,7 @@ areas:
   - cloudfoundry/cfdot
   - cloudfoundry/cfhttp
   - cloudfoundry/clock
+  - cloudfoundry/cnbapplifecycle
   - cloudfoundry/consuladapter
   - cloudfoundry/debugserver
   - cloudfoundry/diego-acceptance


### PR DESCRIPTION
Following @beyhan's [comment](https://github.com/cloudfoundry/community/pull/796#issuecomment-2074171579), we would like to request a cloudfoundry/cnbapplifecycle repository for the lifecycle created within this [RFC](https://github.com/cloudfoundry/community/pull/796).

Is that the right spot?

CC @loewenstein @stephanme @ameowlia 