### PR TITLE
Adds bonzofenix as approver for autoscaler team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2483,7 +2483,7 @@ orgs:
           cli-plugin-repo: admin
           cli: admin
           bosh-package-cf-cli-release: admin
-          cli-private: admin          
+          cli-private: admin
       temp-multiapps-admins:
         description: "Temporary team for managing MultiApps secrets until we have a permanent plan."
         maintainers:
@@ -2506,6 +2506,7 @@ orgs:
         - asalan316
         - silvestre
         - joergdw
+        - bonzofenix
         - olivermautschke
         - geigerj0
         - salzmannsusan

--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -34,6 +34,7 @@ contributors:
 - boyan-velinov
 - brayanhenao
 - bruce-ricard
+- bonzofenix
 - c0d1ngm0nk3y
 - ccjaimes
 - cf-bosh-ci-bot

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -60,6 +60,8 @@ areas:
     github: geigerj0
   - name: Susanne Salzmann
     github: salzmannsusan
+  - name: Alan Moran
+    github: bonzofenix
   reviewers:
   - name: Sumit Kulhadia
     github: kulhadia


### PR DESCRIPTION
List of previous contributions, see [RFC-0008](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0008-role-change-process.md#revoking-approver-role):

https://github.com/cloudfoundry/app-autoscaler-release/commits?author=bonzofenix