### PR TITLE
Remove emalm as an ARP WG execution lead

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -37,8 +37,6 @@ name: App Runtime Platform
 execution_leads:
 - name: Amelia Downs
   github: ameowlia
-- name: Eric Malm
-  github: emalm
 technical_leads:
 - name: Amelia Downs
   github: ameowlia


### PR DESCRIPTION
Unfortunately, I will no longer have the time to dedicate to acting as an execution lead for the App Runtime Platform Working Group, so I am resigning from the role.