### PR TITLE
Add Pete to CLI approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -365,6 +365,8 @@ areas:
     github: gururajsh
   - name: David Alvarado
     github: dalvarado
+  - name: Pete Levine
+    github: PeteLevineA    
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge


### PR DESCRIPTION
Pete Levine has been a CLI reviewer for a while now and would like to become an approver so that github workflows can be run and CLI release can be created.