### PR TITLE
Add stacks repos (responsability of Buildpacks team) to the branch protection exclusions

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -200,3 +200,10 @@ branch-protection:
           protect: false
         staticfile-buildpack-release:
           protect: false
+        # ARI Stacks (Part of Buildpacks) repos to skip branch protection
+        cflinuxfs4:
+          protect: false
+        cflinuxfs4-release:
+          protect: false
+        buildpacks-envs:
+          protect: false


### PR DESCRIPTION
# Context
As part of our (Buildpacks Team) deployment process in addition to the Buildpacks, we also take care of the Stacks. These follow the same logic in terms of deployment, which requires that branch protection does not apply to the master branch as our CI is in charge of pushing to these branches.

c.c @robdimsdale @arjun024 @sophiewigmore 