### PR TITLE
Add platform-runtime team and bot to list of approvers

### DIFF
--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -108,9 +108,19 @@ areas:
     github: syslxg
   - name: Konstantin Semenov
     github: jhvhs
+  - name: Geoff Franks
+    github: geofffranks
+  - name: Maria Shaldybin
+    github: mariash
+  - name: Amin Jamali
+    github: winkingturtle-vmw
+  - name: Marc Paquette
+    github: marcpaquette
   bots:
   - name: Cryogenics CI Bot
     github: Cryogenics-CI
+  - name: CI Bot
+    github: tas-runtime-bot
   repositories:
   - cloudfoundry/existingvolumebroker
   - cloudfoundry/goshims


### PR DESCRIPTION
`app-runtime-platform` is taking over maintenance of this group for now. This PR will give the list of already approved users access to be able to push to a branch of these repositories.