### PR TITLE
Add cflinuxfs4-compat-release repo (responsability of Buildpacks team) to the branch protection exclusions

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -205,5 +205,7 @@ branch-protection:
           protect: false
         cflinuxfs4-release:
           protect: false
+        cflinuxfs4-compat-release:
+          protect: false
         buildpacks-envs:
           protect: false


### PR DESCRIPTION
# Context

Initial work was done in #856. Adding another stack repo to the branch protection rule exclusion. 

C.C @sophiewigmore 