### PR TITLE
Remove branchprotection from capi-env-pool

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -150,6 +150,8 @@ branch-protection:
           protect: false
         capi-dockerfiles:
           protect: false
+        capi-env-pool:
+          protect: false
 
         # ARI Buildpacks repos to skip branch protection
         binary-buildpack:


### PR DESCRIPTION
[capi-env-pool](https://github.com/cloudfoundry/capi-env-pool) is used for a concourse pool resource (https://github.com/concourse/pool-resource) for development environments and is not packaged with capi-release or cf-deployment, so branch protection is not needed.