### PR TITLE
Correct start and end dates of the 2024 CFF TOC and Paketo SC elections

### DIFF
--- a/elections/2024/Paketo-SC/election.yaml
+++ b/elections/2024/Paketo-SC/election.yaml
@@ -1,7 +1,7 @@
 name: 2024 Paketo Buildpacks Steering Committee election
 organization: Cloud Foundry Foundation
-start_datetime: 2024-06-07 06:59:00 # 11:59 pm PDT, 07 Jun 2024
-end_datetime: 2024-06-18 06:59:00 # 11:59 pm PDT, 18 Jun 2024
+start_datetime: 2024-06-08 06:59:00 # 11:59 pm PDT, 07 Jun 2024
+end_datetime: 2024-06-19 06:59:00 # 11:59 pm PDT, 18 Jun 2024
 no_winners: 1
 allow_no_opinion: True
 delete_after: True

--- a/elections/2024/TOC/election.yaml
+++ b/elections/2024/TOC/election.yaml
@@ -1,7 +1,7 @@
 name: 2024 CFF Technical Oversight Committee election
 organization: Cloud Foundry Foundation
-start_datetime: 2024-06-07 06:59:00 # 11:59 pm PDT, 07 Jun 2024
-end_datetime: 2024-06-18 06:59:00 # 11:59 pm PDT, 18 Jun 2024
+start_datetime: 2024-06-08 06:59:00 # 11:59 pm PDT, 07 Jun 2024
+end_datetime: 2024-06-19 06:59:00 # 11:59 pm PDT, 18 Jun 2024
 no_winners: 2
 allow_no_opinion: True
 delete_after: True


### PR DESCRIPTION
This fixes the UTC start and end timestamps for the elections to match the PDT timestamps in the comments. This start date and time also then allows for nominations through the entirety of the Pacific Time day on Jun 7th, as seems to be the intent based on the [announcement message on the cf-dev mailing list](https://lists.cloudfoundry.org/g/cf-dev/message/9479).