### PR TITLE
Change execution to the first Monday of a month

### DIFF
--- a/.github/workflows/org-inactive-user-management.yml
+++ b/.github/workflows/org-inactive-user-management.yml
@@ -2,7 +2,7 @@ name: 'Delete Inactive Users in Github Organization'
 
 on:
   schedule:
-  - cron: '0 0 1 * *'
+  - cron: '0 0 */32,1-7 * 1'
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
TOC meeting is on Tuesdays that is why execution on Monday will fit better because of the two week revocation period.

The schedule will be executed `At 00:00 on every 32nd day-of-month and every day-of-month from 1 through 7 if it's on Monday.` More detail in [this super user thread](https://superuser.com/questions/428807/run-a-cron-job-on-the-first-monday-of-every-month). 