### PR TITLE
Remove not existing uaa-ci repo listin

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2584,5 +2584,4 @@ orgs:
           - iprotsiuk
         members: [ ]
         privacy: closed
-        repos:
-          uaa-ci: admin
+        repos: [ ]


### PR DESCRIPTION
The CF organization automation is failing because uaa-ci repo is not existing. Remove it to fix the automation