### PR TITLE
Fix remove not existing uaa-ci repo listin

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2584,4 +2584,4 @@ orgs:
           - iprotsiuk
         members: [ ]
         privacy: closed
-        repos: [ ]
+        repos: {}


### PR DESCRIPTION
`repos` expect a map and not an array. Let's try this fix. I'm not sure whether this will work with the `peribolos` tooling but I think so based on code here https://github.com/kubernetes/test-infra/blob/0c1e01159b26a39d2a37de4d83cb18ab94747ed8/prow/cmd/peribolos/main.go#L1146-L1164