### PR TITLE
add git repo: cloudfoundry/cf-lookup-route

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -619,6 +619,10 @@ orgs:
       cf-lite-ci:
         has_projects: true
         private: true
+      cf-lookup-route:
+        default_branch: main
+        description: A plugin for the CF-CLI to quickly identify the application a certain route is pointing to.
+        has_projects: true
       cf-mysql-bootstrap:
         description: Auto-bootstrap errand for cf-mysql-release
         has_projects: true

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -354,6 +354,7 @@ areas:
   - name: Konstantin Lapkov
     github: klapkov
   repositories:
+  - cloudfoundry/cf-lookup-route
   - cloudfoundry/cf-networking-helpers
   - cloudfoundry/cf-networking-onboarding
   - cloudfoundry/cf-networking-release


### PR DESCRIPTION
* we want to implement a reverse-route lookup to identify apps for given routes (v3)
* in the past we used an outdated tool building on top of v2: https://github.com/cloud-gov/cf-route-lookup