### PR TITLE
Add Tmp Team to configure Prometheus Exporter Secrets

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2585,3 +2585,13 @@ orgs:
         members: [ ]
         privacy: closed
         repos: {}
+      temp-prometheus-exporter-admins:
+        description: "Temporary team for managing cf/ firehose exporter secrets until we have a permanent plan."
+        maintainers:
+          - benjaminguttmann-avtq
+        members: []
+        privacy: closed
+        repos:
+          cf_exporter: admin
+          firehose_exporter: admin
+          bosh_exporter: admin


### PR DESCRIPTION
I would need to configure secrets to publish docker images for cf_exporter/ firehose_exporter/ bosh_exporter, according to @rkoster this is the current way to get such permissions. 