### PR TITLE
[ARI] Add João Pereira as CLI approver

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -366,13 +366,13 @@ areas:
     github: gururajsh
   - name: David Alvarado
     github: dalvarado
+  - name: João Pereira
+    github: joaopapereira
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge
   - name: Pete Levine
     github: PeteLevineA
-  - name: Shwetha Guraraj
-    github: gururajsh
   - name: Tim Downey
     github: tcdowney
   - name: Sam Gunaratne


### PR DESCRIPTION
João Pereira, an experienced developer, has made multiple contributions to this project and is actively involved in code reviews and discussions as part of our team.