### PR TITLE
[ARI] Add Greg Weresch as CLI reviewer

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -377,6 +377,8 @@ areas:
     github: tcdowney
   - name: Sam Gunaratne
     github: samze
+  - name: Greg Weresch
+    github: weresch
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng


### PR DESCRIPTION
@weresch is a seasoned developer who actively participates in CLI development and maintenance. I endorse him as a CLI reviewer.