### PR TITLE
Extend inactive user automation to warn about inactive WG users

### DIFF
--- a/org/org_management.py
+++ b/org/org_management.py
@@ -88,10 +88,11 @@ class OrgGenerator:
     def get_contributors(self) -> Set[str]:
         return set(self.contributors)
 
-    def get_community_members_with_role(self) -> Set[str]:
-        result = set(self.toc)
+    def get_community_members_with_role_by_wg(self) -> Dict[str, Set[str]]:
+        result = dict()
+        result["toc"] = set(self.toc)
         for wg in self.working_groups:
-            result |= OrgGenerator._wg_github_users(wg)
+            result[wg["name"]] = OrgGenerator._wg_github_users(wg)
         return result
 
     def generate_org_members(self):

--- a/org/org_management.py
+++ b/org/org_management.py
@@ -89,8 +89,7 @@ class OrgGenerator:
         return set(self.contributors)
 
     def get_community_members_with_role_by_wg(self) -> Dict[str, Set[str]]:
-        result = dict()
-        result["toc"] = set(self.toc)
+        result = {"toc": set(self.toc)}
         for wg in self.working_groups:
             result[wg["name"]] = OrgGenerator._wg_github_users(wg)
         return result


### PR DESCRIPTION
As discussed during the TOC meeting on 02.07.2024 this change extends the inactive user automation to warn about WG users who were inactive during the last one year. If this changes is accepted the inactive pr msg will look like:

According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md) following users will be deleted:
user1
user2
....
According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as contributor after this one is merged.
As alternative, if you are active in a working group please check the [promotion rules](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0008-role-change-process.md#proposal) and if you are eligible and wish apply for a role in that working group.

Warning:
Inactive users of Working Group "CF on K8s" are:
user3
...
Inactive users of Working Group "Service Management" are:
user4
...
Inactive users of Working Group "App Runtime Interfaces" are:
user5
...
Inactive users of Working Group "App Runtime Platform" are:
...