### PR TITLE
Update branch protection rules for CLI bosh-package-cf-cli-release

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -140,7 +140,9 @@ branch-protection:
         # CLI
         CLAW:
           protect: false
-          
+        bosh-package-cf-cli-release:
+          protect: false
+
         # ARI Buildpacks repos to skip branch protection
         binary-buildpack:
           protect: false


### PR DESCRIPTION
After internal discussion, we decided to keep using workflow tokens to push release updates directly to the branch.