### PR TITLE
Add temporary capi-admins team

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2599,3 +2599,12 @@ orgs:
           cf_exporter: admin
           firehose_exporter: admin
           bosh_exporter: admin
+      temp-ari-capi-admins:
+        description: "Temporary admin team for CAPI"
+        maintainers:
+          - philippthun
+          - johha
+        members: []
+        privacy: closed
+        repos:
+          cloud_controller_ng: admin


### PR DESCRIPTION
Current use case: temporary admin access to the `cloud_controller_ng` repo is needed to configure GitHub Pages.