### PR TITLE
[ARI] Remove @kulhadia as Autoscaler reviever

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -62,9 +62,6 @@ areas:
     github: salzmannsusan
   - name: Alan Moran
     github: bonzofenix
-  reviewers:
-  - name: Sumit Kulhadia
-    github: kulhadia
   bots:
   - name: App Autoscaler CI Bot
     github: app-autoscaler-ci-bot


### PR DESCRIPTION
This PRs removes former ARI Autoscaler area reviewer @kulhadia.

According to RFC-0008 "An existing Approver may submit the revocation request on behalf of someone else, but the person whose role is being revoked must be given two weeks to refute the revocation."

@kulhadia: Please speak up if you want to continue to contribute to the Autoscaler area in the App Runtime Interfaces working group. You have until July 31st, 2024 to veto your removal from the reviewer role.

In any case, thank you for your contributions to the Autoscaler area. ❤️