### PR TITLE
add oliver heinrich as new member

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -150,6 +150,7 @@ contributors:
 - nouseforaname
 - nvvalchev
 - ohkyle
+- oliver-heinrich
 - oppegard
 - pabloarodas
 - paketo-bot


### PR DESCRIPTION
Oliver is now part of the cf deploy team and want to become a member/contributor