### PR TITLE
bosh-google-light-stemcell-builder has not been used for several years

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -275,6 +275,7 @@ orgs:
         description: Builds light stemcells for GCP from a "full" bosh stemcell
         has_projects: false
         has_wiki: false
+        archived: true
       bosh-io-releases-index:
         description: Index of all release assets
         default_branch: main

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -381,7 +381,6 @@ areas:
   - cloudfoundry/bosh-docker-cpi-release
   - cloudfoundry/bosh-gcscli
   - cloudfoundry/bosh-google-cpi-release
-  - cloudfoundry/bosh-google-light-stemcell-builder
   - cloudfoundry/bosh-io-releases
   - cloudfoundry/bosh-io-releases-index
   - cloudfoundry/bosh-io-stemcells-core-index


### PR DESCRIPTION
The content of the repo was merged into bosh-stemcells-ci previously in an attempt to consolidate stemcell CI repos but this was never archived after that work.