### PR TITLE
Add `nader-ziada` as approver for bosh related projects

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -291,11 +291,11 @@ areas:
     github: anshrupani
   - name: Chris Selzo
     github: selzoc
+  - name: Nader Ziada
+    github: nader-ziada
   reviewers:
   - name: Greg Meyer
     github: gm2552
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Ming Xiao
     github: mingxiao
   - name: Nitin Ravindran
@@ -337,11 +337,11 @@ areas:
     github: a-hassanin
   - name: Ansh Rupani
     github: anshrupani
+  - name: Nader Ziada
+    github: nader-ziada
   reviewers:
   - name: Greg Meyer
     github: gm2552
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Ming Xiao
     github: mingxiao
   - name: Nitin Ravindran


### PR DESCRIPTION
Hello

I was a contributor to CF from 2015-2017 and now back in 2024.

I would like to request to be made an approver for the Stemcell Release Engineering (BOSH) and VM deployment lifecycle (BOSH) area of the Foundational Infrastructure WG.

Here is a summary of recent contributions: 
- 2023-12-04T15:44:28Z: [CLI crashes on trying to select multiple columns to print](https://github.com/cloudfoundry/bosh-cli/issues/636)
- 2024-05-15T21:17:54Z: [Loop each 30 minutes when publishing the azure offer](https://github.com/cloudfoundry/greenhouse-ci/commit/28f636f1d380235d6f6ff839ab200848092276d0)
- 2024-05-21T22:27:45Z: [Wait 3 seconds for monit jobs to stop before unmounting /var/log](https://github.com/cloudfoundry/bosh-agent/commit/262f1a6932a0bb040ea314374ce1dc6a2e0770b1)
- 2024-06-05T12:50:04Z: [error message when --column is used with a column that does not exist](https://github.com/cloudfoundry/bosh-cli/commit/9cec99fca09063dff83deaa0995914daeb98f050)
- 2024-06-10T20:51:14Z: [Add an endpoint in bosh director for download a package with blobstore id](https://github.com/cloudfoundry/bosh/commit/d4a98688f21c44b2da1dc42dc44fe851dfc6d9f5)
- 2024-06-11T17:36:01Z: [Add an endpoint in bosh director for download a package with blobstore id](https://github.com/cloudfoundry/bosh/commit/d4a98688f21c44b2da1dc42dc44fe851dfc6d9f5)
- 2024-06-20T21:05:11Z: [Attempts to make unmount more reliable](https://github.com/cloudfoundry/bosh-agent/commit/87778d349ea7d4b5d51438ef9413209011402999)
- 2024-07-04T15:32:54Z: [update the variable name used in the test to resolve compile error](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/07df3c95daf01df094a22c88b3f77d77a3737e27)
- 2024-07-09T19:48:23Z: [correctly set custom gcp role to be used by int test](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/ebd8d90aa77054619ed083c79672609823d5f445)
- 2024-07-09T20:58:48Z: [Compare path-parts instead of path-strings when filtering mounts](https://github.com/cloudfoundry/bpm-release/commit/1e53ee597dd5b34839d8ffb1bf5c91ad4f8f36ab)
- 2024-07-10T14:38:47Z: [Add missing roles needed for integration tests](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/950d4bb8bf20d2292ec37be2a4f98520a5c242c1)
- 2024-07-11T20:09:57Z: [Bump golang deps for windows-acceptance-tests](https://github.com/cloudfoundry/greenhouse-ci/commit/8b6b1831b1c375c77f61293e13a11d6f33ed2115)
- 2024-07-22T18:23:46Z: [rename unit test task in pipeline to make it more clear](https://github.com/cloudfoundry/greenhouse-ci/commit/d1a1787bf5ed98fd49cdd48f2d0bc1dce866f016)
- 2024-06-24T19:29:51Z: [Refactor pipeline for use without shepherd environment or PRs](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/8c86f7958e4702f84a483b5b756ffe5c92957010)
- 2024-06-24T21:34:12Z: [Update pipeline credentials;](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/17d8e1707fafc91f51a46494ccb93d2204a257c2)
- 2024-06-25T21:03:34Z: [Remove code related to running bbr from a separate VM as part of the tests](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/9f5813f5525278ae0afc8b32937c5d70f9215fe6)
- 2024-06-25T21:14:40Z: [Use full path to bbr binary](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/e49aa150b2676f443d1a14afcb7e754e271fc480)
- 2024-06-25T21:28:47Z: [Use BOSH_ALL_PROXY when running bbr](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/b570e9e43fd3f80409b5da8371b953ef51bdba1c)
- 2024-06-25T22:03:28Z: [Additional pipeline cleanup](https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/commit/bf39c440b87f91a69b765d31868a461ffb547786)

in addition to many contributions between 2015 and 2017

