### PR TITLE
Inactive users to be removed from ARD approvers

### DIFF
--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -53,8 +53,6 @@ areas:
     name: Dave Walter
   - github: ctlong
     name: Carson Long
-  - github: tjvman
-    name: Tom Viehman
   - github: philippthun
     name: Philipp Thun
   - github: johha
@@ -65,12 +63,6 @@ areas:
     name: Aftab Alam
   - github: jimconner
     name: Jim Conner
-  - github: andrewdriver123
-    name: Andrew Driver
-  - github: combor
-    name: Piotr Komborski
-  - github: shaun7pan
-    name: Shaun Pan
   repositories:
   - cloudfoundry/app-runtime-deployments-infrastructure
   - cloudfoundry/cf-acceptance-tests


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARD approvers:

- @andrewdriver123
- @shaun7pan
- @combor
- @tjvman

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #937