### PR TITLE
Inactive users to be removed from ARI approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -498,6 +498,9 @@ areas:
   - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Notifications
+  bots:
+  - name: VMware notifications release bot
+    github: cf-frontend
   approvers:
   - name: David Stevenson
     github: dsboulder

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -302,8 +302,6 @@ areas:
 
 - name: CAPI
   approvers:
-  - name: Tom Viehman
-    github: tjvman
   - name: Florian Braun
     github: FloThinksPi
   - name: Philipp Thun
@@ -379,8 +377,6 @@ areas:
   approvers:
   - name: Al Berez
     github: a-b
-  - name: Juan Diego González
-    github: jdgonzaleza
   - name: Ryker Reed
     github: reedr3
   - name: Michael Oleske
@@ -478,14 +474,10 @@ areas:
     github: boyan-velinov
   - name: Rangel Ivanov
     github: radito3
-  - name: Dido
-    github: ddonchev
   - name: Ikasarov
     github: ikasarov
   - name: Velizar Kalapov
     github: vkalapov
-  - name: Nikolay Valchev
-    github: nvvalchev
   - name: Vasil Bogdanov
     github: VRBogdanov
   - name: Yavor Uzunov
@@ -506,9 +498,6 @@ areas:
   - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Notifications
-  bots:
-  - name: VMware notifications release bot
-    github: cf-frontend
   approvers:
   - name: David Stevenson
     github: dsboulder


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARD approvers/bots:
- @jdgonzaleza
- @ddonchev
- @tjvman
- @cf-frontend
- @nvvalchev

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #937