### PR TITLE
Remove inactive users reported by the automation

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -211,6 +211,8 @@ areas:
   approvers:
   - name: Andrew Garner
     github: abg
+  - name: Colin Shield
+    github: colins
   - name: Kyle Ong
     github: ohkyle
   - name: Kim Basset
@@ -270,6 +272,8 @@ areas:
     github: max-soe
   - name: Aram Price
     github: aramprice
+  - name: Shilpa Chandrashekara
+    github: ShilpaChandrashekara
   - name: Joerg W
     github: joergdw
   - name: Ansh Rupani

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -43,20 +43,12 @@ technical_leads:
 bots:
 - name: bosh-admin-bot
   github: bosh-admin-bot
-- name: bosh-windows-ci
-  github: bosh-windows-ci
-- name: cf-gitbot
-  github: cf-gitbot
 - name: runtime-bot
   github: tas-runtime-bot
 - name: cf-uaa-ci-bot
   github: cf-identity
-- name: cf-bosh-ci-bot
-  github: cf-bosh-ci-bot
 - name: Cryogenics-CI
   github: Cryogenics-CI
-- name: bbr-ci
-  github: bbr-ci
 - name: mysql-ci
   github: pcf-core-services-writer
 areas:
@@ -88,8 +80,6 @@ areas:
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)
   reviewers:
-  - name: Alenjandra Lara
-    github: alejandra-lara
   - name: claire t.
     github: Spimtav
   - name: Greg Meyer
@@ -139,8 +129,6 @@ areas:
     github: jhvhs
   - name: Long Nguyen
     github: lnguyen
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Rajan Agaskar
     github: ragaskar
   repositories:
@@ -223,8 +211,6 @@ areas:
   approvers:
   - name: Andrew Garner
     github: abg
-  - name: Colin Shield
-    github: colins
   - name: Kyle Ong
     github: ohkyle
   - name: Kim Basset
@@ -274,8 +260,6 @@ areas:
     github: cunnie
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Daniel Felipe Ochoa
     github: danielfor
   - name: Kenneth Lakin
@@ -286,8 +270,6 @@ areas:
     github: max-soe
   - name: Aram Price
     github: aramprice
-  - name: Shilpa Chandrashekara
-    github: ShilpaChandrashekara
   - name: Joerg W
     github: joergdw
   - name: Ansh Rupani


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users have been identified as inactive by a github action (see https://github.com/cloudfoundry/community/pull/937):
@bosh-windows-ci
@cf-bosh-ci-bot
@bbr-ci
@cf-gitbot
@colins
@ShilpaChandrashekara
@mrosecrance
@alejandra-lara

This pr suggest to remove their roles from the FI WG. According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request.