### PR TITLE
Exclude CLAW from branch protection rule

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -137,6 +137,10 @@ branch-protection:
         capi-env-pool:
           protect: false
 
+        # CLI
+        CLAW:
+          protect: false
+          
         # ARI Buildpacks repos to skip branch protection
         binary-buildpack:
           protect: false


### PR DESCRIPTION
CLI uses CLAW as a redirect for downloads. We use github actions workflows for our release. The [workflow](https://github.com/cloudfoundry/cli/blob/main/.github/workflows/release-build-sign-upload.yml#L1025) updates the repo with latest version number to serve using a bot account. This push is failing because of branch protection rules as seen [here](https://github.com/cloudfoundry/cli/actions/runs/9860194541/job/27226694327#step:3:43). The same action [passed](https://github.com/cloudfoundry/cli/actions/runs/9860194541/job/27226905725#step:3:43) when it ran with branch protection rule removed for CLAW. We tested this with multiple different settings (changing user/email/keys and combinations of these), none of them worked with branch protection rules being set. 

The ssh key used to access repo belongs to the CF CLI BOT which belongs [cloudfoundry/wg-app-runtime-interfaces-cli-bots](https://github.com/orgs/cloudfoundry/teams/wg-app-runtime-interfaces-cli-bots) Discussed this issue in WG Call as well. So the best course of action for now is to remove the branch protection rule. We are doing similar thing with homebrew-tap update from our [workflow](https://github.com/cloudfoundry/cli/actions/runs/9860676331/workflow#L186) which has no issues. This repo has no branch protection rule set.