### PR TITLE
Add terraform-provider-cloudfoundry

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2312,6 +2312,10 @@ orgs:
         allow_merge_commit: false
         has_issues: false
         has_projects: true
+      terraform-provider-cloudfoundry:
+        default_branch: main
+        description: Terraform provider to manage Cloud Foundry resources using v3 APIs 
+        has_projects: true
       terraform-provider-csbmysql:
         allow_merge_commit: false
         allow_rebase_merge: false

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -451,6 +451,21 @@ areas:
   repositories:
   - cloudfoundry/go-cfclient
 
+- name: Terraform Provider Cloudfoundry
+  approvers:
+  - name: Yogesh Purantharan
+    github: pyogesh2
+  - name: Vipin Vijaykumar
+    github: vipinvkmenon
+  - name: Kesavan
+    github: KesavanKing
+  - name: Debaditya Ray 
+    github: Dray56
+  - name: Gourab Mukherjee
+    github: Gourab1998
+  repositories:
+  - cloudfoundry/terraform-provider-cloudfoundry
+
 - name: MultiApps
   approvers:
   - name: Alexander Tsvetkov


### PR DESCRIPTION
This is to start the discussion of moving the terraform-provider-cloudfoundry contribution from SAP to CF Foundation.

Details:
Current Repo: https://github.com/SAP/terraform-provider-cloudfoundry

Motivation:
Build a stable flexible and usable CF Terraform provider from scratch to:
- Take advantage of V3 APIs
- Use the well maintaiend go-cfclient
- Use the newer, recommended  Terraform Plugin Framework
