### PR TITLE
New github repo for FWIG shared Concourse tasks

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -362,6 +362,10 @@ orgs:
         description: Go CLI for S3
         has_projects: false
         has_wiki: false
+      bosh-shared-ci:
+        description: Concourse CI tasks intended to be used across many different projects
+        has_projects: false
+        has_wiki: false
       bosh-softlayer-cpi-release:
         description: An external BOSH CPI for the SoftLayer cloud written in Golang
         has_projects: true

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -402,6 +402,7 @@ areas:
   - cloudfoundry/bosh-package-ruby-release
   - cloudfoundry/bosh-psmodules
   - cloudfoundry/bosh-s3cli
+  - cloudfoundry/bosh-shared-ci
   - cloudfoundry/bosh-softlayer-cpi-release
   - cloudfoundry/bosh-utils
   - cloudfoundry/bosh-virtualbox-cpi-release


### PR DESCRIPTION
We need a place to hold Concourse tasks that are shared and intended to be used by multiple different projects.

We considered reusing one of our existing repositories, but none of them seemed like a good fit.

Examples of tasks that would live in this repo:
- [check-for-patched-cves.sh](https://github.com/cloudfoundry/bosh-package-golang-release/blob/8c9d8842a38f748a906b6e52bb40bc5a2a4d8324/ci/tasks/shared/check-for-patched-cves.sh)
- [bosh-agent-compile.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/ci/tasks/shared/bosh-agent-compile.yml)