### PR TITLE
Move DRATs from FI WG to ARD WG

### DIFF
--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -72,6 +72,7 @@ areas:
   - cloudfoundry/cf-smoke-tests
   - cloudfoundry/cf-smoke-tests-release
   - cloudfoundry/cf-test-helpers
+  - cloudfoundry/disaster-recovery-acceptance-tests
   - cloudfoundry/honeycomb-ginkgo-reporter
   - cloudfoundry/relint-ci-pools
   - cloudfoundry/relint-envs

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -148,7 +148,6 @@ areas:
   - cloudfoundry/bosh-backup-and-restore
   - cloudfoundry/bosh-backup-and-restore-test-releases
   - cloudfoundry/bosh-disaster-recovery-acceptance-tests
-  - cloudfoundry/disaster-recovery-acceptance-tests
   - cloudfoundry/exemplar-backup-and-restore-release
   - cloudfoundry/homebrew-tap
   bots:


### PR DESCRIPTION
* DRATs are executed in ARD WG validation pipeline (just like CATs), so it makes sense to move them to ARD WG for maintenance