### PR TITLE
Fix org automation because of none existing user rhall-pivotal

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -112,8 +112,6 @@ areas:
     github: xtremerui
   - name: Rizwan Reza
     github: rizwanreza
-  - name: Ryan Hall
-    github: rhall-pivotal
   - name: Wayne Adams
     github: wayneadams
   approvers:


### PR DESCRIPTION
The org automation is failing because the user @rhall-pivotal doesn't exist any more. Logs from the automation:

```
{"client":"github","component":"peribolos","level":"info","msg":"UpdateTeamMembershipBySlug(cloudfoundry, wg-foundational-infrastructure-disaster-recovery-bbr-reviewers, rhall-pivotal, false)","severity":"info","time":"2024-09-03T04:47:10Z"}
{"component":"peribolos","level":"warning","msg":"UpdateTeamMembership(wg-foundational-infrastructure-disaster-recovery-bbr-reviewers(wg-foundational-infrastructure-disaster-recovery-bbr-reviewers), rhall-pivotal, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user\",\"status\":\"404\"}","severity":"warning","time":"2024-09-03T04:47:46Z"}
{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure cloudfoundry teams: failed to update wg-foundational-infrastructure child teams: failed to update wg-foundational-infrastructure-disaster-recovery-bbr-reviewers members: UpdateTeamMembership(wg-foundational-infrastructure-disaster-recovery-bbr-reviewers(wg-foundational-infrastructure-disaster-recovery-bbr-reviewers), rhall-pivotal, false) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user\",\"status\":\"404\"}","severity":"fatal","time":"2024-09-03T04:47:46Z"}
```

In https://github.com/cloudfoundry/community/pull/736 he was reported as inactive and deleted as contributors but we missed to delete the user from FI WG. It looks like that the github user @rhall-pivotal doesn't exist any more which is braking our automation. 