### PR TITLE
[ARI] Remove docs-buildpacks from ARI WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -71,20 +71,6 @@ areas:
   - cloudfoundry/app-autoscaler-env-bbl-state
   - cloudfoundry/app-runtime-interfaces-infrastructure
 
-- name: Buildpacks Docs
-  approvers:
-  - name: Arjun Sreedharan
-    github: arjun024
-  - name: Forest Eckhardt
-    github: ForestEckhardt
-  - name: Rob Dimsdale-Zucker
-    github: robdimsdale
-  - name: Sophie Wigmore
-    github: sophiewigmore
-  repositories:
-  - cloudfoundry/docs-buildpacks
-  - cloudfoundry/example-sidecar-buildpack
-
 - name: Buildpacks Go
   approvers:
   - name: Arjun Sreedharan
@@ -258,6 +244,7 @@ areas:
   - cloudfoundry/buildpacks-github-config
   - cloudfoundry/buildpacks-workstation
   - cloudfoundry/dagger
+  - cloudfoundry/example-sidecar-buildpack
   - cloudfoundry/libbuildpack
   - cloudfoundry/public-buildpacks-ci-robots
   - cloudfoundry/switchblade


### PR DESCRIPTION
- This repo is already managed by the Docs WG, and multiple WGs can't own the same repo ([source](https://github.com/cloudfoundry/community/pull/944#issuecomment-2287798758))
- Move example-sidecar-buildpack to an existing ARI WG area, so it doesn't feel alone in a moribund area