### PR TITLE
Move homebrew-tap to Admin WG from Foundational Infrastructure WG

### DIFF
--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -61,7 +61,7 @@ areas:
   - cloudfoundry/summit-training-classes
   - cloudfoundry/training-cert-admin
   
-- name: Shared
+- name: Homebrew
   approvers:
   - name: Al Berez
     github: a-b

--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -60,6 +60,22 @@ areas:
   - cloudfoundry/summit-hands-on-labs
   - cloudfoundry/summit-training-classes
   - cloudfoundry/training-cert-admin
+  
+- name: Shared
+  approvers:
+  - name: Al Berez
+    github: a-b
+  - name: Shwetha Gururaj
+    github: gururajsh
+  - name: João Pereira
+    github: joaopapereira
+  - name: Sam Gunaratne
+    github: samze
+  bots:
+  - name: CF CLI Eng
+    github: cf-cli-eng
+  repositories:
+  - cloudfoundry/homebrew-tap
 config:
   github_project_sync:
     mapping:

--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -60,8 +60,8 @@ areas:
   - cloudfoundry/summit-hands-on-labs
   - cloudfoundry/summit-training-classes
   - cloudfoundry/training-cert-admin
-  
-- name: Homebrew
+
+- name: CF Homebrew TAP
   approvers:
   - name: Al Berez
     github: a-b
@@ -71,6 +71,28 @@ areas:
     github: joaopapereira
   - name: Sam Gunaratne
     github: samze
+  - name: Aram Price
+    github: aramprice
+  - name: Brian Upton
+    github: ystros
+  - name: Chris Selzo
+    github: selzoc
+  - name: Diego Lemos
+    github: dlresende
+  - name: George Blue
+    github: blgm
+  - name: Iain Findlay
+    github: ifindlay-cci
+  - name: Kenneth Lakin
+    github: klakin-pivotal
+  - name: Konstantin Kiess
+    github: nouseforaname
+  - name: Konstantin Semenov
+    github: jhvhs
+  - name: Long Nguyen
+    github: lnguyen
+  - name: Rajan Agaskar
+    github: ragaskar    
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -147,7 +147,6 @@ areas:
   - cloudfoundry/bosh-backup-and-restore-test-releases
   - cloudfoundry/bosh-disaster-recovery-acceptance-tests
   - cloudfoundry/exemplar-backup-and-restore-release
-  - cloudfoundry/homebrew-tap
   bots:
   - name: tas-operability-bot
     github: tas-operability-bot


### PR DESCRIPTION
Since CF CLI uses homebrew-tap repository is used by teams across multiple WGs, moving it to Admin WG. Related PR https://github.com/cloudfoundry/community/pull/944.

Have included some of the current CLI approvers as approvers for this.