### PR TITLE
chore: Add temporary admins

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2617,3 +2617,13 @@ orgs:
         privacy: closed
         repos:
           cloud_controller_ng: admin
+      temp-ari-terraform-provider-cloudfoundry-admins:
+        description: "Temporary team for managing terraform-provider-cloudfoundry secrets."
+        maintainers:
+          - pyogesh2
+          - KesavanKing
+          - vipinvkmenon
+        members: []
+        privacy: closed
+        repos:
+          terraform-provider-cloudfoundry: admin


### PR DESCRIPTION
Add temporary admins for the `terraform-provider-cloudfoundry`. 
This is required to manage the secrets for the repo, Namely terraform registry `gpg` keys