### PR TITLE
chore: Add bot

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -463,6 +463,9 @@ areas:
     github: Dray56
   - name: Gourab Mukherjee
     github: Gourab1998
+  bots:
+  - name: SAP OSPO Bot
+    github: SAP-OSPO-ADMIN
   repositories:
   - cloudfoundry/terraform-provider-cloudfoundry
 


### PR DESCRIPTION
Add bot user for the `terraform-provider-cloudfoundry`
- This bot is requrired for automated activities for OSPO team