### PR TITLE
Add new repo `uaa-ci`

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2368,6 +2368,10 @@ orgs:
         description: CloudFoundry User Account and Authentication (UAA) Server
         has_projects: true
         has_wiki: false
+      uaa-ci:
+        default_branch: main
+        has_projects: true
+        has_wiki: false
       uaa-cli:
         description: CLI for UAA written in Go
         has_projects: true

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -188,6 +188,29 @@ areas:
   - cloudfoundry/uaa-key-rotator
   - cloudfoundry/uaa-release
   - cloudfoundry/uaa-singular
+- name: Identity and Auth (UAA) CI
+  approvers:
+  - name: Peter Chen
+    github: peterhaochen47
+  - name: Hongchol Sinn
+    github: hsinn0
+  - name: Duane May
+    github: duanemay
+  - name: Prateek Gangwal
+    github: coolgang123
+  reviewers:
+  - name: Markus Strehle
+    github: strehle
+  - name: Florian Tack
+    github: tack-sap
+  - name: Torsten Luh
+    github: torsten-sap
+  - name: Adrian Hoelzl
+    github: adrianhoelzl-sap
+  - name: Klaus Kiefer
+    github: klaus-sap
+  repositories:
+  - cloudfoundry/uaa-ci
 - name: Identity and Auth (UAA) Go Client
   approvers:
   - name: Joe Fitzgerald


### PR DESCRIPTION
- To migrate from `pivotal` org.
- Giving approver roles only to the current team members with access to secrets that are required to update the pipelines.