### PR TITLE
Update `uaa-ci` repo approvers and other repo team members

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -56,14 +56,8 @@ areas:
   approvers:
   - name: Peter Chen
     github: peterhaochen47
-  - name: Bruce Ricard
-    github: bruce-ricard
   - name: Hongchol Sinn
     github: hsinn0
-  - name: Danny Faught
-    github: swalchemist
-  - name: Alicia Yingling
-    github: Tallicia
   - name: Prateek Gangwal
     github: coolgang123
   reviewers:
@@ -143,20 +137,14 @@ areas:
   approvers:
   - name: Peter Chen
     github: peterhaochen47
-  - name: Bruce Ricard
-    github: bruce-ricard
   - name: Markus Strehle
     github: strehle
   - name: Hongchol Sinn
     github: hsinn0
-  - name: Danny Faught
-    github: swalchemist
   - name: Florian Tack
     github: tack-sap
   - name: Torsten Luh
     github: torsten-sap
-  - name: Alicia Yingling
-    github: Tallicia
   - name: Adrian Hoelzl
     github: adrianhoelzl-sap
   - name: Klaus Kiefer
@@ -176,28 +164,6 @@ areas:
   - cloudfoundry/uaa-key-rotator
   - cloudfoundry/uaa-release
   - cloudfoundry/uaa-singular
-- name: Identity and Auth (UAA) CI
-  approvers:
-  - name: Peter Chen
-    github: peterhaochen47
-  - name: Hongchol Sinn
-    github: hsinn0
-  - name: Duane May
-    github: duanemay
-  - name: Prateek Gangwal
-    github: coolgang123
-  reviewers:
-  - name: Markus Strehle
-    github: strehle
-  - name: Florian Tack
-    github: tack-sap
-  - name: Torsten Luh
-    github: torsten-sap
-  - name: Adrian Hoelzl
-    github: adrianhoelzl-sap
-  - name: Klaus Kiefer
-    github: klaus-sap
-  repositories:
   - cloudfoundry/uaa-ci
 - name: Identity and Auth (UAA) Go Client
   approvers:
@@ -205,20 +171,14 @@ areas:
     github: joefitzgerald
   - name: Peter Chen
     github: peterhaochen47
-  - name: Bruce Ricard
-    github: bruce-ricard
   - name: Markus Strehle
     github: strehle
   - name: Hongchol Sinn
     github: hsinn0
-  - name: Danny Faught
-    github: swalchemist
   - name: Florian Tack
     github: tack-sap
   - name: Torsten Luh
     github: torsten-sap
-  - name: Alicia Yingling
-    github: Tallicia
   - name: Adrian Hoelzl
     github: adrianhoelzl-sap
   - name: Klaus Kiefer
@@ -226,6 +186,8 @@ areas:
   reviewers:
   - name: Duane May
     github: duanemay
+  - name: Prateek Gangwal
+    github: coolgang123
   repositories:
   - cloudfoundry/go-uaa
 - name: Integrated Databases (Mysql / Postgres)


### PR DESCRIPTION
- Made SAP team approvers of `uaa-ci` repo so they can create PRs for the private repo. After that, we do not need separate `area` for `uaa-ci` repo, so removed the `area` that was created specifically for `uaa-ci`.
- Updated VMware team members.