### PR TITLE
Archive Cloud Controller GoLang PoC

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1290,10 +1290,12 @@ orgs:
           written in Go.
         has_projects: true
         has_wiki: false
+        archived: true
         homepage: https://cloudfoundry.github.io/go-cf-api/
       go-cf-api-release:
         allow_rebase_merge: false
         default_branch: main
+        archived: true
         has_projects: true
       go-cfclient:
         default_branch: main

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -334,8 +334,6 @@ areas:
   - cloudfoundry/tps
   - cloudfoundry/cc-uploader
   - cloudfoundry/sync-integration-tests
-  - cloudfoundry/go-cf-api
-  - cloudfoundry/go-cf-api-release
   - cloudfoundry/blobstore_url_signer
   - cloudfoundry/capi-workspace
   - cloudfoundry/delayed_job_sequel


### PR DESCRIPTION
The GoLang PoC of the Cloud Controller rewrite never gained attraction. Archiving it as its a stale, unused project.