### PR TITLE
Switch temp-arp-networking admins

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2570,7 +2570,8 @@ orgs:
         description: "Temporary team for managing GitHub integrations for automation/concourse."
         maintainers:
           - plowin
-          - domdom82
+          - peanball
+          - Soha-Albaghdady
         members: []
         privacy: closed
         repos:


### PR DESCRIPTION
As discussed with @ameowlia via stack we would like to switch our team admins