### PR TITLE
Grant credhub bot access to homebrew-tap.

### DIFF
--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -96,6 +96,8 @@ areas:
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng
+  - name: Credhub CLI
+    github: credhub-ci-bot
   repositories:
   - cloudfoundry/homebrew-tap
 config:


### PR DESCRIPTION
Credhub used to have access to homebrew-tap before it moved to Admin WG from Foundational Infrastructure WG