### PR TITLE
archive the cpu-entitlement plugins

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -921,8 +921,10 @@ orgs:
         has_wiki: false
       cpu-entitlement-admin-plugin:
         has_projects: true
+        archived: true
       cpu-entitlement-plugin:
         has_projects: true
+        archived: true
       credhub:
         allow_merge_commit: false
         allow_squash_merge: false

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -170,8 +170,6 @@ areas:
   repositories:
   - cloudfoundry/cert-injector
   - cloudfoundry/commandrunner
-  - cloudfoundry/cpu-entitlement-admin-plugin
-  - cloudfoundry/cpu-entitlement-plugin
   - cloudfoundry/diff-exporter
   - cloudfoundry/dontpanic
   - cloudfoundry/envoy-nginx-release


### PR DESCRIPTION
the features are now available in the [cf cli](https://github.com/cloudfoundry/cli/issues/2812).