### PR TITLE
Re-add in mrosecrance to foundational infra

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -121,6 +121,8 @@ areas:
     github: jhvhs
   - name: Long Nguyen
     github: lnguyen
+  - name: Maya Rosecrance
+    github: mrosecrance
   - name: Rajan Agaskar
     github: ragaskar
   repositories:
@@ -234,6 +236,8 @@ areas:
   approvers:
   - name: Rajan Agaskar
     github: ragaskar
+  - name: Maya Rosecrance
+    github: mrosecrance
   - name: Brian Upton
     github: ystros
   - name: Matthias Vach
@@ -294,6 +298,8 @@ areas:
     github: nouseforaname
   - name: Rajan Agaskar
     github: ragaskar
+  - name: Maya Rosecrance
+    github: mrosecrance
   - name: Kenneth Lakin
     github: klakin-pivotal
   - name: Daniel Felipe Ochoa


### PR DESCRIPTION
I need to be able to keep track of release progress in the OS Concourse instance. I didn't think I needed code access which is why I allowed myself to be removed in https://github.com/cloudfoundry/community/commit/71fa9c498ac308eb1dc73db19b775451b52d1f04#diff-d3c528a51643cefd2dfa0235766b810fbb9c698bbe4e88a5f8a601f4bde8ba55L93 but this turns out to have been a mistake