### PR TITLE
Assigning number 0032 to RFC from PR #941

### DIFF
--- a/toc/rfc/assign-rfc-number.sh
+++ b/toc/rfc/assign-rfc-number.sh
@@ -27,7 +27,7 @@ NOPUSH=${NOPUSH:-}
 #
 
 generate_id() {
-  id="$(find "$script_dir" -maxdepth 2 -type f -exec basename {} \; | sed 's/[^0-9]*//' | sed -E 's|^([[:digit:]]{4})-.*$|\1|' | sort | tail -n 1 | sed 's/^0*//')"
+  id="$(find "$script_dir" -maxdepth 2 -type f -exec basename {} \; | grep -E '^rfc-[0-9]{4}-' | sed 's/[^0-9]*//' | sed -E 's|^([[:digit:]]{4})-.*$|\1|' | sort | tail -n 1 | sed 's/^0*//')"
   ((id++))
   printf "%04d" "${id}"
 }

--- a/toc/rfc/rfc-0032-cfapiv2-eol.md
+++ b/toc/rfc/rfc-0032-cfapiv2-eol.md
@@ -3,8 +3,8 @@
 - Name: CF API v2 End of Life
 - Start Date: 2024-08-08
 - Author(s): stephanme
-- Status: Draft <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
-- RFC Pull Request: [#941](https://github.com/cloudfoundry/community/pull/941)
+- Status: Accepted
+- RFC Pull Request: [community#941](https://github.com/cloudfoundry/community/pull/941)
 
 
 ## Summary


### PR DESCRIPTION
- fix assign-rfc-number.sh script to deal with RFC drafts containing numbers in file name like rfc-draft-cfapiv2-eol.md