### PR TITLE
Make RFC merge commit SHA required parameter for assign-rfc-number

### DIFF
--- a/toc/rfc/README.md
+++ b/toc/rfc/README.md
@@ -38,7 +38,7 @@ The [`assign-rfc-number.sh`](assign-rfc-number.sh) script will assign the next R
 
 1. Check out the `main` branch at the RFC PR merge commit.
 1. Change into the `toc/rfc` directory.
-1. Run `./assign-rfc-number.sh`.
+1. Run `./assign-rfc-number.sh <rfc-merge-commit-sha>` where `<rfc-merge-commit-sha>` is the "commit-ish" (commit SHA or commit expression) that resolves to the merge commit of the RFC.
 1. If you had set `NOPUSH=true` when running the script, push the numbering commit to `main`.
 
 Script options, to be set via environment variable (such as `DEBUG=true ./assign-rfc-number.sh`):
@@ -47,7 +47,6 @@ Script options, to be set via environment variable (such as `DEBUG=true ./assign
 * `REPO`: Sets the name of the repository. (Default: `community`)
 * `DEBUG`: Set to a nonzero value to enable script debugging via the `-x` flag in Bash. (Default: unset)
 * `NOPUSH`: Set to a nonzero value not to push the renumbering commit automatically. (Default: unset)
-* `RFC_MERGE_COMMITISH`: Set to a "commit-ish" (commit SHA or commit expression) that resolves to the merge commit of the RFC to number. (Default: `HEAD`)
 
 ## Managing Standards and Processes
 

--- a/toc/rfc/assign-rfc-number.sh
+++ b/toc/rfc/assign-rfc-number.sh
@@ -16,10 +16,15 @@ if [[ "${DEBUG}" ]] ; then
   set -x
 fi
 
+RFC_MERGE_COMMITISH=${1:-}
+if [[ -z "${RFC_MERGE_COMMITISH}" ]] ; then
+  >&2 echo "RFC merge commit SHA is required argument to execute the script. The SHA is needed to identify the RFC PR number."
+  exit 1
+fi
+
 OWNER=${OWNER:-cloudfoundry}
 REPO=${REPO:-community}
 MAIN_BRANCH=${MAIN_BRANCH:-main}
-RFC_MERGE_COMMITISH=${RFC_MERGE_COMMITISH:-HEAD}
 NOPUSH=${NOPUSH:-}
 
 ####
@@ -82,6 +87,7 @@ if [[ "$num_parents" -ne 2 ]]; then
   exit 2
 fi
 
+# lists all pull request HEADs and greps for the second parent of the RFC merge commit which is the RFC PR HEAD to get the PR number
 PR_NUMBER=$(git ls-remote origin 'pull/*/head' | grep -F -f <(git rev-parse "${RFC_MERGE_COMMITISH}^2") | awk -F'/' '{print $3}')
 
 RFC_ID=$(generate_id)


### PR DESCRIPTION
Often we forget to set the `RFC_MERGE_COMMITISH` env when a RFC merge commit is not the latest in the community repository. To avoid the errors listed below the script will require the merge commit SHA in the future.

https://github.com/cloudfoundry/community/commit/ccd3dbee9f2064423cdaf2e1f21bb221575798e9
https://github.com/cloudfoundry/community/commit/b75da18f4a3895b3e2248b25a43aea3f41f70a67
