### PR TITLE
Add "Acceptance Tests - MTA" to branch protection checks 

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -107,6 +107,7 @@ branch-protection:
             - "EasyCLA"
             - "Create Bosh Release"
             - "Acceptance Tests - Broker_Check"
+            - "Acceptance Tests - MTA"
             - "Build suite=test, mysql=8"
             - "Build suite=test, postgres=12"
             - "Build suite=integration, mysql=8"
@@ -142,7 +143,7 @@ branch-protection:
               teams: ["wg-app-runtime-interfaces-autoscaler-bots"]
           include: [ "^main$" ]
 
-          
+
         # Cloud Controller / CAPI related repos to skip branch protection on
         cf-performance-tests-pipeline:
           protect: false


### PR DESCRIPTION
This pull request includes a small change to the `org/branchprotection.yml` file. The change adds a new test to the branch protection rules.

* [`org/branchprotection.yml`](diffhunk://#diff-bf77010bb652c9edcda9b3c66c9d61c73fac7f7d890334b21f961f712654e9adR110): Added "Acceptance Tests - MTA" to the list of required status checks