### PR TITLE
add back cf-bosh-ci-bot that was removed in #992

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -32,6 +32,7 @@ contributors:
 - c0d1ngm0nk3y
 - ccjaimes
 - cf-buildpacks-eng
+- cf-bosh-ci-bot
 - cf-cli-eng
 - cf-final-release-election-bot
 - cf-frontend

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -45,6 +45,8 @@ bots:
   github: bosh-admin-bot
 - name: runtime-bot
   github: tas-runtime-bot
+- name: cf-bosh-ci-bot
+  github: cf-bosh-ci-bot
 - name: cf-uaa-ci-bot
   github: cf-identity
 - name: Cryogenics-CI


### PR DESCRIPTION
in PR #992 the cf-bosh-ci-bot was removed.
this bot is needed for several ci tasks in bosh.ci.cloudfoundry.org