### PR TITLE
[ARI] Modify autoscaler branch protection checks

### DIFF
--- a/org/branchprotection.yml
+++ b/org/branchprotection.yml
@@ -106,8 +106,8 @@ branch-protection:
             contexts:
             - "EasyCLA"
             - "Create Bosh Release"
-            - "Acceptance Tests - Broker_Check"
-            - "Acceptance Tests - MTA"
+            - "Acceptance Tests - BOSH release / Result"
+            - "Acceptance Tests - MTA / Result"
             - "Build suite=test, mysql=8"
             - "Build suite=test, postgres=12"
             - "Build suite=integration, mysql=8"


### PR DESCRIPTION
# Issue

Due to the setup of our acceptance test, the outcome of the acceptance tests was often not correctly reflected in the status checks.

# Fix

Switch to evaluating a common job in the workflow ("Result") to remove the source of issues.
