### PR TITLE
Inactive users to be removed from ARI WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -269,8 +269,6 @@ areas:
     github: FloThinksPi
   - name: Philipp Thun
     github: philippthun
-  - name: Merric de Launey
-    github: MerricdeLauney
   - name: Johannes Haass
     github: johha
   - name: Michael Oleske


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:
- @MerricdeLauney

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #1014