### PR TITLE
Remove inactive user "kmarkwardt-vmware"

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -115,7 +115,6 @@ contributors:
 - klakin-pivotal
 - klapkov
 - klaus-sap
-- kmarkwardt-vmware
 - kohara88
 - korifi-bot
 - kpujadev

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -207,8 +207,6 @@ areas:
     github: kimago
   - name: Ryan Wittrup
     github: ryanwittrup
-  - name: Kevin Markwardt
-    github: kmarkwardt-vmware
   reviewers:
   - name: Pascal Zimmermann
     github: ZPascal


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from FI WG approvers/reviewers/bots:

@kmarkwardt-vmware

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1014