### PR TITLE
Create new repo `credhub-oss-ci`

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -952,6 +952,11 @@ orgs:
         description: CredHub CLI provides a command line interface to interact with
           CredHub servers
         has_projects: true
+      credhub-oss-ci:
+        default_branch: main
+        has_projects: true
+        has_wiki: false
+        private: true
       credhub-perf-release:
         has_projects: true
       csb-brokerpak-aws:
@@ -2615,6 +2620,7 @@ orgs:
         privacy: closed
         repos:
           uaa-ci: admin
+          credhub-oss-ci: admin
       temp-prometheus-exporter-admins:
         description: "Temporary team for managing cf/ firehose exporter secrets until we have a permanent plan."
         maintainers:

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -74,6 +74,7 @@ areas:
   - cloudfoundry/credhub-api-site
   - cloudfoundry/credhub-cli
   - cloudfoundry/credhub-ci-locks
+  - cloudfoundry/credhub-oss-ci
   - cloudfoundry/credhub-perf-release
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)


### PR DESCRIPTION
- To contain part of CredHub CI code.
- To move some pipelines from an internal Concourse to the Foundation Concourse.