### PR TITLE
archive notifications repo, incorporated into notifications-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1873,6 +1873,7 @@ orgs:
         has_projects: true
       notifications:
         description: The notifications service component of Cloud Foundry
+        archived: true
         has_projects: true
         has_wiki: false
       notifications-release:

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -475,7 +475,6 @@ areas:
     github: evanfarrar
   repositories:
   - cloudfoundry/notifications-release
-  - cloudfoundry/notifications
   - cloudfoundry/app-runtime-interfaces-infrastructure
 
 - name: Stratos Console for Cloud Foundry


### PR DESCRIPTION
We no longer need the notifications repo as we've merged it into the notifications-release repo. 