### PR TITLE
Reduce freq of org management runs

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -9,7 +9,7 @@ on:
       - 'toc/working-groups/*.md'
       - '.github/workflows/org-management.yml'
   schedule:
-    - cron: '0 */7 * * *'
+    - cron: '0 */12 * * *'
 
 jobs:
   peribolos:


### PR DESCRIPTION
- every 12h instead of every 7h
- a successful run takes usually >8h and every second run gets aborted