### PR TITLE
Add Tim Downey as a Diego and Networking Reviewer

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -102,6 +102,8 @@ areas:
   reviewers:
   - name: Konstantin Lapkov
     github: klapkov
+  - name: Tim Downey
+    github: tcdowney
   repositories:
   - cloudfoundry/archiver
   - cloudfoundry/auction
@@ -366,6 +368,8 @@ areas:
     github: Mrizwanshaik
   - name: Michal Tekel
     github: mtekel
+  - name: Tim Downey
+    github: tcdowney
   repositories:
   - cloudfoundry/cf-lookup-route
   - cloudfoundry/cf-networking-helpers


### PR DESCRIPTION
I used to be a [Networking](https://github.com/cloudfoundry/routing-release/commits?author=tcdowney) contributor and work adjacently to Diego as a CAPI Approver. I'd like to stay up to date of changes to these projects and think being a bonafide "Reviewer" would help with that. Thanks for your consideration! 