### PR TITLE
Add Joe Eltgroth as contributor

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -232,3 +232,4 @@ contributors:
 - ZPascal
 - zucchinidev
 - nookala
+- joeeltgroth

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -67,6 +67,8 @@ areas:
   reviewers:
   - name: Duane May
     github: duanemay
+  - name: Joe Eltgroth
+    github: joeeltgroth
   repositories:
   - cloudfoundry-incubator/credhub-api-docs
   - cloudfoundry/credhub


### PR DESCRIPTION
New team member of the team supporting credhub at Broadcom