### PR TITLE
Update RFC 0027: Unify load balancing property name

### DIFF
--- a/toc/rfc/rfc-0027-generic-per-route-features.md
+++ b/toc/rfc/rfc-0027-generic-per-route-features.md
@@ -56,7 +56,7 @@ applications:
   routes:
   - route: example.com
     options:
-      loadbalancing-algorithm: round-robin
+      loadbalancing: round-robin
       connection-limit: 15
       session-cookie: FOOBAR
       trim-path: true
@@ -124,7 +124,7 @@ not final):
     "some_key": "some_value"
   },
   "options": {
-    "lb-algo": "least-conn",
+    "loadbalancing": "least-conn",
     "conn-limit": 100,
     "cookie": "my-session-cookie",
     "trim-path": true


### PR DESCRIPTION
In https://github.com/cloudfoundry/capi-release/issues/482, it was decided to unify the API property and internal state for the per-route load-balancing algorithm feature to `loadbalancing`. This was already introduced into cloud controller in https://github.com/cloudfoundry/cloud_controller_ng/pull/4080

The following component PRs accompany this change in the RFC:

* https://github.com/cloudfoundry/gorouter/pull/461
* https://github.com/cloudfoundry/route-registrar/pull/62
* https://github.com/cloudfoundry/routing-release/pull/449
* https://github.com/cloudfoundry/routing-info/pull/7
