### PR TITLE
Add Benjamin Guttmann as approver

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -286,6 +286,8 @@ areas:
     github: rajathagasthya
   - name: Ming Xiao
     github: mingxiao
+  - name: Benjamin Guttmann
+    github: benjaminguttmann-avtq
   reviewers:
   - name: Greg Meyer
     github: gm2552
@@ -295,8 +297,6 @@ areas:
     github: Sascha-Stoj
   - name: Felix Moehler
     github: fmoehler
-  - name: Benjamin Guttmann
-    github: benjaminguttmann-avtq
   repositories:
   - cloudfoundry/concourse-infra-for-fiwg
   - cloudfoundry/bosh-stemcells-ci
@@ -340,6 +340,8 @@ areas:
     github: rajathagasthya
   - name: Ming Xiao
     github: mingxiao
+  - name: Benjamin Guttmann
+    github: benjaminguttmann-avtq
   reviewers:
   - name: Greg Meyer
     github: gm2552
@@ -351,8 +353,6 @@ areas:
     github: Sascha-Stoj
   - name: Felix Moehler
     github: fmoehler
-  - name: Benjamin Guttmann
-    github: benjaminguttmann-avtq
   repositories:
   - cloudfoundry/bbl-state-resource
   - cloudfoundry/bosh


### PR DESCRIPTION
I would like to become an approver for bosh/ stemcell related topics. 

Please find the output of the script below


# Foundational Infrastructure: VM deployment lifecycle (BOSH) Contributions
### PRs Commented on/Reviewed:
- 2024-11-15T11:27:45Z: [Noble fallbackbootloader](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/390)
- 2024-11-25T14:05:13Z: [remove anything related to building softlayer.](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/394)
- 2024-11-25T14:32:10Z: [Noble remove centos opensuse](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/395)
- 2024-11-25T16:46:48Z: [Noble remove vcloud](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/396)
- 2024-11-26T12:24:28Z: [initial noble migration](https://github.com/cloudfoundry/docs-bosh/pull/855)
- 2024-12-12T13:35:08Z: [refactor stemcell repack script](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/401)
### Issues that may be relevant:
- 2018-07-05T09:23:37Z: [Adds ops file to enable graphite output for hm](https://github.com/cloudfoundry/bosh-deployment/pull/268)
- 2019-02-04T14:18:03Z: [Update outdated s3cli version](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/78)
- 2019-02-04T14:20:29Z: [Bumps s3cli version to v0.0.80](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/79)
- 2019-03-26T07:56:59Z: [Change T2/T3 unlimited](https://github.com/cloudfoundry/bosh-aws-cpi-release/issues/97)
- 2019-04-08T08:15:51Z: [Bump os-conf to latest version (v20)](https://github.com/cloudfoundry/bosh-deployment/pull/348)
- 2020-01-13T08:35:07Z: [Add BBR source files ops](https://github.com/cloudfoundry/bosh-deployment/pull/380)
- 2020-01-27T14:06:26Z: [Add BBR source files ops](https://github.com/cloudfoundry/bosh-deployment/pull/383)
- 2020-01-27T14:12:10Z: [[misc][source-releases] Adds ops file to use source files for bbr](https://github.com/cloudfoundry/bosh-deployment/pull/384)
- 2020-02-05T04:01:49Z: [Bump offline uaa ops](https://github.com/cloudfoundry/bosh-deployment/pull/385)
- 2020-03-26T08:55:24Z: [Add syslog auto update + Add syslog no internet ops](https://github.com/cloudfoundry/bosh-deployment/pull/392)
- 2020-07-06T08:28:50Z: [[ci] Add auto-bump for alicloud stemcell + cpi](https://github.com/cloudfoundry/bosh-deployment/pull/394)
- 2020-07-06T13:50:51Z: [[alicloud] Add missing agent blobstore config](https://github.com/cloudfoundry/bosh-deployment/pull/395)
- 2020-10-28T08:12:46Z: [Add openstack raw stemcell](https://github.com/cloudfoundry/bosh-deployment/pull/403)
- 2021-03-01T09:43:34Z: [Creating a new release](https://github.com/cloudfoundry/os-conf-release/issues/59)
- 2021-03-09T07:15:26Z: [[ci] Add auto-bump for alicloud stemcell](https://github.com/cloudfoundry/bosh-deployment/pull/412)
- 2021-04-21T07:39:45Z: [Bump alicloud CPI v34.0.0](https://github.com/cloudfoundry/bosh-deployment/pull/415)
- 2021-06-14T09:16:28Z: [TLS handshake failures after CPI switch to storage.googleapis.com](https://github.com/cloudfoundry/bosh-deployment/issues/419)
- 2021-07-13T08:03:33Z: [[alicloud-cpi] Bump CPI to v39.0.0](https://github.com/cloudfoundry/bosh-deployment/pull/420)
- 2021-10-22T07:44:15Z: [No_Proxy settings getting ignored by Health Monitor](https://github.com/cloudfoundry/bosh/issues/2331)
- 2022-05-25T08:31:57Z: [Use director proxy_timeout also for metrics server](https://github.com/cloudfoundry/bosh/pull/2381)
- 2023-05-23T10:02:41Z: [Add a job for custom drain scripts](https://github.com/cloudfoundry/os-conf-release/pull/66)
- 2023-07-13T09:46:55Z: [Fix code formatting on AZs page.](https://github.com/cloudfoundry/docs-bosh/pull/796)
- 2024-03-01T10:05:44Z: [Update binary s3 bucket information](https://github.com/cloudfoundry/bosh-s3cli/pull/36)
- 2024-05-17T08:43:39Z: [Health_Monitor stop sending logs](https://github.com/cloudfoundry/bosh/issues/2522)
- 2024-05-24T11:36:10Z: [Health-Monitor fails to start because of NATS?](https://github.com/cloudfoundry/bosh/issues/2524)
- 2024-10-17T14:03:17Z: [Remove non existing stemcells from stemcell overview](https://github.com/cloudfoundry/bosh-io-web/pull/64)
- 2024-11-26T12:24:28Z: [initial noble migration](https://github.com/cloudfoundry/docs-bosh/pull/855)
- 2024-12-04T08:09:11Z: [Adding noble migration to migrations section/ Adding title to document](https://github.com/cloudfoundry/docs-bosh/pull/859)
- 2024-12-04T11:29:58Z: [Remove duplicate heading for noble migration docs](https://github.com/cloudfoundry/docs-bosh/pull/860)
### Code contributions:
- 2018-07-05T09:22:39Z: [Adds ops file to enable graphite output for hm](https://github.com/cloudfoundry/bosh-deployment/commit/ad0d6cdb837f4b9dc39a06e73a602ee8f31bb189)
- 2019-02-04T14:16:18Z: [Bumps s3cli version to v0.0.80](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/e0ce522b66367d9fc57c8d16885c29bb554867d5)
- 2020-01-27T14:16:20Z: [[misc][source-releases] Adds ops file to use source files for bbr](https://github.com/cloudfoundry/bosh-deployment/commit/7f599c92fdf8aa832901695dd39d9d4bb715f7a2)
- 2020-03-26T08:51:49Z: [Add update syslog release to CI](https://github.com/cloudfoundry/bosh-deployment/commit/b47edc395c0ef83445f3cb577372df17be65aa19)
- 2020-03-26T08:53:39Z: [Add no-internet-access ops file for syslog release](https://github.com/cloudfoundry/bosh-deployment/commit/93b52b4bde27258981de71e9396bb6136e90078e)
- 2020-07-06T08:23:14Z: [[ci] Add auto-bump for alicloud stemcell + cpi](https://github.com/cloudfoundry/bosh-deployment/commit/b2c42a116212159d417abdc2611ffc1c75c67f31)
- 2020-07-06T08:28:34Z: [[ci] Adjust aliclouds stemcell resource](https://github.com/cloudfoundry/bosh-deployment/commit/6aedbec3a110571ea94b4ae302c5e714fca4c6a5)
- 2020-07-06T13:50:08Z: [[alicloud] Add missing agent blobstore config](https://github.com/cloudfoundry/bosh-deployment/commit/d4d83430f22dde525290fbb195bc586462255432)
- 2020-10-28T07:53:08Z: [[openstack] Add ops file to use raw stemcell](https://github.com/cloudfoundry/bosh-deployment/commit/011adb0c5354d888b81453d1714986f77e8a9ff5)
- 2020-10-28T08:10:19Z: [[openstack] Add auto-bump for openstack-raw stemcell](https://github.com/cloudfoundry/bosh-deployment/commit/6b0aff0b3e8de3f36b7533e73001603bc37bf276)
- 2021-03-09T07:13:42Z: [[ci] Add auto-bump for alicloud stemcell](https://github.com/cloudfoundry/bosh-deployment/commit/7c43a40a15a742cdb3a8a47242649c0200959724)
- 2021-04-21T07:38:07Z: [Bump alicloud CPI v34.0.0](https://github.com/cloudfoundry/bosh-deployment/commit/5bf3558f7814ba4ca4542aec594770c916a9987a)
- 2023-07-13T09:46:19Z: [Fix code formatting on AZs page.](https://github.com/cloudfoundry/docs-bosh/commit/0dfb0811ff20cd2aee928e3e67fd50865d5e6e08)
- 2023-07-13T09:54:03Z: [Fix code formatting on AZs page.](https://github.com/cloudfoundry/docs-bosh/commit/0dfb0811ff20cd2aee928e3e67fd50865d5e6e08)
- 2024-03-01T10:04:27Z: [Update binary s3 bucket information](https://github.com/cloudfoundry/bosh-s3cli/commit/303553345c7dde84587ba83599e03cdb092fa690)
- 2024-10-17T14:02:04Z: [Remove non existing stemcells from stemcell overview](https://github.com/cloudfoundry/bosh-io-web/commit/53fc5f0ef9888eb6acb5bbdf92cbcb0b137fe205)
- 2024-12-04T08:08:03Z: [Adding noble migration to migrations section/ Adding title to document](https://github.com/cloudfoundry/docs-bosh/commit/776d4c2220d79edca9eeb7803db4a96edfcca51a)
- 2024-12-04T11:27:28Z: [Remove duplicate heading for noble migration docs](https://github.com/cloudfoundry/docs-bosh/commit/9e175f44bacc377fd55855f81c9cb56d93b93183)
