### PR TITLE
Add Yusmen Zabanov to the cf-on-k8s working group

### DIFF
--- a/org/contributors.yml
+++ b/org/contributors.yml
@@ -205,6 +205,7 @@ contributors:
 - toabctl
 - torsten-sap
 - totherme
+- uzabanov
 - vinaybheri
 - vipinvkmenon
 - vkalapov
@@ -220,7 +221,6 @@ contributors:
 - xtremerui
 - Yavor16
 - ystros
-- zabanov-lab
 - ZPascal
 - zucchinidev
 - nookala

--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -53,6 +53,8 @@ areas:
     github: julian-hj
   - name: Tim Downey
     github: tcdowney
+  - name: Yusmen Zabanov
+    github: uzabanov
   repositories:
   - cloudfoundry/cf-k8s-secrets
   - cloudfoundry/korifi


### PR DESCRIPTION
- He has been part of the core Korifi team rotation for a couple of
  months now
- He has renamed his github handle, so this is also reflected in this PR
