### PR TITLE
Propose addition of Concourse working group

### DIFF
--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -232,7 +232,7 @@ This working group has no repositories in the `cloudfoundry` GitHub organization
 | Artifact                   | Link |
 | -------------------------- | ---- |
 | Charter                    | [concourse.md](./concourse.md) |
-| Forum                      | TBD  |
+| Forum                      | [GitHub Discussions](https://github.com/concourse/concourse/discussions)  |
 | Community Meeting Calendar | TBD  |
 | Meeting Notes              | TBD  |
 | Slack Channel              | TBD  |

--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -223,7 +223,7 @@ Mission: Provides discreet management of security vulnerabilities issues relevan
 | <img width="30px" src="https://github.com/paulcwarren.png"> | Paul Warren       | VMWare  | [@paulcwarren](https://github.com/paulcwarren) |
 
 
-## Working Group Template
+## Concourse
 
 Mission: Provides the Concourse CI/CD platform.
 

--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -43,6 +43,7 @@ The current working groups are:
 - Paketo
 - Service Management
 - Vulnerability Management
+- Concourse
 
 
 ## App Runtime Deployments
@@ -220,6 +221,27 @@ Mission: Provides discreet management of security vulnerabilities issues relevan
 | &nbsp;                                                   | Leads            | Company | Profile                                 |
 | -------------------------------------------------------- | ---------------- | ------- | --------------------------------------- |
 | <img width="30px" src="https://github.com/paulcwarren.png"> | Paul Warren       | VMWare  | [@paulcwarren](https://github.com/paulcwarren) |
+
+
+## Working Group Template
+
+Mission: Provides the Concourse CI/CD platform.
+
+This working group has no repositories in the `cloudfoundry` GitHub organization.
+
+| Artifact                   | Link |
+| -------------------------- | ---- |
+| Charter                    | [concourse.md](./concourse.md) |
+| Forum                      | TBD  |
+| Community Meeting Calendar | TBD  |
+| Meeting Notes              | TBD  |
+| Slack Channel              | TBD  |
+
+| &nbsp;                                                   | Leads            | Company | Profile                                 |
+| -------------------------------------------------------- | ---------------- | ------- | --------------------------------------- |
+| <img width="30px" src="https://github.com/drich10.png"> | Derek Richard       | Broadcom  | [@drich10](https://github.com/drich10) |
+| <img width="30px" src="https://github.com/taylorsilva.png"> | Taylor Silva       |   | [@taylorsilva](https://github.com/taylorsilva) |
+
 
 <!--
 ## Working Group Template

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -47,6 +47,10 @@ areas:
     github: Spimtav
   - name: Harish Yayi
     github: yharish991
-  reviewers: []
+  reviewers:
+  - name: Ivan Chalukov
+    github: IvanChalukov
+  - name: Kump3r
+    github: Kump3r
   repositories: []
 ```

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -1,0 +1,60 @@
+# Concourse: Working Group Charter
+
+## Mission
+
+Provides the Concourse CI/CD platform.
+
+## Goals
+* Provides a stable and up to date CI/CD platform.
+
+## Scope
+* Maintain public roadmaps for Concourse.
+* Provide the community with regular releases of Concourse.
+* Provide timely releases to address CVEs.
+* Provide the community with technical and end user documentation.
+* Collaborate with other working groups to continue to have first-class support with Cloud Foundry.
+
+## Non-Goals
+
+* Require other working groups or projects to use Concourse.
+
+## Working Group Governance Structure
+
+[Working group governance structure](https://github.com/concourse/governance)
+
+## Membership
+
+[Working group membership](https://github.com/concourse/governance/blob/master/teams/maintainers.yml)
+
+## Roles & Technical Assets
+
+Technical assets for the Concourse working group are contained in the following Github Organizations:
+
+* [github.com/concourse](https://github.com/concourse)
+
+```yaml
+name: Concourse
+execution_leads:
+- name: Derek Richard
+  github: drich10
+- name: Taylor Silva
+  github: taylorsilva
+technical_leads:
+- name: Derek Richard
+  github: drich10
+- name: Taylor Silva
+  github: taylorsilva
+areas:
+- name: Maintainers
+  approvers:
+  - name: Indira
+    github: ichandrabhatta
+  - name: Wayne Adams
+    github: wayneadams
+  - name: Claire Tinati
+    github: Spimtav
+  - name: Harish Yayi
+    github: yharish991
+  reviewers: []
+  repositories: []
+```

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -18,14 +18,6 @@ Provides the Concourse CI/CD platform.
 
 * Require other working groups or projects to use Concourse.
 
-## Working Group Governance Structure
-
-[Working group governance structure](https://github.com/concourse/governance)
-
-## Membership
-
-[Working group membership](https://github.com/concourse/governance/blob/master/teams/maintainers.yml)
-
 ## Roles & Technical Assets
 
 Technical assets for the Concourse working group are contained in the following Github Organizations:
@@ -45,7 +37,7 @@ technical_leads:
 - name: Taylor Silva
   github: taylorsilva
 areas:
-- name: Maintainers
+- name: Core
   approvers:
   - name: Indira
     github: ichandrabhatta

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -24,7 +24,7 @@ Technical assets for the Concourse working group are contained in the following 
 
 * [github.com/concourse](https://github.com/concourse)
 
-```yaml
+```
 name: Concourse
 execution_leads:
 - name: Derek Richard

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -52,5 +52,47 @@ areas:
     github: IvanChalukov
   - name: Kump3r
     github: Kump3r
-  repositories: []
+  repositories:
+  - concourse/concourse
+  - concourse/concourse-bosh-release
+  - concourse/ci
+  - concourse/docs
+  - concourse/dex
+  - concourse/semver-resource
+  - concourse/houdini
+  - concourse/concourse-bosh-deployment
+  - concourse/registry-image-resource
+  - concourse/hg-resource
+  - concourse/github-release-resource
+  - concourse/bosh-io-stemcell-resource
+  - concourse/docker-image-resource
+  - concourse/rfcs
+  - concourse/blog
+  - concourse/concourse-chart
+  - concourse/mock-resource
+  - concourse/infrastructure
+  - concourse/concourse-docker
+  - concourse/git-resource
+  - concourse/examples
+  - concourse/flag
+  - concourse/s3-resource
+  - concourse/pool-resource
+  - concourse/resource-types-website
+  - concourse/resource-types
+  - concourse/oci-build-task
+  - concourse/time-resource
+  - concourse/bosh-io-release-resource
+  - concourse/retryhttp
+  - concourse/prod
+  - concourse/booklit
+  - concourse/oxygen-mask
+  - concourse/datadog-event-resource
+  - concourse/office-hours #here and below is either archived, or we expect to archive in near the future
+  - concourse/governance
+  - concourse/.github
+  - concourse/hush-house
+  - concourse/tracker-resource
+  - concourse/baggage-claim
+  - concourse/buildroot-images
+  - concourse/concourse-pipeline-resource
 ```


### PR DESCRIPTION
👋 We'd like to propose inclusion of the [Concourse project](https://github.com/concourse) in the CFF, and in service of that, create a working group to develop and maintain the future of it. Concourse has been an integral part of Cloud Foundry's CI/CD story and we'd love to keep these projects in close proximity.

With respect to the folks listed in the PR, this is an initial list of _known_ contributors we expect to be a part of the project. We are open to additional members within the group 🙏 .

We'd like to migrate to the CFF's processes and tooling for governance as Concourse is onboarded and the tooling is updated to handle repositories in separate Github organizations. 