### PR TITLE
Fix PR link of RFC 0028

### DIFF
--- a/toc/rfc/rfc-0028-cnb-lifecycle.md
+++ b/toc/rfc/rfc-0028-cnb-lifecycle.md
@@ -5,7 +5,7 @@
 - Start Date: 2024-03-19
 - Author(s): @c0d1ngm0nk3y, @pbusko, @nicolasbender, @modulo11
 - Status: Accepted
-- RFC Pull Request: [community#831](https://github.com/cloudfoundry/community/pull/831)
+- RFC Pull Request: [community#796](https://github.com/cloudfoundry/community/pull/796)
 - Updates: [RFC 0017](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0017-add-cnbs.md)
 
 ## Summary


### PR DESCRIPTION
We had a [bug](https://github.com/cloudfoundry/community/pull/1010) in our RFC number generation script which is fixed in the meantime but here is another RFC with a wrong pr link.