### PR TITLE
[ARI] Add Daniel Garnier-Moiroux as Java Tools contributor

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -388,6 +388,8 @@ areas:
   reviewers:
   - name: Georg Lokowandt
     github: Lokowandtg
+  - name: Daniel Garnier-Moiroux
+    github: kehrlann
   approvers:
   - name: Daniel Mikusa
     github: dmikusa


### PR DESCRIPTION
Hey team,

I'm Daniel, from Broadcom. Currently working on the UAA.
I will also be working with on the cf-java-client with Anthony and David.