### PR TITLE
Remove app-runtime-interfaces-infrastructure from Docs WG

### DIFF
--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -60,5 +60,4 @@ areas:
   - cloudfoundry/docs-services
   - cloudfoundry/docs-credhub
   - cloudfoundry/docs-dotnet-core-tutorial
-  - cloudfoundry/app-runtime-interfaces-infrastructure
 ```


### PR DESCRIPTION
Every repo can belong to one WG only according to [rfc-0007-repository-ownership](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0007-repository-ownership.md).

I added recently a validation of this rule the org automation (#1057) and app-runtime-interfaces-infrastructure is the only repo that is part of 2 WGs. This PR cleans this up.

In case you need approver access to app-runtime-interfaces-infrastructure, we find a solution like creating a separate area in ARI WG.