### PR TITLE
Remove bot user from ARI Terraform Provider

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -422,9 +422,6 @@ areas:
     github: Dray56
   - name: Gourab Mukherjee
     github: Gourab1998
-  bots:
-  - name: SAP OSPO Bot
-    github: SAP-OSPO-ADMIN
   repositories:
   - cloudfoundry/terraform-provider-cloudfoundry
 


### PR DESCRIPTION
SAP-OSPO-ADMIN github user was invited to cloudfoundry org but the invitation was rejected or expired. As a consequence, the org automation fails.