### PR TITLE
Adjust contributions script to confirm deletion without prompting

### DIFF
--- a/toc/working-groups/contributions-for-user.sh
+++ b/toc/working-groups/contributions-for-user.sh
@@ -30,7 +30,7 @@ usage_checks() {
   fi
 
   if gist_url=$(echo "test" | gh gist create -d test -f test - 2>/dev/null); then
-    gh gist delete "${gist_url}" >/dev/null 2>&1
+    gh gist delete "${gist_url}" --yes >/dev/null 2>&1
   else 
     echo 'Please login to GitHub with the `gh` cli using credentials with permissions to create gists' >&2
     exit 1


### PR DESCRIPTION
Adjust contributions script to confirm "gh gist delete" without prompting.

The script is hanging on
```
Parsing working group metadata...

```
with git hub cli

```
gh version 2.66.1 (2025-01-31)
https://github.com/cli/cli/releases/tag/v2.66.1
```
