### PR TITLE
Make `joeeltgroth` CredHub repo approver

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -62,6 +62,8 @@ areas:
     github: hsinn0
   - name: Prateek Gangwal
     github: coolgang123
+  - name: Joe Eltgroth
+    github: joeeltgroth
   - name: Markus Strehle
     github: strehle
   reviewers:
@@ -69,8 +71,6 @@ areas:
     github: duanemay
   - name: Behrouz Soroushian
     github: bsoroushian
-  - name: Joe Eltgroth
-    github: joeeltgroth
   - name: Ajita Jain
     github: jajita
   - name: Andrew Costa


### PR DESCRIPTION
- Joe has been working on major feature to replace ouath2 library since last year.
- We want to have a feature branch in the repo that can be worked by multiple team members.
- For that, we want to make Joe CredHub repo approver now instead of having to wait to meet all the usual requirements.