### PR TITLE
Ignore concourse WG in parsable-working-groups

### DIFF
--- a/toc/working-groups/parsable-working-groups.sh
+++ b/toc/working-groups/parsable-working-groups.sh
@@ -11,7 +11,7 @@ for group in $(ls ../*.md | grep -v -e ROLES -e CHANGEPLAN -e PRINCIPLES -e GOVE
         ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
 done
 
-for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability); do
+for working_group in $(ls *.md | grep -v -e WORKING-GROUPS -e paketo -e vulnerability -e concourse); do
       cat ${working_group} | awk '/^```yaml$/{flag=1;next}/^```$/{flag=0}flag' | \
             ruby -rjson -ryaml -e "puts YAML.load(ARGF.read).to_json" 2> /dev/null | jq '[.]'
 done


### PR DESCRIPTION
The `concourse` WG doesn't have a yaml block yet and should be ignored by the parsable-working-groups script. Otherwise the script returns only a `false` value for the WG which brakes other automatons using this script. 