### PR TITLE
Add "brokerapi" repo to CloudFoundry

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -432,6 +432,10 @@ orgs:
         description: Buildpack Runtime Acceptance Tests
         has_projects: false
         has_wiki: false
+      brokerapi:
+        description: A Go package for implementing the V2 Open Service Broker API
+        has_projects: false
+        has_wiki: true
       bsdtar:
         has_projects: true
         has_wiki: false

--- a/toc/working-groups/service-management.md
+++ b/toc/working-groups/service-management.md
@@ -58,6 +58,7 @@ areas:
   - cloudfoundry/terraform-provider-csbpg
   - cloudfoundry/terraform-provider-csbmysql
   - cloudfoundry/terraform-provider-csbsqlserver
+  - cloudfoundry/brokerapi
 - name: OSB API
   approvers:
   - name: Rodrigo Sampaio Vaz


### PR DESCRIPTION
Add the repo: https://github.com/pivotal-cf/brokerapi

This repo is a commonly used Go implementation of the Open Service Broker API which is part of this working group. It makes sense for it to reside here.