### PR TITLE
remove inactive ARP users

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -259,44 +259,16 @@ areas:
   approvers:
   - name: Jeanette Booher
     github: jbooherl
-  - name: Aditya Choudhary
-    github: aditya267vmware
   - name: Chaitanya Krishna Mullangi
     github: chaitanyamullangi
-  - name: Dibyajyoti Mohapatra
-    github: dibya1947
   - name: Kanika Bathla
     github: kabathla
-  - name: Karthik Seshadri
-    github: karthikseshadri
-  - name: Mervin Nirmal John M W
-    github: jmervinnirma
-  - name: Mohammed Thavaf A R
-    github: m-thavaf
-  - name: Mukesh Khicher
-    github: mukeshkhicher-br
-  - name: Nakul Ogale
-    github: nakulogale-cb
-  - name: Pranay Raj
-    github: rpranay1
-  - name: Puja Kumari
-    github: kpujadev
-  - name: Radhakrishnan Devarajan
-    github: radhavmwtnz
   - name: Saloni Shah
     github: saloni-sshah
-  - name: Sanand Dange
-    github: dsanand22
-  - name: Shefali Dubey
-    github: dubeyshefali
   - name: Shrisha Chandrashekar
     github: shrisha-c
-  - name: Siddartha Laxman Karibhimanvar
-    github: siddarthalk
   - name: Srinivas Sunka
     github: ssunka
-  - name: Sudharsan G V
-    github: sg038444
   repositories:
   - cloudfoundry/metric-store-ci
   - cloudfoundry/metric-store-release


### PR DESCRIPTION
This PR removes the following inactive users from the ARP WG: 
@kpujadev
@rpranay1
@dsanand22
@karthikseshadri
@dibya1947
@dubeyshefali
@aditya267vmware
@m-thavaf
@sg038444
@radhavmwtnz
@siddarthalk
@nakulogale-cb
@jmervinnirma
@mukeshkhicher-br

You have been [marked inactive](https://github.com/cloudfoundry/community/pull/1068) because you have not made a commit, issue, or PR to any cloud foundry repo in over a year. You have 2 weeks to dispute this change. To dispute please: (1) comment on this PR (2) do an activity (make a commit, issue or PR) so that the bots will know you are active.

I will merge this PR on or after Tuesday March 4th.