### PR TITLE
Remove admins for pcap and pcap-release

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -2608,8 +2608,6 @@ orgs:
         privacy: closed
         repos:
           haproxy-boshrelease: admin
-          pcap-release: admin
-          pcap: admin
       temp-sm-csb-bots-admins:
         description: "Temporary team to allow for bots driven dependency bumps until we implement another strategy"
         maintainers:


### PR DESCRIPTION
The `pcap` and `pcap-release` repositories have been [archived](https://github.com/cloudfoundry/community/pull/1076) and `pcap` even deleted. That is why, we don't need the admin user configuration any more. This is also breaking the [Sync Github Organization Settings](https://github.com/cloudfoundry/community/actions/runs/13402627003/job/37436493835) GitHub action.