### PR TITLE
archive inlined routing-release submodules

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -699,6 +699,7 @@ orgs:
       cf-routing-test-helpers:
         default_branch: main
         has_projects: true
+        archived: true
       cf-slackin:
         has_projects: true
         private: true
@@ -714,6 +715,7 @@ orgs:
         default_branch: main
         description: TCP Router repository for Cloud Foundry
         has_projects: true
+        archived: true
       cf-test-helpers:
         default_branch: main
         description: Helpers for running tests against Cloud Foundry
@@ -2058,6 +2060,7 @@ orgs:
       routing-acceptance-tests:
         default_branch: main
         has_projects: true
+        archived: true
       routing-api:
         default_branch: main
         has_projects: false
@@ -2065,6 +2068,7 @@ orgs:
       routing-api-cli:
         default_branch: main
         has_projects: true
+        archived: true
       routing-ci:
         archived: true
         has_projects: true

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -370,8 +370,6 @@ areas:
   - cloudfoundry/cf-networking-helpers
   - cloudfoundry/cf-networking-onboarding
   - cloudfoundry/cf-networking-release
-  - cloudfoundry/cf-routing-test-helpers
-  - cloudfoundry/cf-tcp-router
   - cloudfoundry/gorouter
   - cloudfoundry/haproxy-boshrelease
   - cloudfoundry/healthchecker-release
@@ -381,9 +379,7 @@ areas:
   - cloudfoundry/pcap-release
   - cloudfoundry/policy_client
   - cloudfoundry/route-registrar
-  - cloudfoundry/routing-acceptance-tests
   - cloudfoundry/routing-api
-  - cloudfoundry/routing-api-cli
   - cloudfoundry/routing-concourse
   - cloudfoundry/routing-info
   - cloudfoundry/routing-release


### PR DESCRIPTION
See: https://github.com/cloudfoundry/routing-release/pull/457