### PR TITLE
Use markdown checklists instead of tasklists for the RFC tracking template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/rfc-issue-template.md
@@ -13,7 +13,5 @@ CF-Deployment version:
 CLI version:
 CF Docs:
 
-```[tasklist]
 ### Tasks
-- [ ] ...
-```
+- [ ] TODO: link prs and issues


### PR DESCRIPTION
Github [taskslist are deprecated](https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#tasklist-blocks-will-be-retired-and-replaced-with-sub-issues) and Github suggest to use sub-issues instead but I don't think that we should force project to start creating issues for everything. That is why, I suggest to switch to markdown checklists.