### PR TITLE
fix: remove duplicate user

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -346,8 +346,6 @@ areas:
     github: peanball
   - name: Plamen Doychev
     github: PlamenDoychev
-  - name: Patrick Lowin
-    github: plowin
   reviewers:
   - name: Soha Alboghdady
     github: Soha-Albaghdady


### PR DESCRIPTION
With #1046 I added Patrick as an approver as part of the networking area merge but missed that he already was an approver. This commit removes the duplicate mention.