### PR TITLE
Revert "Unarchive docs-deploying-cf"

### DIFF
--- a/org/cloudfoundry.yml
+++ b/org/cloudfoundry.yml
@@ -1152,7 +1152,6 @@ orgs:
       docs-deploying-cf:
         description: The docs repo for material on deploying Cloud Foundry
         has_projects: true
-        archived: false
       docs-dev-guide:
         description: Documentation for application developers who want to deploy their
           applications to Cloud Foundry


### PR DESCRIPTION
This didn't work with the error msg:
`{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure cloudfoundry repos: asked to unarchive an archived repo, unsupported by GH API","severity":"fatal","time":"2025-03-20T02:34:44Z"}`

This reverts commit 8162ce94813e9a909d82e8f1cf6793648893bd04.