### PR TITLE
Removes klakin-pivotal from various lists

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -110,7 +110,6 @@ orgs:
     - KesavanKing
     - kevin-ortega
     - kimago
-    - klakin-pivotal
     - klapkov
     - klaus-sap
     - kohara88

--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -83,8 +83,6 @@ areas:
     github: blgm
   - name: Iain Findlay
     github: ifindlay-cci
-  - name: Kenneth Lakin
-    github: klakin-pivotal
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Konstantin Semenov

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -124,8 +124,6 @@ areas:
     github: blgm
   - name: Iain Findlay
     github: ifindlay-cci
-  - name: Kenneth Lakin
-    github: klakin-pivotal
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Konstantin Semenov
@@ -267,8 +265,6 @@ areas:
     github: ramonskie
   - name: Daniel Felipe Ochoa
     github: danielfor
-  - name: Kenneth Lakin
-    github: klakin-pivotal
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Max Soest
@@ -327,8 +323,6 @@ areas:
     github: ragaskar
   - name: Maya Rosecrance
     github: mrosecrance
-  - name: Kenneth Lakin
-    github: klakin-pivotal
   - name: Daniel Felipe Ochoa
     github: danielfor
   - name: Brian Upton


### PR DESCRIPTION
Friday, April 11th is my last day at Broadcom. klakin-pivotal has always been a corporate-only account. With my departure, I will no longer be manning this account. So, let's remove it from positions of responsibility.