### PR TITLE
Add new WG CI bot that uses the CloudFoundry.org email account

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -43,6 +43,8 @@ technical_leads:
 bots:
 - name: CI Bot
   github: tas-runtime-bot
+- name: WG CI Bot
+  github: appruntimeplatform-bot
 - name: Networking CI Bot
   github: CFN-CI
 - name: CF Logging and Metrics Bot


### PR DESCRIPTION
In preparation for the transfer of Broadcom GCP accounts over to the CFF, we've created a new GitHub bot that is purely OSS.