### PR TITLE
Add ctlong to ARP WG - Metric Store area

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -278,6 +278,8 @@ areas:
     github: shrisha-c
   - name: Srinivas Sunka
     github: ssunka
+  - name: Carson Long
+    github: ctlong
   repositories:
   - cloudfoundry/metric-store-ci
   - cloudfoundry/metric-store-release


### PR DESCRIPTION
I would like to become an Approver in the ARP WG - Metric Store area.

There has been no commits to default branches of any of the repos owned by this area in 7+ months. There are many PRs in https://github.com/cloudfoundry/metric-store-release that are not being reviewed.