### PR TITLE
Add missing repo to list

### DIFF
--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -59,5 +59,6 @@ areas:
   - cloudfoundry/docs-dev-guide
   - cloudfoundry/docs-services
   - cloudfoundry/docs-credhub
+  - /cloudfoundry/docs-deploying-cf
   - cloudfoundry/docs-dotnet-core-tutorial
 ```

--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -59,6 +59,6 @@ areas:
   - cloudfoundry/docs-dev-guide
   - cloudfoundry/docs-services
   - cloudfoundry/docs-credhub
-  - /cloudfoundry/docs-deploying-cf
+  - cloudfoundry/docs-deploying-cf
   - cloudfoundry/docs-dotnet-core-tutorial
 ```


### PR DESCRIPTION
The docs-deploying-cf repo is used in building the CF docs, but it was missing from the assets list.