### PR TITLE
Promote new CF writers to Approver role to help with reviewing and merging Doc PRs

### DIFF
--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -31,6 +31,10 @@ name: Documentation
 execution_leads:
 - name: Anita Flegg
   github: anita-flegg
+- name: Stuart Clements
+  github: stuclem
+- name: Richard Johnson
+  github: RichardJJG
 technical_leads:
 - name: Anita Flegg
   github: anita-flegg


### PR DESCRIPTION
Richard Johnson and Stuart Clements are replacing Paul Spinrad in this role.