### PR TITLE
Support multiple orgs in inactive user deletion

### DIFF
--- a/orgs/org_user_management.py
+++ b/orgs/org_user_management.py
@@ -101,7 +101,9 @@ class InactiveUserHandler:
         path = f"{_SCRIPT_PATH}/contributors.yml"
         contributors_yaml = self._load_yaml_file(path)
         users_to_delete_lower = [user.lower() for user in users_to_delete]
-        contributors_yaml["orgs"][self.github_org]["contributors"] = [c for c in contributors_yaml["orgs"][self.github_org]["contributors"] if c.lower() not in users_to_delete_lower]
+        contributors_yaml["orgs"][self.github_org]["contributors"] = [
+            c for c in contributors_yaml["orgs"][self.github_org]["contributors"] if c.lower() not in users_to_delete_lower
+        ]
         self._write_yaml_file(path, contributors_yaml)
 
     def get_inactive_users_msg(self, users_to_delete, inactive_users_by_wg, tagusers):

--- a/orgs/org_user_management.py
+++ b/orgs/org_user_management.py
@@ -101,7 +101,7 @@ class InactiveUserHandler:
         path = f"{_SCRIPT_PATH}/contributors.yml"
         contributors_yaml = self._load_yaml_file(path)
         users_to_delete_lower = [user.lower() for user in users_to_delete]
-        contributors_yaml["contributors"] = [c for c in contributors_yaml["contributors"] if c.lower() not in users_to_delete_lower]
+        contributors_yaml["orgs"][self.github_org]["contributors"] = [c for c in contributors_yaml["orgs"][self.github_org]["contributors"] if c.lower() not in users_to_delete_lower]
         self._write_yaml_file(path, contributors_yaml)
 
     def get_inactive_users_msg(self, users_to_delete, inactive_users_by_wg, tagusers):


### PR DESCRIPTION
With the [change](https://github.com/cloudfoundry/community/commit/208be3b2ebb453d2e827fa3bc25b9aef54f3849e) we introduced multiple org support to [contributors.yml](https://github.com/cloudfoundry/community/blob/main/orgs/contributors.yml). This change adapts the inactive user deletion to work with the new structure of [contributors.yml](https://github.com/cloudfoundry/community/blob/main/orgs/contributors.yml).