### PR TITLE
remove inactive ARP users

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -75,24 +75,16 @@ areas:
   - cloudfoundry/cnbapplifecycle
 - name: Diego
   approvers:
-  - name: Andrew Crump
-    github: acrmp
-  - name: Benjamin Fuller
-    github: Benjamintf1
   - name: Brandon Roberson
     github: ebroberson
   - name: Geoff Franks
     github: geofffranks
-  - name: Josh Russett
-    github: jrussett
   - name: Maria Shaldybin
     github: mariash
   - name: Chris Selzo
     github: selzoc
   - name: Amin Jamali
     github: winkingturtle-vmw
-  - name: David Sabeti
-    github: dsabeti
   - name: Marc Paquette
     github: marcpaquette
   - name: Vladimir Savchenko
@@ -155,12 +147,8 @@ areas:
     github: georgethebeatle
   - name: Geoff Franks
     github: geofffranks
-  - name: Josh Russett
-    github: jrussett
   - name: Maria Shaldybin
     github: mariash
-  - name: David Sabeti
-    github: dsabeti
   - name: Marc Paquette
     github: MarcPaquette
   - name: Chris Selzo
@@ -202,14 +190,10 @@ areas:
 
 - name: Logging and Metrics
   approvers:
-  - name: Andrew Crump
-    github: acrmp
   - name: Benjamin Fuller
     github: Benjamintf1
   - name: Geoff Franks
     github: geofffranks
-  - name: Josh Russett
-    github: jrussett
   - name: Chris Selzo
     github: selzoc
   - name: Carson Long
@@ -218,8 +202,6 @@ areas:
     github: mkocher
   - name: Amin Jamali
     github: winkingturtle-vmw
-  - name: Rebecca Roberts
-    github: rroberts2222
   - name: Jovan Kostovski
     github: chombium
   reviewers:
@@ -270,10 +252,6 @@ areas:
     github: jbooherl
   - name: Chaitanya Krishna Mullangi
     github: chaitanyamullangi
-  - name: Kanika Bathla
-    github: kabathla
-  - name: Saloni Shah
-    github: saloni-sshah
   - name: Shrisha Chandrashekar
     github: shrisha-c
   - name: Srinivas Sunka
@@ -287,12 +265,8 @@ areas:
 
 - name: Networking
   approvers:
-  - name: Andrew Crump
-    github: acrmp
   - name: Tamara Boehm
     github: b1tamara
-  - name: Benjamin Fuller
-    github: Benjamintf1
   - name: Brandon Roberson
     github: ebroberson
   - name: Carson Long
@@ -303,8 +277,6 @@ areas:
     github: geofffranks
   - name: Greg Cobb
     github: Gerg
-  - name: Josh Russett
-    github: jrussett
   - name: Maria Shaldybin
     github: mariash
   - name: Matthew Kocher
@@ -317,8 +289,6 @@ areas:
     github: stefanlay
   - name: Amin Jamali
     github: winkingturtle-vmw
-  - name: David Sabeti
-    github: dsabeti
   - name: Maximilian Moehl
     github: maxmoehl
   - name: Marc Paquette


### PR DESCRIPTION
Removing inactive users from ARP. @acrmp, @Benjamintf1 , @jrussett , @dsabeti , @kabathla, @saloni-sshah, @rroberts2222

To dispute please: (1) comment on this PR (2) do an activity (make a commit, issue or PR) so that the bots will know you are active.

I will merge this PR on or after Tuesday May 20th.