### PR TITLE
Add chombium as approver for system logging and metrics

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -232,6 +232,8 @@ areas:
     github: ctlong
   - name: Ivan Protsiuk
     github: iprotsiuk
+  - name: Jovan Kostovski
+    github: chombium
   reviewers:
   - name: Rebecca Roberts
     github: rroberts2222


### PR DESCRIPTION
Add Jovan Kostovski, GitHub account `chombium` as approver for `System Logging and Metrics`.

I've been working with these releases with the past few years as active contributor in the Logging and Metrics team, I even have reviewed few PRs. As none of the listed approvers for the `System Logging and Metrics` group except @ctlong are active I think it would be good if we have another active approver for this group who will take care of the GitHub repos.

@ctlong, @ameowlia Would you be kind to take a look and approve this PR?