### PR TITLE
Remove inactive users from FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -116,16 +116,12 @@ areas:
     github: selzoc
   - name: Diego Lemos
     github: dlresende
-  - name: Gareth Smith
-    github: totherme
   - name: George Blue
     github: blgm
   - name: Iain Findlay
     github: ifindlay-cci
   - name: Konstantin Kiess
     github: nouseforaname
-  - name: Konstantin Semenov
-    github: jhvhs
   - name: Long Nguyen
     github: lnguyen
   - name: Maya Rosecrance
@@ -210,8 +206,6 @@ areas:
     github: abg
   - name: Colin Shield
     github: colins
-  - name: Kyle Ong
-    github: ohkyle
   - name: Kim Basset
     github: kimago
   - name: Ryan Wittrup
@@ -233,8 +227,6 @@ areas:
   - name: Ivan Protsiuk
     github: iprotsiuk
   reviewers:
-  - name: Rebecca Roberts
-    github: rroberts2222
   - name: Ausaf Ahmed
     github: aqstack
   - name: Glenn Oppegard
@@ -261,8 +253,6 @@ areas:
     github: cunnie
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Daniel Felipe Ochoa
-    github: danielfor
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Max Soest
@@ -323,8 +313,6 @@ areas:
     github: ragaskar
   - name: Maya Rosecrance
     github: mrosecrance
-  - name: Daniel Felipe Ochoa
-    github: danielfor
   - name: Brian Upton
     github: ystros
   - name: Chris Selzo
@@ -441,8 +429,6 @@ areas:
   approvers:
     - name: Benjamin Guttmann
       github: benjaminguttmann-avtq
-    - name: Ferran Rodenas
-      github: frodenas
     - name: Gilles Miraillet
       github: gmllt
     - name: Mario Di Miceli


### PR DESCRIPTION
According to this [pr](https://github.com/cloudfoundry/community/pull/1141) following users are inactive: @jhvhs, @frodenas, @rroberts2222, @pcf-core-services-writer, @danielfor, @totherme, @colins

To dispute please: (1) comment on this PR (2) do an activity (make a commit, issue or PR) so that the bots will know you are active.

We will merge this PR on or after Tuesday May 20th.