### PR TITLE
Add RichardJJG to contributors.yml

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -161,6 +161,7 @@ orgs:
     - rajathagasthya
     - ramonskie
     - reedr3
+    - RichardJJG
     - rlewis24
     - robdimsdale
     - rpranay1


### PR DESCRIPTION
I'm a technical writer at VMware (now owned by Broadcom), working with Anita Flegg and Stuart Clements.