### PR TITLE
Add repo for `bosh-common`

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -218,6 +218,9 @@ orgs:
         description: BOSH CLI v2+
         has_projects: false
         has_wiki: false
+      bosh-common:
+        default_branch: main
+        has_projects: true
       bosh-compile-action:
         default_branch: main
         has_projects: true

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -378,6 +378,7 @@ areas:
   - cloudfoundry/bosh-bbl-ci-envs
   - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-cli
+  - cloudfoundry/bosh-common
   - cloudfoundry/bosh-cpi-certification
   - cloudfoundry/bosh-cpi-go
   - cloudfoundry/bosh-cpi-ruby


### PR DESCRIPTION
This is part of the work to extract this gem from cloudfoundry/bosh

See: https://github.com/cloudfoundry/bosh/issues/2612