### PR TITLE
Consolidate Windows 2019 stemcell repos

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -417,6 +417,7 @@ orgs:
       bosh-windows-acceptance-tests:
         has_projects: true
       bosh-windows-stemcell-builder:
+        default_branch: windows-2019
         has_projects: true
       bosh-workstation:
         allow_merge_commit: false

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -366,6 +366,8 @@ orgs:
         has_projects: true
         private: true
       bosh-psmodules:
+        archived: true
+        default_branch: windows-2019
         description: PowerShell modules for building Windows Stemcells
         has_projects: false
       bosh-s3cli:
@@ -1454,6 +1456,8 @@ orgs:
       grace:
         has_projects: true
       greenhouse-ci:
+        archived: true
+        default_branch: windows-2019
         has_projects: true
         has_wiki: false
       groot:
@@ -2302,6 +2306,8 @@ orgs:
         default_branch: main
         has_projects: true
       stembuild:
+        archived: true
+        default_branch: windows-2019
         description: Binary to be used to build BOSH-compatible stemcells for Windows
           Server 2019 on vSphere.
         has_projects: true


### PR DESCRIPTION
bosh-psmodules, greenhouse-ci, and stembuild repositories have been
consolidated into the bosh-windows-stemcell-builder repo. This is
intended to reduce cognitive overhead when dealing with Windows stemcell
building code, and to more closely mirror how the Linux stemcell
ecosystem works.

The windows-2019 branch here was used to move files to their intended
directory when merging their git history into the
bosh-windows-stemcell-builder repo.