### PR TITLE
chore: fix contributors.yml

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -107,7 +107,7 @@ orgs:
     - korifi-bot
     - krsna-m
     - krutten
-    - lechner77
+    - lechnerc77
     - lnguyen
     - loewenstein-sap
     - Lokowandtg


### PR DESCRIPTION
Fix wrong GitHub handle in `contribiutors.yml` as mentioned in https://github.com/cloudfoundry/community/pull/1161#issuecomment-2896829537