### PR TITLE
ARI: merge OSB API area into CAPI

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -299,12 +299,6 @@ areas:
   - cloudfoundry/staticfile-buildpack
   - cloudfoundry/staticfile-buildpack-release
 
-- name: OSB API
-  approvers: []
-  repositories:
-  - openservicebrokerapi/servicebroker
-  - openservicebrokerapi/osb-checker
-
 - name: CAPI
   approvers:
   - name: Florian Braun
@@ -367,6 +361,8 @@ areas:
   - cloudfoundry/steno
   - cloudfoundry/runtimeschema
   - cloudfoundry/app-runtime-interfaces-infrastructure
+  - openservicebrokerapi/servicebroker
+  - openservicebrokerapi/osb-checker
 
 - name: CLI
   approvers:


### PR DESCRIPTION
- OSB API area got orphaned when the last approver was removed by #1162 (inactive user cleanup)
- decision in ARI WG meeting on 25-05-27 to add the repos to the CAPI area