### PR TITLE
Add Praveen K Kumar as contributor

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -216,3 +216,4 @@ orgs:
     - Milena-Encheva
     - AttilaAlmasi
     - dtasSap
+    - praveenkalluri18

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -142,6 +142,9 @@ areas:
   - name: tas-operability-bot
     github: tas-operability-bot
 - name: Identity and Auth (UAA)
+  members:
+  - name: Praveen K Kumar
+    github: praveenkalluri18
   approvers:
   - name: Peter Chen
     github: peterhaochen47

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -142,9 +142,6 @@ areas:
   - name: tas-operability-bot
     github: tas-operability-bot
 - name: Identity and Auth (UAA)
-  members:
-  - name: Praveen K Kumar
-    github: praveenkalluri18
   approvers:
   - name: Peter Chen
     github: peterhaochen47
@@ -166,6 +163,9 @@ areas:
     github: kehrlann
   - name: Filip Hanik
     github: fhanik
+  reviewers:
+  - name: Praveen K Kumar
+    github: praveenkalluri18
   repositories:
   - cloudfoundry/cf-identity-acceptance-tests-release
   - cloudfoundry/cf-uaa-lib


### PR DESCRIPTION
I've recently joined the UAA team in the Tanzu division at Broadcom to support @duanemay and the rest of the team, so that's why I would need to be part of these contributors' files.

Regarding the EasyCLA signing, I'm currently in the process of getting internal approval to be certified as part of Broadcom in this tool. I'll let you know as soon as that's done.

