### PR TITLE
Inactive users to be removed from FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -95,16 +95,12 @@ areas:
     github: yharish991
   - name: Indira Chandrabhatta
     github: ichandrabhatta
-  - name: Janice Bailey
-    github: bjanice75
   - name: Nader Ziada
     github: nader-ziada
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
   - name: Rui Yang
     github: xtremerui
-  - name: Rizwan Reza
-    github: rizwanreza
   - name: Wayne Adams
     github: wayneadams
   approvers:


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@bjanice75
@rizwanreza

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #1177