### PR TITLE
Update orgs.yml to fix "Sync Github Organization Settings" action

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2593,7 +2593,6 @@ orgs:
           - a-b
           - gururajsh
           - reedr3
-          - ccjaimes
         members: []
         privacy: closed
         repos:


### PR DESCRIPTION
The action is complaining because this user is not in the contributors.yml anymore. Digging a bit I noticed that they were removed by the [inactive users automation yesterday](https://github.com/cloudfoundry/community/pull/1177). This PR only cleans up a temp group.