### PR TITLE
Update cf-on-k8s working group members

### DIFF
--- a/toc/working-groups/cf-on-k8s.md
+++ b/toc/working-groups/cf-on-k8s.md
@@ -30,11 +30,11 @@ Bring the ease and simplicity of the Cloud Foundry developer experience to Kuber
 ```yaml
 name: CF on K8s
 execution_leads:
-- name: Andrew Wittrock
-  github: Birdrock
-technical_leads:
 - name: Georgi Sabev
   github: georgethebeatle
+technical_leads:
+- name: Danail Branekov
+  github: danail-branekov
 bots:
 - name: korifi-bot
   github: korifi-bot
@@ -45,8 +45,8 @@ areas:
   approvers:
   - name: Andrew Costa
     github: acosta11
-  - name: Danail Branekov
-    github: danail-branekov
+  - name: Andrew Wittrock
+    github: Birdrock
   - name: Dave Walter
     github: davewalter
   - name: Julian Hjortshoj


### PR DESCRIPTION
Following a discussin on the last TOC update:
- Change execution lead to Georgi Sabev
- Change technical lead to Danail Branekov
