### PR TITLE
remove reedr3 from temp group

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2592,7 +2592,6 @@ orgs:
         maintainers:
           - a-b
           - gururajsh
-          - reedr3
         members: []
         privacy: closed
         repos:


### PR DESCRIPTION
The sync action is complaining because this user is not in the contributors.yml anymore. Digging a bit I noticed that they were removed by the https://github.com/cloudfoundry/community/pull/1177. This PR only cleans up a temp group.