### PR TITLE
feat: Remove the ruby call and adjust the gist file url

### DIFF
--- a/toc/working-groups/contributions-for-user.sh
+++ b/toc/working-groups/contributions-for-user.sh
@@ -29,6 +29,16 @@ usage_checks() {
     exit 1
   fi
 
+  if [[ ! -e $(which yq) ]]; then
+    echo 'The `yq` cli (https://github.com/mikefarah/yq) is required for this script' >&2
+    exit 1
+  fi
+
+  if [[ ! -e $(which jq) ]]; then
+      echo 'The `jq` cli (https://github.com/jqlang/jq) is required for this script' >&2
+      exit 1
+  fi
+
   if gist_url=$(echo "test" | gh gist create -d test -f test - 2>/dev/null); then
     gh gist delete "${gist_url}" --yes >/dev/null 2>&1
   else 
@@ -100,7 +110,7 @@ find_issues_for_repo() {
   areas=($(echo "${TOC_JSON}" | jq --arg wg_name "${WORKING_GROUP}" -r '.[] | select(.name == $wg_name) | .areas[].name'))
   for area in "${areas[@]}"; do
     echo "Gathering contributions for the '${WORKING_GROUP}: ${area}' area..."
-    uri_safe_file=$(echo "${wg} - ${area}.md" | jq  -sRr '@uri')
+    uri_safe_file=$(echo "${wg} - ${area}.md" | jq  -sRr '@uri' | sed s/%20/\ /g | sed s/%0A//g | sed s/%2F/and/g)
     gist_url=$( (
     echo "# ${WORKING_GROUP}: ${area} Contributions"
     declare -a repos


### PR DESCRIPTION
### PR Summary
This pull request introduces the following improvements:

#### Removal of Ruby Dependency
- Replaces the Ruby-based YAML-to-JSON conversion in with the modern [yq](https://github.com/mikefarah/yq) CLI tool
- The Ruby invocation previously used for parsing YAML is now fully replaced by `yq -o=json .`, reducing external dependencies and increasing maintainability
- - The parsing logic is centralized in a new shell function, and results are collected into a single JSON array for improved downstream usage

#### URL Encoding Adjustment
- In , the URI-safe file naming step has been enhanced. `contributions-for-user.sh`
- After URL-encoding filenames with `jq -sRr '@uri'`, a series of `sed` substitutions is applied to:
    - Replace spaces (`%20` →` `)
    - Remove newlines (`%0A`)
    - Replace slashes ( `%2F`→ `and`)
- This ensures generated files are better suited for the specific needs and readable



#### Additional Notes
- Both scripts now explicitly check for the availability of and before proceeding, ensuring a smoother user experience and clearer error messages. `yq` & `jq`

**In summary:**
This PR modernizes YAML parsing by eliminating the Ruby runtime dependency and improves custom handling of encoded filenames, making the scripts more portable and robust.

