### PR TITLE
Updating TOC membership after 2025 Election

### DIFF
--- a/toc/TOC.md
+++ b/toc/TOC.md
@@ -63,9 +63,9 @@ the Cloud Foundry community via an election.
 
 | &nbsp;                                                       | Member                 | Company     | Profile                                          | Term Start | Term End |
 | ------------------------------------------------------------ | -----------------------| ----------- | ------------------------------------------------ | ---------- | --------
-| <img width="30px" src="https://github.com/ameowlia.png">     | Amelia Downs           | VMware      | [@ameowlia](https://github.com/ameowlia)         | 2023-06-21 | 2025     |
+| <img width="30px" src="https://github.com/gerg.png">         | Greg Cobb              | VMware      | [@gerg](https://github.com/Gerg)                 | 2025-07-01 | 2027     |
 | <img width="30px" src="https://github.com/beyhan.png">       | Beyhan Veli (TOC Chair)| SAP         | [@beyhan](https://github.com/beyhan)             | 2022-06-22 | 2024     |
-| <img width="30px" src="https://github.com/ChrisMcGowan.png"> | Chris McGowan          | Cloud.gov   | [@ChrisMcGowan](https://github.com/ChrisMcGowan) | 2023-06-21 | 2025     |
+| <img width="30px" src="https://github.com/Cweibel.png">      | Chris Weibel           | Cloud.gov   | [@cweibel](https://github.com/cweibel)           | 2027-07-01 | 2027     |
 | <img width="30px" src="https://github.com/rkoster.png">      | Ruben Koster           | VMware      | [@rkoster](https://github.com/rkoster)           | 2022-06-22 | 2024     |
 | <img width="30px" src="https://github.com/stephanme.png">    | Stephan Merker         | SAP         | [@stephanme](https://github.com/stephanme)       | 2023-06-21 | 2025     |
 


### PR DESCRIPTION
Updating TOC Membership after 2025 Election so GH automation can run and define access.