### PR TITLE
Fix failing github sync settings action

### DIFF
--- a/toc/TOC.md
+++ b/toc/TOC.md
@@ -124,7 +124,7 @@ execution_leads:
 - name: Chris Weibel
   github: cweibel
 - name: Greg Cobb
-  github: Gerg
+  github: gerg
 - name: Ruben Koster
   github: rkoster
 - name: Stephan Merker


### PR DESCRIPTION
Our Sync Github Organization Settings is failing with:

```
{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure cloudfoundry members: users in both roles: gerg","severity":"fatal","time":"2025-07-03T00:16:58Z"}
```

I suspect that https://github.com/cloudfoundry/community/pull/1230 configured Greg with upper case and this is causing an issue with the Peribolos tooling. This is a try to fix that.