### PR TITLE
Remove inactive users FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -91,8 +91,6 @@ areas:
   reviewers:
   - name: claire t.
     github: Spimtav
-  - name: Greg Meyer
-    github: gm2552
   - name: Harish Yayi
     github: yharish991
   - name: Indira Chandrabhatta
@@ -103,8 +101,6 @@ areas:
     github: xtreme-nitin-ravindran
   - name: Rui Yang
     github: xtremerui
-  - name: Wayne Adams
-    github: wayneadams
   approvers:
   - name: Aram Price
     github: aramprice
@@ -288,8 +284,6 @@ areas:
   - name: Ahmed Hassanin
     github: a-hassanin
   reviewers:
-  - name: Greg Meyer
-    github: gm2552
   - name: Sascha Stojanovic
     github: Sascha-Stoj
   - name: Julian Hjortshoj
@@ -342,8 +336,6 @@ areas:
   - name: Felix Moehler
     github: fmoehler
   reviewers:
-  - name: Greg Meyer
-    github: gm2552
   - name: Benjamin Gandon
     github: bgandon
   - name: Sascha Stojanovic


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@gm2552
@wayneadams

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1237