### PR TITLE
fix: Adjust the permissions of Andreas

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -215,6 +215,7 @@ areas:
     github: ryanwittrup
   - name: Pascal Zimmermann
     github: ZPascal
+  reviewers:
   - name: Andreas Kyrian
     github: Jobsby
   repositories:


### PR DESCRIPTION
Andreas [requested](https://github.com/cloudfoundry/community/blob/110d9cb13b03a1f37e36707b309377e5c459c8d4/toc/working-groups/foundational-infrastructure.md?plain=1#L218) reviewer permissions, but the missing rebase accidentally gives the user approver permissions.