### PR TITLE
Create repo for consolidation of blobstore CLI's

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -196,6 +196,10 @@ orgs:
         has_projects: false
         has_wiki: false
         private: true
+      bosh-blobstore-clis:
+        description: CLIs for interacting with blobstores
+        has_projects: false
+        has_wiki: false
       bosh-bootloader:
         allow_merge_commit: false
         allow_squash_merge: false

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -368,6 +368,7 @@ areas:
   - cloudfoundry/bosh-azure-storage-cli
   - cloudfoundry/bosh-apt-resources
   - cloudfoundry/bosh-bbl-ci-envs
+  - cloudfoundry/bosh-blobstore-clis
   - cloudfoundry/bosh-bootloader
   - cloudfoundry/bosh-cli
   - cloudfoundry/bosh-common


### PR DESCRIPTION
This repo is expected to contain the blobstore CLI's used in the BOSH ecosytem, at present these are:
- https://github.com/cloudfoundry/bosh-azure-storage-cli
- https://github.com/cloudfoundry/bosh-gcscli
- https://github.com/cloudfoundry/bosh-s3cli
- https://github.com/cloudfoundry/bosh-ali-storage-cli

See also
- https://github.com/cloudfoundry/cloud_controller_ng/pull/4443