### PR TITLE
Add branch protection rules for uaa and uaa-release

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -941,3 +941,37 @@ branch-protection:
             bypass_pull_request_allowances:
               teams: ["wg-service-management-cloud-service-broker-bots"]
           include: [ "^main$" ]  
+
+        uaa:
+         protect: true
+         allow_deletions: false
+         allow_disabled_policies: true 
+         allow_force_pushes: false
+         enforce_admins: false
+         include:
+         - ^develop$
+         - ^v[0-9]*$
+         required_pull_request_reviews:
+          bypass_pull_request_allowances:
+            teams:
+            - wg-foundational-infrastructure-bots
+          dismiss_stale_reviews: true
+          require_code_owner_reviews: true
+          required_approving_review_count: 1
+
+        uaa-release:
+         protect: true
+         allow_deletions: false
+         allow_disabled_policies: true 
+         allow_force_pushes: false
+         enforce_admins: false
+         include:
+         - ^develop$
+         - ^v[0-9]*$
+         required_pull_request_reviews:
+          bypass_pull_request_allowances:
+            teams:
+            - wg-foundational-infrastructure-bots
+          dismiss_stale_reviews: true
+          require_code_owner_reviews: true
+          required_approving_review_count: 1


### PR DESCRIPTION
We use Github deploy keys in our automation for uaa and uaa-release, which doesn't work with the default branch protection rules.  