### PR TITLE
Remove Inactive Users FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -89,8 +89,6 @@ areas:
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)
   reviewers:
-  - name: claire t.
-    github: Spimtav
   - name: Harish Yayi
     github: yharish991
   - name: Indira Chandrabhatta
@@ -99,8 +97,6 @@ areas:
     github: nader-ziada
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
-  - name: Rui Yang
-    github: xtremerui
   approvers:
   - name: Aram Price
     github: aramprice
@@ -178,8 +174,6 @@ areas:
   - cloudfoundry/uaa-ci
 - name: Identity and Auth (UAA) Go Client
   approvers:
-  - name: Joe Fitzgerald
-    github: joefitzgerald
   - name: Peter Chen
     github: peterhaochen47
   - name: Markus Strehle
@@ -205,8 +199,6 @@ areas:
   approvers:
   - name: Andrew Garner
     github: abg
-  - name: Colin Shield
-    github: colins
   - name: Kim Basset
     github: kimago
   - name: Ryan Wittrup


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@joefitzgerald
@Spimtav
@xtremerui
@colins

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1237