### PR TITLE
Disable enforcing branch-protection for bosh.io stemcells cpi index

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -751,6 +751,23 @@ branch-protection:
             require_code_owner_reviews: true
             required_approving_review_count: 1
 
+        bosh-io-stemcells-cpi-index:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: false
+          include:
+          - ^main$
+          - ^v[0-9]*$
+          protect: true
+          required_pull_request_reviews:
+            bypass_pull_request_allowances:
+              teams:
+              - wg-foundational-infrastructure-bots
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
+
         homebrew-tap:
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
Required for deploy keys and was missed in https://github.com/cloudfoundry/community/pull/1263