### PR TITLE
Disable enforcing branch-protection for jumpbox deployment

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -1078,3 +1078,20 @@ branch-protection:
             dismiss_stale_reviews: true
             require_code_owner_reviews: true
             required_approving_review_count: 1
+
+        jumpbox-deployment:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: false
+          include:
+          - ^master$
+          - ^v[0-9]*$
+          protect: true
+          required_pull_request_reviews:
+            bypass_pull_request_allowances:
+              teams:
+              - wg-foundational-infrastructure-bots
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1


### PR DESCRIPTION
Required for deploy keys and was missed in https://github.com/cloudfoundry/community/pull/1263