### PR TITLE
CredHub repo: Disable enforcing branch-protection for admins

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -1011,6 +1011,23 @@ branch-protection:
             require_code_owner_reviews: true
             required_approving_review_count: 1
 
+        credhub-acceptance-tests:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: false
+          include:
+          - ^main$
+          - ^v[0-9]*$
+          protect: true
+          required_pull_request_reviews:
+            bypass_pull_request_allowances:
+              teams:
+              - wg-foundational-infrastructure-bots
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
+
         credhub-api-site:
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
- This disables branch-protection rules for admins in FI WG repositories included in this pr. We use Github deploy keys in our automation which doesn't work with the default branch protection rules.

- The original addition of this rule has a typo: https://github.com/cloudfoundry/community/pull/1277
- now this commit adds this repo back without the typo