### PR TITLE
Add Ned Petrov as a BOSH reviewer

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -295,6 +295,8 @@ areas:
     github: alphasite
   - name: Clay Kauzlaric
     github: KauzClay
+  - name: Ned Petrov
+    github: neddp
   repositories:
   - cloudfoundry/concourse-infra-for-fiwg
   - cloudfoundry/bosh-stemcells-ci
@@ -351,6 +353,8 @@ areas:
     github: peanball
   - name: Clay Kauzlaric
     github: KauzClay
+  - name: Ned Petrov
+    github: neddp
   repositories:
   - cloudfoundry/bbl-state-resource
   - cloudfoundry/bosh


### PR DESCRIPTION
Add Ned Petrov to the Foundational Infrastructure working group as a BOSH reviewer.