### PR TITLE
Skip branchprotection for cf-openapi

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -261,6 +261,8 @@ branch-protection:
           protect: false
         capi-env-pool:
           protect: false
+        cf-openapi:
+          protect: false
 
         # CLI
         CLAW:


### PR DESCRIPTION
The cf-openapi repo is a non productive experiment and doesn't really need branch protection rules