### PR TITLE
Remove user ifindlay-cci

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -77,7 +77,6 @@ orgs:
     - hibell
     - hsinn0
     - iaftab-alam
-    - ifindlay-cci
     - ikasarov
     - iprotsiuk
     - itsouvalas

--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -81,8 +81,6 @@ areas:
     github: dlresende
   - name: George Blue
     github: blgm
-  - name: Iain Findlay
-    github: ifindlay-cci
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Konstantin Semenov
@@ -90,7 +88,7 @@ areas:
   - name: Long Nguyen
     github: lnguyen
   - name: Rajan Agaskar
-    github: ragaskar    
+    github: ragaskar
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng


### PR DESCRIPTION
The [Sync Github Organization Settings](https://github.com/cloudfoundry/community/actions/runs/16989865344/job/48166497010) is failing because there is a issue with the github user @ifindlay-cci. This pr suggest to remove the user until we clarify the issue and the change can be reverted when we have clarity on it and it doesn't fail the automation.