### PR TITLE
Remove ifindlay-cci to fix Sync Github Organization Settings Job

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -112,8 +112,6 @@ areas:
     github: dlresende
   - name: George Blue
     github: blgm
-  - name: Iain Findlay
-    github: ifindlay-cci
   - name: Konstantin Kiess
     github: nouseforaname
   - name: Long Nguyen


### PR DESCRIPTION
In https://github.com/cloudfoundry/community/pull/1290 we missed the FI WG entry and the Sync Github Organization Settings  job is still failing