### PR TITLE
Add ARI WG leads as Storage CLI approvers

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -517,6 +517,10 @@ areas:
     github: xandroc
   - name: Jochen Ehret
     github: jochenehret
+  - name: Greg Cobb
+    github: gerg
+  - name: Stephan Merker
+    github: stephanme
   reviewers:
   - name: Benjamin Gandon
     github: bgandon


### PR DESCRIPTION
Storage CLI area is shared between ARI and FI.
ARI WG leads should be able to approve PRs and have access to Concourse pipelines.