### PR TITLE
Un-archive certsplitter

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -569,7 +569,7 @@ orgs:
       certsplitter:
         has_issues: false
         has_projects: true
-        archived: true
+        archived: false
       cf-acceptance-tests:
         default_branch: develop
         description: CF Acceptance tests

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -112,6 +112,7 @@ areas:
   - cloudfoundry/buildpackapplifecycle
   - cloudfoundry/bytefmt
   - cloudfoundry/cacheddownloader
+  - cloudfoundry/certsplitter
   - cloudfoundry/cfdot
   - cloudfoundry/cfhttp
   - cloudfoundry/clock


### PR DESCRIPTION
It turns out that we need to keep this a separate package to use in both diego + winc releases.

If merging this won't auto-unarchive but just prevent automation from re-archiving it, can someone also please unarchive the repo?

https://github.com/cloudfoundry/certsplitter