### PR TITLE
Remove lapsed Logging/Metrics approvers/reviewers

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -187,8 +187,6 @@ areas:
     github: geofffranks
   - name: Chris Selzo
     github: selzoc
-  - name: Carson Long
-    github: ctlong
   - name: Matthew Kocher
     github: mkocher
   - name: Amin Jamali
@@ -200,12 +198,6 @@ areas:
     github: ZPascal
   - name: Felix Hambrecht
     github: fhambrec
-  - name: Glenn Oppegard
-    github: oppegard
-  - name: Ausaf Ahmed
-    github: aqstack
-  - name: Ivan Protsiuk
-    github: iprotsiuk
   - name: Andrew Costa
     github: acosta11
   - name: Karthick Udayakumar
@@ -245,16 +237,12 @@ areas:
 
 - name: Metric Store
   approvers:
-  - name: Jeanette Booher
-    github: jbooherl
   - name: Chaitanya Krishna Mullangi
     github: chaitanyamullangi
   - name: Shrisha Chandrashekar
     github: shrisha-c
   - name: Srinivas Sunka
     github: ssunka
-  - name: Carson Long
-    github: ctlong
   reviewers:
   - name: Wei Li
     github: weili-broadcom

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -227,17 +227,9 @@ areas:
   approvers:
   - name: Ben Fuller
     github: Benjamintf1
-  - name: Carson Long
-    github: ctlong
-  - name: Ivan Protsiuk
-    github: iprotsiuk
   - name: Jovan Kostovski
     github: chombium
   reviewers:
-  - name: Ausaf Ahmed
-    github: aqstack
-  - name: Glenn Oppegard
-    github: oppegard
   - name: Wei Li
     github: weili-broadcom
   repositories:


### PR DESCRIPTION
Per https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#revoking-reviewer-or-approver-role, the removed people have 2 weeks to refute their removal.

cc @ctlong @oppegard @aqstack @iprotsiuk @jbooherl 