### PR TITLE
Add Wei as Reviewer for Logging/Metrics

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -227,6 +227,8 @@ areas:
     github: kart2bc
   - name: Tim Downey
     github: tcdowney
+  - name: Wei Li
+    github: weili-broadcom
   repositories:
   - cloudfoundry/app-runtime-platform-envs
   - cloudfoundry/bosh-system-metrics-forwarder-release
@@ -268,6 +270,9 @@ areas:
     github: ssunka
   - name: Carson Long
     github: ctlong
+  reviewers:
+  - name: Wei Li
+    github: weili-broadcom
   repositories:
   - cloudfoundry/metric-store-ci
   - cloudfoundry/metric-store-release

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -236,6 +236,8 @@ areas:
     github: aqstack
   - name: Glenn Oppegard
     github: oppegard
+  - name: Wei Li
+    github: weili-broadcom
   repositories:
   - cloudfoundry/blackbox
   - cloudfoundry/bosh-system-metrics-server-release


### PR DESCRIPTION
Wei is working to ramp-up in the logging/metrics area to replace some lapsed contributors (see https://github.com/cloudfoundry/community/pull/1294).

Per https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#promotion-to-reviewer-or-approver, two existing approvers for each working group area need to attest that Wei meets the criteria for the [Reviewer role](https://github.com/cloudfoundry/community/blob/main/toc/ROLES.md#reviewer).

cc @weili-broadcom @cloudfoundry/wg-app-runtime-platform-logging-and-metrics-approvers @cloudfoundry/wg-app-runtime-platform-metric-store-approvers @cloudfoundry/wg-foundational-infrastructure-system-logging-and-metrics-rsyslog-event-log-approvers 