### PR TITLE
remove branch protection for bosh-apt-resources

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -25,6 +25,8 @@ branch-protection:
           protect: false
         relint-envs:
           protect: false
+        bosh-apt-resources:
+          protect: false
 
         # App Runtime Platform repos to skip branch protection on
         app-runtime-platform-envs:


### PR DESCRIPTION
as i'm the only person maintaning this. it makes no sense to protect this branch