### PR TITLE
Archive the bsdtar archive

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -450,6 +450,7 @@ orgs:
         has_projects: false
         has_wiki: true
       bsdtar:
+        archived: true
         has_projects: true
         has_wiki: false
       build-system-cnb:


### PR DESCRIPTION
This repo is no longer needed.

See https://github.com/cloudfoundry/bsdtar/pull/3