### PR TITLE
Reduce the request batch size in inactive user request

### DIFF
--- a/orgs/org_user_management.py
+++ b/orgs/org_user_management.py
@@ -41,7 +41,7 @@ class InactiveUserHandler:
         query = """
         {
             organization(login: \"%s\") {
-                membersWithRole(first: 50, after:%s) {
+                membersWithRole(first: 20, after:%s) {
                     pageInfo {
                         hasNextPage
                         endCursor


### PR DESCRIPTION
According to [this discussion](https://github.com/orgs/community/discussions/24844#discussioncomment-3245605) there are 10s timeouts on GitHub side for all API calls and the requested amount of data could be a reason for requests to hit that timeout. That is why this change is reducing the requested size of 50 users to 20 for one request. Testing locally worked and the calls didn't fails with 502.