### PR TITLE
Inactive users to be removed from ARI WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -331,8 +331,6 @@ areas:
     github: gururajsh
   - name: Sriram Nookala
     github: nookala
-  - name: George Gelashvili
-    github: pivotalgeorge
   repositories:
   - cloudfoundry/cloud_controller_ng
   - cloudfoundry/capi-release
@@ -373,8 +371,6 @@ areas:
     github: joaopapereira
   - name: Sam Gunaratne
     github: samze
-  - name: Greg Weresch
-    github: weresch
   reviewers:
   - name: George Gelashvili
     github: pivotalgeorge
@@ -382,8 +378,6 @@ areas:
     github: PeteLevineA
   - name: Tim Downey
     github: tcdowney
-  - name: Michael Chinigo
-    github: chinigo
   - name: Daria Anton
     github: Dariquest
   bots:
@@ -461,8 +455,6 @@ areas:
     github: theghost5800
   - name: Boyan Velinov
     github: boyan-velinov
-  - name: Rangel Ivanov
-    github: radito3
   - name: Ikasarov
     github: ikasarov
   - name: Velizar Kalapov
@@ -513,15 +505,11 @@ areas:
     github: wayneeseguin
   - name: Norm Abromovitz
     github: norman-abramovitz
-  - name: Ioannis Tsouvalas
-    github: itsouvalas
   reviewers:
   - name: Dr. Xiujiao Gao
     github: xiujiao
   - name: Dennis Bell
     github: dennisjbell
-  - name: Dr. Hu
-    github: haochenhu233
 
   repositories:
   - cloudfoundry/stratos


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers: @haochenhu233
@weresch
@itsouvalas
@chinigo
@radito3
@pivotalgeorge

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #1318