### PR TITLE
Remove Inactive Users FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -89,10 +89,6 @@ areas:
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)
   reviewers:
-  - name: Harish Yayi
-    github: yharish991
-  - name: Indira Chandrabhatta
-    github: ichandrabhatta
   - name: Nader Ziada
     github: nader-ziada
   - name: Nitin Ravindran
@@ -108,8 +104,6 @@ areas:
     github: dlresende
   - name: George Blue
     github: blgm
-  - name: Konstantin Kiess
-    github: nouseforaname
   - name: Long Nguyen
     github: lnguyen
   - name: Maya Rosecrance
@@ -130,9 +124,6 @@ areas:
   - cloudfoundry/bosh-backup-and-restore-test-releases
   - cloudfoundry/bosh-disaster-recovery-acceptance-tests
   - cloudfoundry/exemplar-backup-and-restore-release
-  bots:
-  - name: tas-operability-bot
-    github: tas-operability-bot
 - name: Identity and Auth (UAA)
   approvers:
   - name: Peter Chen
@@ -254,14 +245,8 @@ areas:
     github: mvach
   - name: Long Nguyen
     github: lnguyen
-  - name: Brian Cunnie
-    github: cunnie
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Konstantin Kiess
-    github: nouseforaname
-  - name: Max Soest
-    github: max-soe
   - name: Aram Price
     github: aramprice
   - name: Shilpa Chandrashekara
@@ -310,14 +295,8 @@ areas:
     github: lnguyen
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Benjamin Gandon
-    github: bgandon
-  - name: Brian Cunnie
-    github: cunnie
   - name: Aram Price
     github: aramprice
-  - name: Konstantin Kiess
-    github: nouseforaname
   - name: Rajan Agaskar
     github: ragaskar
   - name: Maya Rosecrance
@@ -349,8 +328,6 @@ areas:
   - name: Felix Moehler
     github: fmoehler
   reviewers:
-  - name: Benjamin Gandon
-    github: bgandon
   - name: Sascha Stojanovic
     github: Sascha-Stoj
   - name: Alexander Lais
@@ -458,14 +435,8 @@ areas:
     github: lnguyen
   - name: Ramon Makkelie
     github: ramonskie
-  - name: Benjamin Gandon
-    github: bgandon
-  - name: Brian Cunnie
-    github: cunnie
   - name: Aram Price
     github: aramprice
-  - name: Konstantin Kiess
-    github: nouseforaname
   - name: Rajan Agaskar
     github: ragaskar
   - name: Maya Rosecrance
@@ -527,8 +498,6 @@ areas:
   - name: Stephan Merker
     github: stephanme
   reviewers:
-  - name: Benjamin Gandon
-    github: bgandon
   - name: Sascha Stojanovic
     github: Sascha-Stoj
   - name: Alexander Lais
@@ -543,8 +512,6 @@ areas:
     github: gururajsh
   - name: Sriram Nookala
     github: nookala
-  - name: George Gelashvili
-    github: pivotalgeorge
   repositories:
   - cloudfoundry/bosh-ali-storage-cli
   - cloudfoundry/bosh-azure-storage-cli


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers: @bgandon
@max-soe
@ichandrabhatta
@yharish991
@nouseforaname
@pivotalgeorge
@tas-operability-bot
@cunnie

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged. Please also state a reason why you would like to be re-added. Inactivity was detected by a github action, see #1318

I took @joefitzgerald and @colins out based on the discussions in https://github.com/cloudfoundry/community/pull/1271

@yharish991 could you please state a reason why you and @tas-operability-bot should presered the role?