### PR TITLE
Unarchive app autoscaler repo

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -28,7 +28,7 @@ orgs:
         description: Cloud Controller API Docs
         has_projects: true
       app-autoscaler:
-        archived: true
+        archived: false
         default_branch: main
         description: Auto Scaling for CF Applications
         has_projects: true

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -63,6 +63,7 @@ areas:
   - name: App Autoscaler CI Bot
     github: app-autoscaler-ci-bot
   repositories:
+  - cloudfoundry/app-autoscaler
   - cloudfoundry/app-autoscaler-release
   - cloudfoundry/app-autoscaler-cli-plugin
   - cloudfoundry/app-autoscaler-env-bbl-state


### PR DESCRIPTION
This pull request makes updates related to the App Autoscaler project, primarily by reactivating the repository and ensuring it is properly listed in documentation.

Repository status updates:

* Set the `archived` status of the `app-autoscaler` repository to `false` in `orgs/orgs.yml`, reactivating the repository.

Documentation and working group updates:

* Added `cloudfoundry/app-autoscaler` to the list of repositories in the App Autoscaler area in `toc/working-groups/app-runtime-interfaces.md`.