### PR TITLE
Adding tristanpoland, patzeltj, and mafolz as approvers for Stratos Project

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -368,6 +368,12 @@ areas:
     github: norman-abramovitz
   - name: Ioannis Tsouvalas
     github: itsouvalas
+  - name: Tristan Poland
+    github: tristanpoland
+  - name: Jan Lucca Patzelt
+    github: patzeltj
+  - name: Matthias Folz
+    github: mafolz
   reviewers:
   - name: Dr. Xiujiao Gao
     github: xiujiao


### PR DESCRIPTION
Adding users
  Tristan Poland of FiveTwenty
  Jan Lucca Patzelt of STACKIT
  Matthias Folz of anynines
as approvers for the project.