### PR TITLE
Update bosh-agent-index branch protection

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -498,6 +498,23 @@ branch-protection:
             require_code_owner_reviews: true
             required_approving_review_count: 1
 
+        bosh-agent-index:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: false
+          include:
+          - ^master$
+          - ^v[0-9]*$
+          protect: true
+          required_pull_request_reviews:
+            bypass_pull_request_allowances:
+              teams:
+              - wg-foundational-infrastructure-bots
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
+
         bosh-cpi-go:
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
This changes the branch protection for bosh-agent-index to match that used by bosh-cli.

Not sure if this is the correct incantation for this change.