### PR TITLE
Adjust branch protection for socks5-proxy

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -770,6 +770,23 @@ branch-protection:
             require_code_owner_reviews: true
             required_approving_review_count: 1
 
+        socks5-proxy:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: false
+          include:
+            - ^main$
+            - ^v[0-9]*$
+          protect: true
+          required_pull_request_reviews:
+            bypass_pull_request_allowances:
+              teams:
+                - wg-foundational-infrastructure-bots
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
+
         homebrew-tap:
           allow_deletions: false
           allow_disabled_policies: true


### PR DESCRIPTION
To address CI failures, see:
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/socks5-proxy/jobs/bump-deps/builds/30