### PR TITLE
Added 'app-autoscaler' repo with admin rights for app-autoscaler team

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2662,6 +2662,7 @@ orgs:
         members: []
         privacy: closed
         repos:
+          app-autoscaler: admin
           app-autoscaler-release: admin
           app-autoscaler-cli-plugin: admin
           app-runtime-interfaces-infrastructure: admin


### PR DESCRIPTION
As part of our migration from app-autoscaler-release repo to app-autoscaler we need admin access to the unarchived app autoscaler https://github.com/cloudfoundry/community/pull/1326