### PR TITLE
Add chombium to contributors list

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -43,6 +43,7 @@ orgs:
     - cf-rabbit-bot
     - cf-release-notes-bot
     - chaitanyamullangi
+    - chombium
     - colins
     - coolgang123
     - Cryogenics-CI


### PR DESCRIPTION
I saw that my GitHub username is missing in the list, so I've added it.