### PR TITLE
Update Stratos repos to use pr->develop->main workflow

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2359,9 +2359,11 @@ orgs:
         has_wiki: false
       stratos:
         description: 'Stratos: Web-based Management UI for Cloud Foundry and Kubernetes'
+        default_branch: develop
         has_projects: true
       stratos-buildpack:
         description: Custom buildpack Stratos (UI for Cloud Foundry)
+        default_branch: develop
         has_projects: true
       summit-hands-on-labs:
         description: Hands-on Labs for CF Summit Boston '18 and beyond


### PR DESCRIPTION
We are moving Stratos from an all PRs to main(master) to a branch->develop->main(master) process where develop is merged to main on releases.

New PR created to fix typo in PR 1352 and remove unrelated reviewer/approver commit accidentally included.