### PR TITLE
Remove Inactive Users FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -47,8 +47,6 @@ bots:
   github: cf-bosh-ci-bot
 - name: cf-uaa-ci-bot
   github: cf-identity
-- name: Cryogenics-CI
-  github: Cryogenics-CI
 - name: mysql-ci
   github: pcf-core-services-writer
 areas:
@@ -108,8 +106,6 @@ areas:
     github: blgm
   - name: Long Nguyen
     github: lnguyen
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Nishad Mathur
     github: alphasite
   - name: Rajan Agaskar
@@ -167,8 +163,6 @@ areas:
   - cloudfoundry/uaa-ci
 - name: Identity and Auth (UAA) Go Client
   approvers:
-  - name: Joe Fitzgerald
-    github: joefitzgerald
   - name: Peter Chen
     github: peterhaochen47
   - name: Markus Strehle
@@ -231,12 +225,8 @@ areas:
   approvers:
   - name: Rajan Agaskar
     github: ragaskar
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Brian Upton
     github: ystros
-  - name: Matthias Vach
-    github: mvach
   - name: Long Nguyen
     github: lnguyen
   - name: Ramon Makkelie
@@ -295,14 +285,10 @@ areas:
     github: aramprice
   - name: Rajan Agaskar
     github: ragaskar
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Brian Upton
     github: ystros
   - name: Chris Selzo
     github: selzoc
-  - name: Matthias Vach
-    github: mvach
   - name: Ahmed Hassanin
     github: a-hassanin
   - name: Ansh Rupani
@@ -439,14 +425,10 @@ areas:
     github: aramprice
   - name: Rajan Agaskar
     github: ragaskar
-  - name: Maya Rosecrance
-    github: mrosecrance
   - name: Brian Upton
     github: ystros
   - name: Chris Selzo
     github: selzoc
-  - name: Matthias Vach
-    github: mvach
   - name: Ahmed Hassanin
     github: a-hassanin
   - name: Ansh Rupani


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@mrosecrance
@mvach
@Cryogenics-CI
@joefitzgerald

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1359