### PR TITLE
Add branch protection rules for app-autoscaler

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -218,8 +218,6 @@ branch-protection:
             - "Build suite=test, mysql=8"
             - "Build suite=integration, mysql=8"
             - "reviewdog"
-            - "Build suite=integration, postgres=15"
-            - "Build suite=test, postgres=15"
             - "CodeQL"
           required_pull_request_reviews:
             dismiss_stale_reviews: false


### PR DESCRIPTION
  Branch Protection for app-autoscaler Repository
  - Added new branch protection rules for the app-autoscaler repository
  - Enabled branch protection on the main branch
  - Disabled force pushes and branch deletions
  - Configured required status checks:
    - "EasyCLA"
    - "Acceptance Tests - MTA / Result"
    - "Build suite=integration, postgres=15"
    - "Build suite=test, postgres=15"
  - Set up required review requirements

  Status Check Optimization
  - Removed "Acceptance Tests - MTA / Result" from app-autoscaler-release repository checks
  - This check is now covered by the main app-autoscaler repository protection rules
  - Eliminates redundancy in status check requirements
