### PR TITLE
Inactive users to be removed from ARI WG

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -239,8 +239,6 @@ areas:
   - name: Sam Gunaratne
     github: samze
   reviewers:
-  - name: George Gelashvili
-    github: pivotalgeorge
   - name: Pete Levine
     github: PeteLevineA
   - name: Tim Downey
@@ -301,14 +299,10 @@ areas:
 
 - name: Terraform Provider Cloudfoundry
   approvers:
-  - name: Yogesh Purantharan
-    github: pyogesh2
   - name: Vipin Vijaykumar
     github: vipinvkmenon
   - name: Christian Lechner
     github: lechnerc77
-  - name: Kesavan
-    github: KesavanKing
   - name: Debaditya Ray 
     github: Dray56
   - name: Gourab Mukherjee
@@ -382,8 +376,6 @@ areas:
   - name: Ioannis Tsouvalas
     github: itsouvalas
   reviewers:
-  - name: Dr. Xiujiao Gao
-    github: xiujiao
   - name: Dennis Bell
     github: dennisjbell
 


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@KesavanKing
@pivotalgeorge
@xiujiao
@pyogesh2

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #1359