### PR TITLE
Remove radito3 from temp-multiapps-admins

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2641,7 +2641,6 @@ orgs:
           - IvanBorislavovDimitrov
           - theghost5800
           - boyan-velinov
-          - radito3
           - ikasarov
           - vkalapov
           - VRBogdanov


### PR DESCRIPTION
- radito3 was removed by #1359
- temp-multiapps-admins is a manually maintained team