### PR TITLE
Remove MySQL-checks

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -215,8 +215,6 @@ branch-protection:
             - "EasyCLA"
             - "Create Bosh Release"
             - "Acceptance Tests - BOSH release / Result"
-            - "Build suite=test, mysql=8"
-            - "Build suite=integration, mysql=8"
             - "reviewdog"
             - "CodeQL"
           required_pull_request_reviews:


### PR DESCRIPTION
This removes a MySQL-check that has accidentally not been migrated to the repository <https://github.com/cloudfoundry/app-autoscaler>.

However as we wanted to remove support for MySQL anyway, we do this immediately.