### PR TITLE
Remove Inactive Users FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -45,8 +45,6 @@ bots:
   github: bosh-admin-bot
 - name: runtime-bot
   github: tas-runtime-bot
-- name: cf-bosh-ci-bot
-  github: cf-bosh-ci-bot
 - name: cf-uaa-ci-bot
   github: cf-identity
 - name: mysql-ci
@@ -132,8 +130,6 @@ areas:
     github: hsinn0
   - name: Florian Tack
     github: tack-sap
-  - name: Torsten Luh
-    github: torsten-sap
   - name: Adrian Hoelzl
     github: adrianhoelzl-sap
   - name: Duane May
@@ -173,8 +169,6 @@ areas:
     github: hsinn0
   - name: Florian Tack
     github: tack-sap
-  - name: Torsten Luh
-    github: torsten-sap
   - name: Adrian Hoelzl
     github: adrianhoelzl-sap
   - name: Filip Hanik


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers:
@torsten-sap
@cf-bosh-ci-bot

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged. Please also state a reason why you would like to be re-added. Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1318