### PR TITLE
Add mkocher to FI - VM deployment lifecycle (BOSH)

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -313,6 +313,8 @@ areas:
     github: KauzClay
   - name: Sebastian Heid
     github: s4heid
+  - name: Matthew Kocher
+    github: mkocher
   reviewers:
   - name: Sascha Stojanovic
     github: Sascha-Stoj


### PR DESCRIPTION
I started working on Bosh in 2013 but took a few years off. I've been back working on bosh for a while now and would like to make things official.

The script has helpfully [summarized my contributions in this gist](https://gist.github.com/mkocher/77273c0b3f23cb77ce0674e117206cbb) though the script can't begin to capture how deeply Bosh has warped my mind over the years. People tell me I'm crazy when I talk about how much fun it is to play _What Will The Bosh Director Do_ every time I run `bosh deploy`.