### PR TITLE
Fix yq commit message parsing in contributions script

### DIFF
--- a/toc/working-groups/contributions-for-user.sh
+++ b/toc/working-groups/contributions-for-user.sh
@@ -71,22 +71,72 @@ usage_checks() {
   fi
 }
 
-find_commits_for_repo() {
+find_commits_grouped_by_pr_for_repo() {
   local user=$1
   local repo=$2
 
-  if commits=$(gh api --paginate "repos/${repo}/commits?author=${user}&per_page=100" 2>/dev/null); then
-    echo "${commits}" | interactions=$(yq -oj -I=0 -r '
-      .[] |
-      "- " + .commit.author.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
-    ') yq -oj -r '(select(strenv(interactions) == "- ") | . = "") // strenv(interactions)'
+  if ! prs=$(gh api --paginate "search/issues?q=repo:${repo}+type:pr+author:${user}+is:merged&per_page=100" 2>/dev/null); then
+    return
   fi
-  if commits=$(gh api --paginate "repos/${repo}/commits?committer=${user}&per_page=100" 2>/dev/null); then
-    echo "${commits}" | interactions=$(yq -oj -I=0 -r '
-      .[] |
-      "- " + .commit.committer.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
-    ') yq -oj -r '(select(strenv(interactions) == "- ") | . = "") // strenv(interactions)'
+
+  local merged_pr_count
+  merged_pr_count=$(echo "${prs}" | yq -oj -r '.items | length')
+
+  while IFS= read -r pr_json; do
+    [[ -z "${pr_json}" ]] && continue
+    local pr_number pr_title pr_url pr_date
+    pr_number=$(echo "${pr_json}" | yq -oj -r '.number')
+    pr_title=$(echo "${pr_json}"  | yq -oj -r '.title')
+    pr_url=$(echo "${pr_json}"    | yq -oj -r '.html_url')
+    pr_date=$(echo "${pr_json}"   | yq -oj -r '.created_at')
+
+    echo "- ${pr_date}: [${pr_title}](${pr_url})"
+
+    if pr_commits=$(gh api --paginate "repos/${repo}/pulls/${pr_number}/commits?per_page=100" 2>/dev/null); then
+      local pr_commit_count
+      pr_commit_count=$(echo "${pr_commits}" | yq -oj -r '. | length')
+      if [[ "${pr_commit_count}" -gt 1 ]]; then
+        echo "${pr_commits}" | yq -oj -I=0 -r '
+          .[] |
+          "  - " + .commit.author.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
+        '
+      fi
+    fi
+  done < <(echo "${prs}" | yq -oj -I=0 -r '.items[]')
+
+  # Fallback for very recent merged PRs that might not be searchable yet.
+  if [[ "${merged_pr_count}" -gt 0 ]]; then
+    return
   fi
+
+  while IFS= read -r pr_json; do
+    [[ -z "${pr_json}" ]] && continue
+    local pr_title pr_url pr_date pr_number
+    pr_title=$(echo "${pr_json}" | yq -oj -r '.payload.pull_request.title')
+    pr_url=$(echo "${pr_json}"   | yq -oj -r '.payload.pull_request.html_url')
+    pr_date=$(echo "${pr_json}"  | yq -oj -r '.payload.pull_request.created_at')
+    pr_number=$(echo "${pr_json}"| yq -oj -r '.payload.number')
+
+    echo "- ${pr_date}: [${pr_title}](${pr_url})"
+
+    if pr_commits=$(gh api --paginate "repos/${repo}/pulls/${pr_number}/commits?per_page=100" 2>/dev/null); then
+      local pr_commit_count
+      pr_commit_count=$(echo "${pr_commits}" | yq -oj -r '. | length')
+      if [[ "${pr_commit_count}" -gt 1 ]]; then
+        echo "${pr_commits}" | yq -oj -I=0 -r '
+          .[] |
+          "  - " + .commit.author.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
+        '
+      fi
+    fi
+  done < <(echo "${EVENTS_JSON}" | user="${user}" repository="${repo}" yq -oj -I=0 -r '
+    .[]
+    | select(.type == "PullRequestEvent")
+    | select(.repo.name == strenv(repository))
+    | select(.payload.action == "closed")
+    | select(.payload.pull_request.user.login == strenv(user))
+    | select(.payload.pull_request.merged == true)
+  ')
 }
 
 find_prs_for_repo() {
@@ -196,8 +246,8 @@ for area in "${areas[@]}"; do
 
       echo "### Code contributions:"
       for repo in "${repos[@]}"; do
-        find_commits_for_repo "${USERNAME}" "${repo}"
-      done | sort -u
+        find_commits_grouped_by_pr_for_repo "${USERNAME}" "${repo}"
+      done
       echo
     ) | gh gist create -d "${USERNAME}'s Possible Contributions to ${WORKING_GROUP} - ${area}" -f "${uri_safe_file}" - 2>/dev/null
   )

--- a/toc/working-groups/contributions-for-user.sh
+++ b/toc/working-groups/contributions-for-user.sh
@@ -78,13 +78,13 @@ find_commits_for_repo() {
   if commits=$(gh api --paginate "repos/${repo}/commits?author=${user}&per_page=100" 2>/dev/null); then
     echo "${commits}" | interactions=$(yq -oj -I=0 -r '
       .[] |
-      "- " + .commit.author.date + ": [" + (.commit.message | split("\n")[0]) + "](" + .html_url + ")"
+      "- " + .commit.author.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
     ') yq -oj -r '(select(strenv(interactions) == "- ") | . = "") // strenv(interactions)'
   fi
   if commits=$(gh api --paginate "repos/${repo}/commits?committer=${user}&per_page=100" 2>/dev/null); then
     echo "${commits}" | interactions=$(yq -oj -I=0 -r '
       .[] |
-      "- " + .commit.committer.date + ": [" + (.commit.message | split("\n")[0]) + "](" + .html_url + ")"
+      "- " + .commit.committer.date + ": [" + ((.commit.message | split("\n"))[0]) + "](" + .html_url + ")"
     ') yq -oj -r '(select(strenv(interactions) == "- ") | . = "") // strenv(interactions)'
   fi
 }
@@ -171,7 +171,7 @@ areas=($(echo "${TOC_JSON}" | wg_name="${WORKING_GROUP}" yq -oj -r -I=0 -r "
 
 for area in "${areas[@]}"; do
   echo "Gathering contributions for the '${WORKING_GROUP}: ${area}' area..."
-  uri_safe_file=$(echo "${wg} - ${area}.md" | yq -oj -I=0 -r '@uri' | sed -E 's/\%20|\+|\%28/\ /g' | sed -E 's/\%0A|\%29//g' | sed 's/%2F/and/g')
+  uri_safe_file=$(echo "${WORKING_GROUP} - ${area}.md" | yq -oj -I=0 -r '@uri' | sed -E 's/\%20|\+|\%28/\ /g' | sed -E 's/\%0A|\%29//g' | sed 's/%2F/and/g')
   gist_url=$(
     (
       echo "# ${WORKING_GROUP}: ${area} Contributions"


### PR DESCRIPTION
f631f9255859feb0eac3f08ce3b504c6ee1f5a17 (Group by PR)
Refactors toc/working-groups/contributions-for-user.sh to replace flat commit listing with find_commits_grouped_by_pr_for_repo.

“Code contributions” now:
- finds merged PRs authored by the user (search/issues ... author:<user> is:merged)
- prints each PR as a top-level bullet
- fetches commits per PR and prints commit bullets under the PR only when the PR has more than one commit
- falls back to recent PullRequestEvent merged/closed events only when search returns no merged PRs.
- Removes sort -u from the code-contributions section so PR/commit grouping is preserved.

76bad69c7358df12c5ceb4e28dd8282828d476b7 (Fix yq commit message parsing in contributions script)
- Fixes the yq expression in commit formatting from (.commit.message | split("\n")[0]) to ((.commit.message | split("\n"))[0]), avoiding the !!seq ... cannot be added to a !!str runtime error.
- Fixes gist filename generation to use ${WORKING_GROUP} instead of ${wg} in uri_safe_file, preventing incorrect/empty filename prefixes.