### PR TITLE
Inactive users to be removed from FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -119,8 +119,6 @@ areas:
     github: ragaskar
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   repositories:
   - cloudfoundry/backup-and-restore-sdk-release
   - cloudfoundry/bosh-backup-and-restore
@@ -240,8 +238,6 @@ areas:
     github: ramonskie
   - name: Aram Price
     github: aramprice
-  - name: Shilpa Chandrashekara
-    github: ShilpaChandrashekara
   - name: Joerg W
     github: joergdw
   - name: Ansh Rupani
@@ -256,8 +252,6 @@ areas:
     github: alphasite
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler
@@ -316,8 +310,6 @@ areas:
     github: alphasite
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler
@@ -424,8 +416,6 @@ areas:
       github: benjaminguttmann-avtq
     - name: Gilles Miraillet
       github: gmllt
-    - name: Mario Di Miceli
-      github: mdimiceli
     - name: Nicolas Herbst
       github: nmaurer23
   repositories:
@@ -464,8 +454,6 @@ areas:
     github: nader-ziada
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:
- @mdimiceli
- @mingxiao
- @ShilpaChandrashekara 

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see #1469