### PR TITLE
Inactive users to be removed from FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -119,8 +119,6 @@ areas:
     github: ragaskar
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   repositories:
   - cloudfoundry/backup-and-restore-sdk-release
   - cloudfoundry/bosh-backup-and-restore
@@ -240,8 +238,6 @@ areas:
     github: ramonskie
   - name: Aram Price
     github: aramprice
-  - name: Shilpa Chandrashekara
-    github: ShilpaChandrashekara
   - name: Joerg W
     github: joergdw
   - name: Ansh Rupani
@@ -256,8 +252,6 @@ areas:
     github: alphasite
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler
@@ -316,8 +310,6 @@ areas:
     github: alphasite
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler
@@ -424,8 +416,6 @@ areas:
       github: benjaminguttmann-avtq
     - name: Gilles Miraillet
       github: gmllt
-    - name: Mario Di Miceli
-      github: mdimiceli
     - name: Nicolas Herbst
       github: nmaurer23
   repositories:
@@ -464,8 +454,6 @@ areas:
     github: nader-ziada
   - name: Julian Hjortshoj
     github: julian-hj
-  - name: Ming Xiao
-    github: mingxiao
   - name: Benjamin Guttmann
     github: benjaminguttmann-avtq
   - name: Felix Moehler

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -60,8 +60,6 @@ areas:
     github: hsinn0
   - name: Prateek Gangwal
     github: coolgang123
-  - name: Joe Eltgroth
-    github: joeeltgroth
   - name: Markus Strehle
     github: strehle
   - name: Daniel Linsley
@@ -69,8 +67,6 @@ areas:
   reviewers:
   - name: Duane May
     github: duanemay
-  - name: Behrouz Soroushian
-    github: bsoroushian
   - name: Ajita Jain
     github: jajita
   - name: Andrew Costa
@@ -90,8 +86,6 @@ areas:
   - cloudfoundry/secure-credentials-broker
 - name: Disaster Recovery (BBR)
   reviewers:
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
   - name: Allan Yu
@@ -246,8 +240,6 @@ areas:
     github: selzoc
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Nishad Mathur
     github: alphasite
   - name: Julian Hjortshoj
@@ -304,8 +296,6 @@ areas:
     github: anshrupani
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Nishad Mathur
     github: alphasite
   - name: Julian Hjortshoj
@@ -450,8 +440,6 @@ areas:
     github: anshrupani
   - name: Nitin Ravindran
     github: xtreme-nitin-ravindran
-  - name: Nader Ziada
-    github: nader-ziada
   - name: Julian Hjortshoj
     github: julian-hj
   - name: Benjamin Guttmann
@@ -482,8 +470,6 @@ areas:
     github: Benjamintf1
   - name: Sam Gunaratne
     github: samze
-  - name: Alex Rocha
-    github: xandroc
   - name: Jochen Ehret
     github: jochenehret
   - name: Greg Cobb


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@xandroc
@nader-ziada
@bsoroushian
@joeeltgroth
According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1486