### PR TITLE
working with the BOSH team

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -121,6 +121,8 @@ areas:
     github: julian-hj
   - name: Ming Xiao
     github: mingxiao
+  - name: Colin Shield
+    github: colins
   repositories:
   - cloudfoundry/backup-and-restore-sdk-release
   - cloudfoundry/bosh-backup-and-restore
@@ -268,6 +270,8 @@ areas:
     github: KauzClay
   - name: Ned Petrov
     github: neddp
+  - name: Colin Shield
+    github: colins
   reviewers:
   - name: Allan Yu
     github: ay901246
@@ -332,6 +336,8 @@ areas:
     github: neddp
   - name: Maria Shaldybin
     github: mariash
+  - name: Colin Shield
+    github: colins
   reviewers:
   - name: Allan Yu
     github: ay901246


### PR DESCRIPTION
Adding Colin Shield (colins) as approver to:
- Disaster Recovery (BBR)
- Stemcell Release Engineering (BOSH)
- VM deployment lifecycle (BOSH)
