### PR TITLE
Archive bosh-bbl-ci-envs

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -194,6 +194,7 @@ orgs:
         description: Test Releases for bosh-backup-and-restore
         has_projects: true
       bosh-bbl-ci-envs:
+        archived: true
         description: BOSH DNS release CI envs
         has_projects: false
         has_wiki: false


### PR DESCRIPTION
- [x] Merge **AFTER** https://github.com/cloudfoundry/bosh-bbl-ci-envs/pull/3


This repo was only used for CI, could it be deleted after / instead of archiving?
