### PR TITLE
Add cf-identity and Duane May to homebrew-tap

### DIFF
--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -89,11 +89,15 @@ areas:
     github: lnguyen
   - name: Rajan Agaskar
     github: ragaskar
+  - name: Duane May
+    github: duanemay
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng
   - name: Credhub CLI
     github: credhub-ci-bot
+  - name: cf-uaa-ci-bot
+    github: cf-identity
   repositories:
   - cloudfoundry/homebrew-tap
 config:


### PR DESCRIPTION
We want to publish uaa-cli in homebrew, the current version there is 4 years old.