### PR TITLE
Inactive users to be removed from FI WG

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -263,8 +263,6 @@ areas:
   reviewers:
   - name: Allan Yu
     github: ay901246
-  - name: Sascha Stojanovic
-    github: Sascha-Stoj
   - name: Ivaylo Ivanov
     github: ivaylogi98
   - name: Yuri Adam
@@ -300,8 +298,6 @@ areas:
     github: a-hassanin
   - name: Ansh Rupani
     github: anshrupani
-  - name: Nitin Ravindran
-    github: xtreme-nitin-ravindran
   - name: Nishad Mathur
     github: alphasite
   - name: Julian Hjortshoj
@@ -325,8 +321,6 @@ areas:
   reviewers:
   - name: Allan Yu
     github: ay901246
-  - name: Sascha Stojanovic
-    github: Sascha-Stoj
   - name: Alexander Lais
     github: peanball
   - name: Ivaylo Ivanov
@@ -412,8 +406,6 @@ areas:
   approvers:
     - name: Benjamin Guttmann
       github: benjaminguttmann-avtq
-    - name: Gilles Miraillet
-      github: gmllt
     - name: Nicolas Herbst
       github: nmaurer23
   reviewers:
@@ -449,8 +441,6 @@ areas:
     github: a-hassanin
   - name: Ansh Rupani
     github: anshrupani
-  - name: Nitin Ravindran
-    github: xtreme-nitin-ravindran
   - name: Julian Hjortshoj
     github: julian-hj
   - name: Benjamin Guttmann
@@ -492,8 +482,6 @@ areas:
   reviewers:
   - name: Allan Yu
     github: ay901246
-  - name: Sascha Stojanovic
-    github: Sascha-Stoj
   - name: Alexander Lais
     github: peanball
   - name: Al Berez


### PR DESCRIPTION
According to the rules for inactivity defined in [RFC-0025](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md), the following users should be removed from ARI approvers/reviewers/bots:

@gmllt
@xtreme-nitin-ravindran
@Sascha-Stoj

According to the [revocation policy in the RFC](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0025-define-criteria-and-removal-process-for-inactive-members.md#remove-the-membership-to-the-cloud-foundry-github-organization), users have two weeks to refute this revocation, if they wish by commenting on this pull-request and open a new pull-request to be re-added as approver after this one is merged.

Inactivity was detected by a github action, see https://github.com/cloudfoundry/community/pull/1509