### PR TITLE
Add cf-k8s-releases repo

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -19,6 +19,20 @@ branch-protection:
             bypass_pull_request_allowances:
               teams: ["wg-app-runtime-deployments-bots"] # no area bots configured
           include: [ "^main$", "^v[0-9]*$"]
+        cf-k8s-releases:
+          allow_deletions: false
+          allow_disabled_policies: true
+          allow_force_pushes: false
+          enforce_admins: true
+          include: ["^main$"]
+          protect: true
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
         cf-relint-ci-semver:
           protect: false
         relint-ci-pools:

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -648,6 +648,12 @@ orgs:
         archived: true
         default_branch: main
         has_projects: true
+      cf-k8s-releases:
+        allow_merge_commit: false
+        default_branch: main
+        description: k8s deploy assets (helm charts and dockerfiles) for Cloud Foundry
+        has_projects: false
+        has_wiki: false
       cf-k8s-secrets:
         default_branch: main
         has_projects: true

--- a/toc/working-groups/app-runtime-deployments.md
+++ b/toc/working-groups/app-runtime-deployments.md
@@ -107,4 +107,5 @@ areas:
   - cloudfoundry/k8s-garden-client
   - cloudfoundry/k8s-policy-agent
   - cloudfoundry/kind-deployment
+  - cloudfoundry/cf-k8s-releases
 ```


### PR DESCRIPTION
New repo to host k8s assets because they are not bound to `kind` only. Next step would be to build those assets automatically whenever there is a new bosh release.