### PR TITLE
Add diego-db-helpers repo

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -1099,6 +1099,10 @@ orgs:
         archived: true
         has_projects: true
         private: true
+      diego-db-helpers:
+        description: DB Helpers Shared by BBS + Locket
+        has_issues: false
+        has_projects: true
       diego-design-notes:
         archived: true
         description: Diego Architectural Design Musings and Explications

--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -115,6 +115,7 @@ areas:
   - cloudfoundry/clock
   - cloudfoundry/debugserver
   - cloudfoundry/runtime-ci-pools
+  - cloudfoundry/diego-db-helpers
   - cloudfoundry/diego-logging-client
   - cloudfoundry/diego-release
   - cloudfoundry/diego-upgrade-stability-tests


### PR DESCRIPTION
Adds a new repo to help detangle the bbs-locket-rep-auctioneer interdependency mess and get rid of more submodules!