### PR TITLE
update stemcell branch protection rules

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -494,9 +494,7 @@ branch-protection:
           allow_force_pushes: false
           enforce_admins: false
           include:
-          - ^ubuntu-jammy$
-          - ^ubuntu-noble$
-          - ^v[0-9]*$
+          - ^ubuntu-[a-z]+$
           protect: true
           required_pull_request_reviews:
             bypass_pull_request_allowances:


### PR DESCRIPTION
Update this to work for current and future ubuntu stemcell lines. Also removing the `^v[0-9]*$` line as we don't use that naming scheme for branches anymore.