### PR TITLE
Add repo for rust package release

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -354,6 +354,10 @@ orgs:
         description: Ruby release for use with `bosh vendor-package`
         default_branch: main
         has_projects: false
+      bosh-package-rust-release:
+        description: Rust release for use with `bosh vendor-package`
+        default_branch: main
+        has_projects: false
       bosh-linux-stemcell-builder:
         default_branch: ubuntu-jammy
         description: 'BOSH Ubuntu Linux stemcells '

--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -374,6 +374,7 @@ areas:
   - cloudfoundry/bosh-package-nginx-release
   - cloudfoundry/bosh-package-python-release
   - cloudfoundry/bosh-package-ruby-release
+  - cloudfoundry/bosh-package-rust-release
   - cloudfoundry/bosh-psmodules
   - cloudfoundry/bosh-shared-ci
   - cloudfoundry/bosh-utils
@@ -563,6 +564,7 @@ config:
     - cloudfoundry/bosh-package-nginx-release
     - cloudfoundry/bosh-package-python-release
     - cloudfoundry/bosh-package-ruby-release
+    - cloudfoundry/bosh-package-rust-release
     - cloudfoundry/bosh-s3cli
     - cloudfoundry/bosh-warden-cpi-release
     - cloudfoundry/bpm-release


### PR DESCRIPTION
This is primarily for use with https://github.com/cloudfoundry/bosh-package-ruby-release since modern ruby JIT infrastructure requires Rust to build.

Ref: https://docs.ruby-lang.org/en/4.0/jit/yjit_md.html