### PR TITLE
Add Agentic Runtime working group

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -23,6 +23,10 @@ orgs:
       admin-tools:
         has_projects: true
         private: true
+      agentic-runtime-notes:
+        default_branch: main
+        description: Research notes, design documents, and RFCs for the Agentic Runtime Working Group
+        has_projects: true
       api-docs:
         default_branch: main
         description: Cloud Controller API Docs

--- a/toc/working-groups/WORKING-GROUPS.md
+++ b/toc/working-groups/WORKING-GROUPS.md
@@ -34,6 +34,7 @@ Most working groups manage a subset of repositories in the `cloudfoundry` GitHub
 
 The current working groups are:
 
+- Agentic Runtime
 - App Runtime Deployments
 - App Runtime Interfaces
 - App Runtime Platform
@@ -43,6 +44,28 @@ The current working groups are:
 - Paketo
 - Vulnerability Management
 - Concourse
+
+
+## Agentic Runtime
+
+Mission: To define and advance a shared vision for running AI agents and LLM-powered workloads as first-class citizens on Cloud Foundry.
+
+The GitHub repos this WG manages in the `cloudfoundry` GitHub organization are to be labeled with the `cff-wg-agentic-runtime` topic.
+
+| Artifact                   | Link |
+| -------------------------- | ---- |
+| Charter                    | [agentic-runtime.md](./agentic-runtime.md) |
+| Forum                      | TBD |
+| Community Meeting Calendar | TBD |
+| Meeting Notes              | TBD |
+| Slack Channel              | [&#x23;ai-wg](https://cloudfoundry.slack.com/archives/C0B214KJ1HA) |
+
+| &nbsp;                                                   | Leads            | Company | Profile                                  |
+| -------------------------------------------------------- | ---------------- | ------- | ---------------------------------------- |
+| <img width="30px" src="https://github.com/beyhan.png"> | Beyhan Veli | SAP | [@beyhan](https://github.com/beyhan) |
+| <img width="30px" src="https://github.com/wayneeseguin.png"> | Wayne E. Seguin | FiveTwenty.io | [@wayneeseguin](https://github.com/wayneeseguin) |
+| <img width="30px" src="https://github.com/rkoster.png"> | Ruben Koster | Rabobank | [@rkoster](https://github.com/rkoster) |
+| <img width="30px" src="https://github.com/itsouvalas.png"> | Ioannis Tsouvalas | &nbsp; | [@itsouvalas](https://github.com/itsouvalas) |
 
 
 ## App Runtime Deployments

--- a/toc/working-groups/agentic-runtime.md
+++ b/toc/working-groups/agentic-runtime.md
@@ -73,6 +73,8 @@ areas:
     github: nmaurer23
   - name: Rashid Rashidov
     github: rrashidov
+  - name: Gerd Alliu
+    github: al-gerd
   repositories:
   - cloudfoundry/agentic-runtime-notes
 ```

--- a/toc/working-groups/agentic-runtime.md
+++ b/toc/working-groups/agentic-runtime.md
@@ -45,6 +45,8 @@ technical_leads:
 - name: Ioannis Tsouvalas
   github: itsouvalas
 
+bots: []
+
 areas:
 - name: Agentic Runtime
   approvers:

--- a/toc/working-groups/agentic-runtime.md
+++ b/toc/working-groups/agentic-runtime.md
@@ -58,6 +58,8 @@ areas:
     github: vlast3k
   - name: Arsalan Khan
     github: asalan316
+  - name: Kevin Rutten
+    github: krutten
   reviewers:
   - name: Tsvetelina Marinova
     github: ivanovac
@@ -69,6 +71,8 @@ areas:
     github: dudejas
   - name: Nicolas Herbst
     github: nmaurer23
+  - name: Rashid Rashidov
+    github: rrashidov
   repositories:
   - cloudfoundry/agentic-runtime-notes
 ```

--- a/toc/working-groups/agentic-runtime.md
+++ b/toc/working-groups/agentic-runtime.md
@@ -1,0 +1,72 @@
+# Agentic Runtime: Working Group Charter
+
+## Mission
+
+Define and advance a shared vision for running AI agents and LLM-powered workloads as first-class citizens on Cloud Foundry — deployed, managed, secured, scaled, and observed using the same platform-native primitives that developers and operators rely on today.
+
+## Goals
+
+* Establish lifecycle and runtime models for agents running alongside traditional apps on CF
+* Define standards for agent identity, authentication, and authorization within CF spaces
+* Drive platform extensions for autonomy, orchestration, and inter-agent communication on CF
+* Carry CF's core values of security, operability, portability, and developer experience into agentic workloads
+
+## Scope
+
+* Define and evolve architectural, security, and operational models for CF-native agent workloads
+* Evaluate technologies in the agentic ecosystem for relevance to CF's runtime model
+* Produce design documents, RFCs, and implementations for agentic runtime primitives in CF
+* Collaborate with other CF working groups to integrate agent capabilities into the CF platform
+
+## Non-Goals
+
+* General-purpose AI/ML infrastructure not tied to CF's runtime model
+* Agent model training, fine-tuning, or inference serving infrastructure
+* Agentic runtime work targeting Kubernetes-native approaches outside CF's deployment model
+* Exposing GPUs to application containers
+* Running LLMs directly on Diego — LLM inference should be deployed via BOSH and exposed to applications through the CF service broker API
+
+## Roles & Technical Assets
+
+Research notes, design documents, and RFCs for agentic workloads on Cloud Foundry.
+
+```yaml
+name: Agentic Runtime
+
+execution_leads:
+- name: Beyhan Veli
+  github: beyhan
+
+technical_leads:
+- name: Wayne E. Seguin
+  github: wayneeseguin
+- name: Ruben Koster
+  github: rkoster
+- name: Ioannis Tsouvalas
+  github: itsouvalas
+
+areas:
+- name: Agentic Runtime
+  approvers:
+  - name: Benjamin Guttmann
+    github: benjaminguttmann-avtq
+  - name: Aram Price
+    github: aramprice
+  - name: Vladimir Savchenko
+    github: vlast3k
+  - name: Arsalan Khan
+    github: asalan316
+  reviewers:
+  - name: Tsvetelina Marinova
+    github: ivanovac
+  - name: Ned Petrov
+    github: neddp
+  - name: Ivaylo Ivanov
+    github: ivaylogi98
+  - name: Saumya Dudeja
+    github: dudejas
+  - name: Nicolas Herbst
+    github: nmaurer23
+  repositories:
+  - cloudfoundry/agentic-runtime-notes
+```


### PR DESCRIPTION
## Summary

- Adds the **Agentic Runtime** working group charter (`toc/working-groups/agentic-runtime.md`) with mission, goals, scope, non-goals, and the full member roster
- Updates `WORKING-GROUPS.md` with the new WG entry, leads table, and `#ai-wg` Slack channel link
- Adds `cloudfoundry/agentic-runtime-notes` to `orgs/orgs.yml` for repo creation

## Working Group Details

The Agentic Runtime WG defines and advances a shared vision for running AI agents and LLM-powered workloads as first-class citizens on Cloud Foundry.

| Role | Members |
|------|---------|
| Execution Lead | Beyhan Veli |
| Technical Leads | Wayne E. Seguin, Ruben Koster, Ioannis Tsouvalas |
| Approvers | Benjamin Guttmann, Aram Price, Vladimir Savchenko, Arsalan Khan |
| Reviewers | Tsvetelina Marinova, Ned Petrov, Ivaylo Ivanov, Saumya Dudeja, Nicolas Herbst |