### PR TITLE
Add stiv03 to approvers

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -340,8 +340,6 @@ areas:
   - name: Stoyan Ivanov
     github: stiv03
   reviewers:
-  - name: Stoyan Ivanov
-    github: stiv03
   - name: Krasimir Kargov
     github: karrgov
   bots:

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -337,6 +337,8 @@ areas:
     github: Yavor16
   - name: Stefan Yonkov
     github: s-yonkov-yonkov
+  - name: Stoyan Ivanov
+    github: stiv03
   reviewers:
   - name: Stoyan Ivanov
     github: stiv03


### PR DESCRIPTION
I have been a reviewer for a year, actively contributing to projects owned by the SAP Cloud Deployment Service (MTA Deployment Service) team. During this time, I have regularly participated in code reviews and contributed to the codebase.

I meet the stated requirements for becoming an approver, including:

- More than 3 months of reviewer experience in the area
- More than 20 contributions to the area

Based on my experience and ongoing involvement, I would like to request the approver role