### PR TITLE
FIWG: enable deploy keys for os-conf-release

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -532,6 +532,7 @@ config:
     - cloudfoundry/credhub-deployments
     - cloudfoundry/credhub-oss-ci
     - cloudfoundry/jumpbox-deployment
+    - cloudfoundry/os-conf-release
     - cloudfoundry/postgres-release
     - cloudfoundry/socks5-proxy
     - cloudfoundry/windows-utilities-release


### PR DESCRIPTION
Fixes https://bosh.ci.cloudfoundry.org/teams/main/pipelines/os-conf-release/jobs/bump-deps/builds/4#L6a35dfee:13
```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote:
remote: - Changes must be made through a pull request.
To github.com:cloudfoundry/os-conf-release.git
 ! [remote rejected] HEAD -> master (protected branch hook declined)
error: failed to push some refs to 'github.com:cloudfoundry/os-conf-release.git'
failed with non-rebase error
```