### PR TITLE
Add ivaylogi98 as approver

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -223,11 +223,11 @@ areas:
     github: neddp
   - name: Colin Shield
     github: colins
+  - name: Ivaylo Ivanov
+    github: ivaylogi98
   reviewers:
   - name: Allan Yu
     github: ay901246
-  - name: Ivaylo Ivanov
-    github: ivaylogi98
   - name: Yuri Adam
     github: yuriadam-sap
   - name: Danitsa Kostova
@@ -281,13 +281,13 @@ areas:
     github: mariash
   - name: Colin Shield
     github: colins
+  - name: Ivaylo Ivanov
+    github: ivaylogi98
   reviewers:
   - name: Allan Yu
     github: ay901246
   - name: Alexander Lais
     github: peanball
-  - name: Ivaylo Ivanov
-    github: ivaylogi98
   - name: Yuri Adam
     github: yuriadam-sap
   - name: Danitsa Kostova


### PR DESCRIPTION
Hi everyone, I'm applying for the approver role.

Here's a list of my contributions based on the script `contributions-for-user.sh` with changes I'm working on in https://github.com/cloudfoundry/community/pull/1532

# Contributions

## Foundational Infrastructure: VM deployment lifecycle (BOSH) Contributions

### PRs Authored:
- 2026-04-14T11:53:42Z: [Add permission for read-only access to snapshots](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/384) (closed)
- 2026-04-15T17:37:04Z: [Add fallback for permission errors](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/385) (closed)
- 2026-05-04T11:33:55Z: [Add instance storage discovery patterns in config](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/592) (closed)
- 2026-05-11T08:28:13Z: [Fix integration test: use pd-balanced instead of hyperdisk-balanced for disk type change test](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/388) (closed)
- 2026-05-12T15:16:27Z: [Update CHANGELOG for release 50.1.3](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/389) (closed)
- 2026-06-11T10:24:33Z: [Add NVMe support to Alicloud infrastructure configuration](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/635) (closed)
- 2026-06-12T11:01:08Z: [Add NVMe support to Alicloud infrastructure configuration](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/639) (closed)

### PRs Reviewed/Commented on:
- : []()

### Commits on others' PRs:
- 2025-04-15T19:38:10Z: [[RFC0038] Introduce prefix allocation](https://github.com/cloudfoundry/bosh/pull/2611) (by fmoehler)
- 2025-04-30T11:48:31Z: [support multistack networks and prefixes for ipv4 and ipv6](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/181) (by anshrupani)
- 2025-07-07T09:42:57Z: [Fix tags extraction from runtime config](https://github.com/cloudfoundry/bosh/pull/2617) (by IvayloIvanovSAP)
- 2025-07-07T11:16:11Z: [Update debug API version to 3 and fix AMI tagging logic](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/182) (by IvayloIvanovSAP)

### Issues that may be relevant:

- 2026-04-09T09:31:57Z: [Add option to set VM CID in cloud-check](https://github.com/cloudfoundry/bosh-cli/issues/719)
- 2026-04-30T15:20:51Z: [ubuntu-noble warden stemcell: BOSH DNS runtime config needs recursor adjustment for BOSH Lite on GCP](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/584)
- 2026-05-07T06:57:00Z: [Intermittent bootstrap failure on AWS Nitro instances](https://github.com/cloudfoundry/bosh-agent/issues/428)
- 2026-05-07T07:06:37Z: [Persistent disk mount issue with Nitro instances](https://github.com/cloudfoundry/bosh-agent/issues/429)

### Code contributions (merged PRs):
- 2026-02-23T15:29:18Z: [Fix nvme instance storage discovery](https://github.com/cloudfoundry/bosh-agent/pull/407)
  - 2026-02-23T15:27:07Z: [Make implementation iaas-agnostic](https://github.com/cloudfoundry/bosh-agent/commit/a4f8382ee6b23507f581a9167db97efbde32b68d)
  - 2026-02-23T21:37:32Z: [Rename storage resolver files](https://github.com/cloudfoundry/bosh-agent/commit/b5ed026c5abfe97f5ecb9b00c07c33bffbd720fd)
  - 2026-02-23T21:49:10Z: [Fix tests](https://github.com/cloudfoundry/bosh-agent/commit/1d475eac82bdf9da1bb6df9870f2b5bb77c92b3f)
  - 2026-02-24T14:33:59Z: [Remove instance storage resolver](https://github.com/cloudfoundry/bosh-agent/commit/8042658c2b818b82b1019173b59d1f11251290b7)
  - 2026-02-24T14:58:14Z: [Don't use the aws pattern as default](https://github.com/cloudfoundry/bosh-agent/commit/6ab6cd73efc95fff49d9c342daa334320e4d339e)
  - 2026-02-25T14:00:20Z: [Refactor NVMe instance storage discovery and remove unused symlink patterns](https://github.com/cloudfoundry/bosh-agent/commit/6abcf7b3f6149ba8c9d8dae0814a8e7b2c902a99)
  - 2026-02-25T14:34:46Z: [Enhance NVMe instance storage discovery with managed volume pattern support](https://github.com/cloudfoundry/bosh-agent/commit/c3dd347a4906ff2d8e7f4be469d9b05a7bdf376d)
  - 2026-02-26T09:58:45Z: [Fix unit tests](https://github.com/cloudfoundry/bosh-agent/commit/ed62e01acde437acd507e584cebbbeea5d5fa4cd)
  - 2026-03-04T08:19:53Z: [Don't run windows unit tests when not supported](https://github.com/cloudfoundry/bosh-agent/commit/18702886d2689f09cb0c30c2c835576d90c6414b)
  - 2026-03-04T13:18:27Z: [Simplify FakeDevicePathResolver by removing unused fields and methods](https://github.com/cloudfoundry/bosh-agent/commit/45e7c874f1f6cd5b41ddc6e85dd23aeeb00d0349)
  - 2026-04-29T13:43:10Z: [Wait for udev to settle before resolving EBS symlinks](https://github.com/cloudfoundry/bosh-agent/commit/1d089f1def2f2f53dcb2f7016eaa3493e1cb6ff6)
  - 2026-04-30T12:14:06Z: [Add debug logs](https://github.com/cloudfoundry/bosh-agent/commit/2c33e1ca446496e33685fdd47473389ea9a315b5)
  - 2026-04-30T12:14:31Z: [Import udev and add comment about why it's needed](https://github.com/cloudfoundry/bosh-agent/commit/1f547601da1ed8403de9a3d20677df9d781c5826)
- 2026-02-09T14:50:12Z: [Remove leftover path normalization](https://github.com/cloudfoundry/bosh-agent/pull/401)
- 2026-02-06T14:59:20Z: [Fix nvme instance storage discovery](https://github.com/cloudfoundry/bosh-agent/pull/400)
  - 2026-02-09T12:38:48Z: [Refactor instance storage discovery into configurable component](https://github.com/cloudfoundry/bosh-agent/commit/7266b3c2a3d176f4dd139c67f3df9bff801d830d)
  - 2026-02-09T14:05:25Z: [Fix windows tests](https://github.com/cloudfoundry/bosh-agent/commit/0150c6fdf1eed7ae4ab88e43e5875206b43f6ae4)
  - 2026-02-09T14:11:10Z: [Fix windows tests (but for real this time)](https://github.com/cloudfoundry/bosh-agent/commit/c91216438005651b264a27828ae718be8511d154)
- 2026-05-12T15:16:27Z: [Update CHANGELOG for release 50.1.3](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/389)
  - 2026-05-12T15:15:55Z: [Update CHANGELOG for release 50.1.3](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/0d269e022a3394096b3d68582810b31720e77cf5)
  - 2026-05-14T13:08:07Z: [Update CHANGELOG to include link for release 50.1.3](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/2fc90421c2b009c55597536a5ff831c41be0ff53)
- 2026-05-11T08:28:13Z: [Fix integration test: use pd-balanced instead of hyperdisk-balanced for disk type change test](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/388)
- 2026-04-14T11:53:42Z: [Add permission for read-only access to snapshots](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/384)

# Foundational Infrastructure: Ali Cloud VM deployment lifecycle (BOSH) Contributions

### PRs Authored:
(none found)

### PRs Reviewed/Commented on:
(none found)

### Commits on others' PRs:
(none found)

### Issues that may be relevant:
(none found)

### Code contributions (merged PRs):
- 2026-06-01T08:30:49Z: [Enable NVME support on imageCopy](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/pull/204)
  - 2026-05-29T09:56:34Z: [Enable NVME support on imageCopy](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/commit/528238f607bf56ac2a8696d8c9a5d6bdd5a3118b)
  - 2026-06-08T13:43:36Z: [Cleanup comments](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/commit/a5173a51958f4fea83af2505ba455bd11265cf6b)
  - 2026-06-09T09:11:57Z: [Add tests](https://github.com/cloudfoundry/bosh-alicloud-cpi-release/commit/e20f29766c1f5f15ff5f0a291605a84be579ad64)

# Foundational Infrastructure: Storage CLI Contributions

### PRs Authored:
- 2025-11-11T16:14:22Z: [Remove AWS Signature Version config](https://github.com/cloudfoundry/bosh-s3cli/pull/57) (closed)
- 2025-11-25T09:23:27Z: [Fix request signing](https://github.com/cloudfoundry/bosh-s3cli/pull/60) (closed)
- 2026-01-26T15:39:09Z: [Add region to the s3 compatible integration tests](https://github.com/cloudfoundry/bosh-s3cli/pull/63) (closed)
- 2026-02-16T10:53:43Z: [Add default region to config for GCP endpoints](https://github.com/cloudfoundry/bosh-s3cli/pull/64) (closed)
- 2026-02-17T16:31:55Z: [Make checksum calculation configurable](https://github.com/cloudfoundry/bosh-s3cli/pull/66) (closed)

### PRs Reviewed/Commented on:
(none found)

### Commits on others' PRs:
- 2025-08-11T10:41:23Z: [[WIP] Upgrade AWS SDK for Go to v2](https://github.com/cloudfoundry/bosh-s3cli/pull/51) (by beyhan)
- 2026-01-26T15:11:04Z: [Merge bosh-s3cli changes from `7ac9468b` to `39c1e2` (main)](https://github.com/cloudfoundry/storage-cli/pull/25) (by johha)

### Issues that may be relevant:

- 2025-11-06T23:44:31Z: [Updating to AWS go sdk v2 has left integration tests broken](https://github.com/cloudfoundry/bosh-s3cli/issues/55)

### Code contributions (merged PRs):
(none found)

