### PR TITLE
Add Kump3r as approver to Concourse working group

### DIFF
--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -47,11 +47,11 @@ areas:
     github: Spimtav
   - name: Harish Yayi
     github: yharish991
+  - name: Kump3r
+    github: Kump3r
   reviewers:
   - name: Ivan Chalukov
     github: IvanChalukov
-  - name: Kump3r
-    github: Kump3r
   repositories:
   - concourse/concourse
   - concourse/concourse-bosh-release


### PR DESCRIPTION
# Concourse: Core Contributions

Proposing @Kump3r as approver to Concourse working group
### PRs Commented on/Reviewed:

- 2024-11-01T13:47:23Z: [Replace md5 with sha256 algorithm](https://github.com/concourse/concourse/pull/9021)
- 2024-11-02T16:43:59Z: [merging main back into master](https://github.com/concourse/concourse/pull/9022)
- 2025-01-16T10:59:12Z: [Note that --cf-org users still need to be part of a Space](https://github.com/concourse/docs/pull/544)
- 2025-01-24T16:45:13Z: [Bump Dex and other dependencies](https://github.com/concourse/concourse/pull/9059)
- 2025-03-07T23:46:56Z: [Fix `--team` flag in `order-pipelines` command ](https://github.com/concourse/concourse/pull/9102)
- 2025-03-09T08:23:33Z: [Add `--team` flag to `clear-resource-cache` command](https://github.com/concourse/concourse/pull/9106)
- 2025-03-11T07:36:59Z: [Add  `--team` flag to `containers` command](https://github.com/concourse/concourse/pull/9107)
- 2025-03-27T15:52:48Z: [Switch use of md5 hashing to sha256](https://github.com/concourse/concourse/pull/9165)
- 2025-04-06T14:16:57Z: [Warn instead of error on unused resources](https://github.com/concourse/concourse/pull/9177)
- 2025-05-27T11:51:55Z: [Skip renewal for non-renewable Vault tokens](https://github.com/concourse/concourse/pull/9208)
- 2025-06-25T14:13:36Z: [Invalidate access token on Logout](https://github.com/concourse/concourse/pull/9218)
- 2025-07-11T19:54:48Z: [runtime/containerd: ensure logs are not dropped when web node re-attaches to running containers](https://github.com/concourse/concourse/pull/9234)
- 2025-07-23T14:50:15Z: [containerd: add flag to add additional-hosts](https://github.com/concourse/concourse/pull/9238)
- 2025-08-20T18:08:54Z: [Update all dependencies](https://github.com/concourse/concourse/pull/9259)
- 2025-08-29T07:48:33Z: [support zstd layer decompression](https://github.com/concourse/registry-image-resource/pull/390)
- 2025-08-29T11:47:51Z: [Add broadcast message to Concourse cluster](https://github.com/concourse/concourse/pull/9273)
- 2025-09-04T19:14:46Z: [update migration number for switch_md5_to_sha256 [skip-migrations-check]](https://github.com/concourse/concourse/pull/9278)
- 2025-09-10T12:23:16Z: [Prevent resources from emitting empty versions](https://github.com/concourse/concourse/pull/9293)
- 2025-09-25T12:11:35Z: [Create RFC for health endpoint](https://github.com/concourse/rfcs/pull/141)
- 2025-10-15T15:34:03Z: [Add `--team` flag to `clear-versions` command](https://github.com/concourse/concourse/pull/9334)
- 2025-10-16T14:56:53Z: [Add `--non-interactive` flag to `clear-versions` command](https://github.com/concourse/concourse/pull/9335)
- 2025-10-31T23:00:07Z: [Fix [containerd]: make container attach idempotent and handle exited processes gracefully](https://github.com/concourse/concourse/pull/9345)
- 2025-11-06T16:00:18Z: [fix(deps): update module github.com/containerd/containerd/v2 to v2.1.5 [security]](https://github.com/concourse/concourse/pull/9348)
- 2025-11-10T17:59:05Z: [[7.14.x] Bump containerd to v2.1.5 & v1.7.29](https://github.com/concourse/concourse/pull/9354)
- 2025-11-25T16:42:15Z: [set containerd as the default runtime for linux workers](https://github.com/concourse/concourse/pull/9372)
- 2025-11-26T21:23:32Z: [redact secrets is always enabled](https://github.com/concourse/concourse/pull/9378)
- 2026-01-19T16:21:39Z: [Fix down migration cleanup for resource_config_versions_version_md5 index](https://github.com/concourse/concourse/pull/9426)
- 2026-01-20T09:22:09Z: [Fix down migration to fully restore rerun_of indexes](https://github.com/concourse/concourse/pull/9428)
- 2026-01-23T19:01:10Z: [Handle json null values in the resource_config_versions table during the sha256 migration](https://github.com/concourse/concourse/pull/9436)
- 2026-04-14T15:11:20Z: [Cache Vault KV version by mount path to reduce preflight calls (`CONCOURSE_VAULT_ENABLE_KV_MOUNT_CACHE`)](https://github.com/concourse/concourse/pull/9530)
- 2026-04-20T03:17:24Z: [Bump tedsuo/ifrit](https://github.com/concourse/concourse/pull/9539)
- 2026-04-21T10:10:10Z: [Add CONCOURSE_VAULT_ENABLE_KV_MOUNT_CACHE](https://github.com/concourse/concourse-bosh-release/pull/195)
- 2026-05-11T15:24:40Z: [fix: handle all IPv4 loopback resolvers](https://github.com/concourse/concourse/pull/9569)
- 2026-05-18T15:59:29Z: [Update CF connector to implement new Connector interface](https://github.com/concourse/dex/pull/273)
- 2026-05-27T09:50:04Z: [feat: Add health endpoint basic structures and routes](https://github.com/concourse/concourse/pull/9588)
- 2026-06-12T09:47:28Z: [feat: add validation for team names to prevent '/' characters in rename-team command](https://github.com/concourse/concourse/pull/9600)
- 2026-06-19T20:55:49Z: [add --force flag to fly's abort-build command](https://github.com/concourse/concourse/pull/9611)
- 2026-06-24T15:57:19Z: [Add configurable baseline security HTTP headers (Referrer-Policy, COOP, CORP, COEP)](https://github.com/concourse/concourse/pull/9618)
### Issues that may be relevant:

- 2017-05-09T17:48:45Z: [Document and support the ATC REST API](https://github.com/concourse/concourse/issues/1122)
- 2022-12-07T11:55:40Z: [Pipeline freezes when managing resource trough set_pipeline](https://github.com/concourse/concourse/issues/8641)
- 2023-01-16T08:49:37Z: [Missing versions.yml in concourse-bosh-deployment for tag v7.9.0](https://github.com/concourse/concourse/issues/8671)
- 2023-03-06T17:53:20Z: [cf authentication fails on 7.9.1](https://github.com/concourse/concourse/issues/8696)
- 2024-06-25T00:45:38Z: [Update concourse/dex dependancy to at least v2.39.0 from upstream](https://github.com/concourse/concourse/issues/8970)
- 2024-08-27T11:00:58Z: [CONCOURSE_GARDEN_DENY_NETWORK is not working as expected in v 7.11.0](https://github.com/concourse/concourse/issues/8993)
- 2024-10-02T11:43:59Z: [CF API v2 End of Life](https://github.com/concourse/concourse/issues/9006)
- 2024-10-02T13:42:23Z: [Concourse is not FIPS compliant](https://github.com/concourse/concourse/issues/9007)
- 2024-11-05T13:26:51Z: [go build/install is failing](https://github.com/concourse/concourse/issues/9023)
- 2025-01-07T17:59:21Z: [stdout/stderr output to the console is lost when jobs have a long duration](https://github.com/concourse/concourse/issues/9050)
- 2025-01-10T14:37:52Z: [[CloudFoundry Auth] Issue with providing access to a whole organisation](https://github.com/concourse/concourse/issues/9052)
- 2025-03-20T14:29:51Z: [Release 7.13.0](https://github.com/concourse/concourse/issues/9147)
- 2025-04-15T16:01:27Z: [JWT Expiration with CredHub Causes Resource Interpolation Failures After Upgrade to 7.13.0](https://github.com/concourse/concourse/issues/9186)
- 2025-04-24T09:56:38Z: [Missing build logs - containerd](https://github.com/concourse/concourse/issues/9189)
- 2025-04-29T10:15:41Z: [Worker is not de-registered from Concourse](https://github.com/concourse/concourse/issues/9191)
- 2025-08-02T22:45:49Z: [Pipeline attribute is not passed when using fly execute](https://github.com/concourse/concourse/issues/9250)
- 2025-09-01T13:11:01Z: [Overlay volume layers leaking](https://github.com/concourse/concourse/issues/9274)
- 2025-10-30T15:53:27Z: [Entire task restarts if web nodes restart when task is nearly done running](https://github.com/concourse/concourse/issues/9344)
- 2025-12-05T14:14:13Z: [Cookies are missing the SameSite attribute](https://github.com/concourse/concourse/issues/9388)
- 2026-02-10T15:42:17Z: [Circular dependancy in go.mod. file](https://github.com/concourse/concourse/issues/9453)
- 2026-03-17T09:24:24Z: [Missing source keys](https://github.com/concourse/git-resource/issues/469)
- 2026-04-03T13:40:44Z: [Get resource is stuck](https://github.com/concourse/concourse/issues/9511)
- 2026-04-22T11:31:16Z: [Live build event streams can stall after DB failover (fly/browser stop updating until manual pg_notify or refresh)](https://github.com/concourse/concourse/issues/9543)
- 2026-05-13T11:41:27Z: [[Bosh] DB Migrations are not awaited in bosh](https://github.com/concourse/concourse/issues/9575)
- 2026-05-18T14:35:17Z: [CF connector fails after update to v8.2.x](https://github.com/concourse/concourse/issues/9577)
- 2026-06-18T11:58:48Z: [dockerd crashes ~18s after startup in v1.13.1 due to BuildKit healthcheck fatal failure (Docker 29.x)](https://github.com/concourse/docker-image-resource/issues/385)
- 2026-06-22T12:49:09Z: [Cannot build dockerfile containing RUN with oci-build-task and fuse-only priv mode](https://github.com/concourse/concourse/issues/9613)
- 2026-06-24T17:13:03Z: [Resource cache cleanup errors with Postgresql 18](https://github.com/concourse/concourse/issues/9619)
### Code contributions:

- 2024-08-22T08:53:10Z: [Creating Kump3r.yml Signed-off-by: Kalin Tonev tonevkalin@gmail.com](https://github.com/concourse/governance/commit/d33ecb1e8fdeab920ad5d811c06f5fbdb96d6235)
- 2024-08-22T09:35:59Z: [Creating Kump3r.yml Signed-off-by: Kalin Tonev tonevkalin@gmail.com](https://github.com/concourse/governance/commit/d33ecb1e8fdeab920ad5d811c06f5fbdb96d6235)
- 2024-10-02T12:40:33Z: [Switching to CloudFoundry v3 API](https://github.com/concourse/dex/commit/17c0d4f3835e49925e8f0fe5997b8ba9dcebca71)
- 2025-01-03T09:25:51Z: [Add missing endpoint](https://github.com/concourse/dex/commit/9c9fdd9266004bda26c0c1f2495eb5d32ee54ba1)
- 2025-01-07T10:28:51Z: [Refactor CloudFoundry API request handling to use updated response structure](https://github.com/concourse/dex/commit/ff451646ab91859e9ea25d15f52530ddbedae187)
- 2025-01-09T13:35:04Z: [Use simple structures for the apiResult](https://github.com/concourse/dex/commit/0d5987ae471fff0a8813467783d513ae8d6cb16a)
- 2025-01-10T14:20:58Z: [Addapt cloudfoundry_test.go acceptance tests for CF API v3](https://github.com/concourse/dex/commit/d03f9004103b1cd2b9ccb0e545f281124265bd3e)
- 2025-02-11T14:56:42Z: [Removing default value, as to use the one from the source-code](https://github.com/concourse/concourse-bosh-release/commit/bec1eedb64061403b4e1f00b496451c23cce2388)
- 2025-02-11T14:57:14Z: [Removing default value, as to use the one from the source-code](https://github.com/concourse/concourse-bosh-release/commit/bec1eedb64061403b4e1f00b496451c23cce2388)
- 2025-04-15T09:45:04Z: [Reorder instnace groups, so we do not see errors  when using serial dependancy](https://github.com/concourse/concourse-bosh-deployment/commit/17cc766f08cc6b39c6b2431337d61f002f5a1357)
- 2025-04-16T04:59:26Z: [Reorder instnace groups, so we do not see errors  when using serial dependancy](https://github.com/concourse/concourse-bosh-deployment/commit/093adda80cfb58336a2e67790d0049bf2cc45c6e)
- 2025-05-08T11:29:46Z: [Adding the db connection parameter](https://github.com/concourse/concourse/commit/c526abfb75932e1573b73d6ffdce7f058e6eaaa4)
- 2025-05-08T11:30:19Z: [Adding the db connection parameter](https://github.com/concourse/concourse/commit/c526abfb75932e1573b73d6ffdce7f058e6eaaa4)
- 2025-07-23T14:20:49Z: [Adding initial idea for containerd additional host. Not tested](https://github.com/concourse/concourse/commit/74c2f68358f8188035b25a83d3efc0ee8513a6b3)
- 2025-07-23T14:39:54Z: [Remove docker-compose value](https://github.com/concourse/concourse/commit/a799dc309742ecd5d91c37ce15ed925c806acb08)
- 2025-07-23T16:40:17Z: [Additonal hosts support in Concourse Helm Chart](https://github.com/concourse/concourse-chart/commit/8caa7e573d4200edcb64642f3913cee2f2817796)
- 2025-07-23T16:51:27Z: [Additonal hosts support in Concourse Bosh Release](https://github.com/concourse/concourse-bosh-release/commit/3281b2285a9e2a9619c2e9df596d214062c77c86)
- 2025-07-23T17:26:37Z: [Additonal hosts support in Concourse Docs](https://github.com/concourse/docs/commit/3aa947f7d3fb9902e06102bfd19ad39eaa726a0e)
- 2025-07-24T21:15:13Z: [Addressing comments](https://github.com/concourse/concourse/commit/eb464bce81dc1c8ac69e2583c7800305f53f6555)
- 2025-07-25T05:26:09Z: [Fixing tests](https://github.com/concourse/concourse/commit/9a1d9de24fd9f2f2359b7194887a92d4699b462b)
- 2025-07-25T10:26:46Z: [Reversing the order to IP HOST as it was originally intended and adding missed test for IP verification failures](https://github.com/concourse/concourse/commit/4e58cd756351eb5d075c574e52d48a0ac7b8fdab)
- 2025-08-04T06:38:40Z: [Fixing Prometheus Emitter for one-off builds with fly execute](https://github.com/concourse/concourse/commit/98dcf0d82f2d370200b84a11ef8772d615bcb400)
- 2025-08-04T07:04:42Z: [Merge branch 'concourse:master' into prometheus-emit-one-off](https://github.com/concourse/concourse/commit/f62b19640db13c9b68774b94cabf3c9f1a7367b9)
- 2025-08-07T04:37:21Z: [Merge branch 'concourse:master' into prometheus-emit-one-off](https://github.com/concourse/concourse/commit/eecffafdf05a97ea94ac65a43da936b0da130332)
- 2025-09-25T12:08:38Z: [Create RFC for health endpoint](https://github.com/concourse/rfcs/commit/e4b0430dd6132e936040ea64222574916ad1cbd7)
- 2025-09-25T12:12:31Z: [Create RFC for health endpoint](https://github.com/concourse/rfcs/commit/e4b0430dd6132e936040ea64222574916ad1cbd7)
- 2025-11-04T09:59:41Z: [Address comments so far and extend document with detailed proposition](https://github.com/concourse/rfcs/commit/3b2ae4360f08e236e1380f2911aa178e33578484)
- 2025-11-04T13:19:15Z: [Merge branch 'concourse:master' into master](https://github.com/concourse/rfcs/commit/9320105c64ecd87f1e83118ffc181ea5371aa339)
- 2025-11-04T17:01:56Z: [Add an integration test simillar to the others](https://github.com/concourse/concourse/commit/87e168e9daf5d242609b177ddad8b5a050ad9cd3)
- 2025-11-04T17:46:18Z: [Clean-up consistent to original Attach(), instead of defer and no logs from process assert](https://github.com/concourse/concourse/commit/f9be0959073b97af5709be01ad4b50116943baf6)
- 2025-12-05T14:18:40Z: [Add SameSite attribute to authentication and CSRF cookies](https://github.com/concourse/concourse/commit/961f345264abbd8996aa4e732186cf82a4cd21d4)
- 2026-04-02T13:56:04Z: [worker/runtime: wrap containers from NewContainer and Containers with request timeout](https://github.com/concourse/concourse/commit/32886d823e6dc0fabc0b99be4e89cd6372acc9d7)
- 2026-04-07T07:47:01Z: [Merge branch 'concourse:master' into master](https://github.com/concourse/concourse/commit/079fe4b700f4b4ed5a46ce7ca93ead423cc0c4e0)
- 2026-04-07T07:59:56Z: [worker/runtime/integration: Add an integration test to ensure request timeout is propagate correctly](https://github.com/concourse/concourse/commit/8df4fd748e044c521c35efb8a88396c8cbcdd89d)
- 2026-04-07T08:24:32Z: [fix: Add missing import for specs-go](https://github.com/concourse/concourse/commit/021b6598c6cfd68d8b9aca767c8f718d808b7ed8)
- 2026-05-07T12:05:44Z: [fix: DNS resolution for Ubuntu 24 stemcells by updating resolver parsing logic and adding tests](https://github.com/concourse/concourse/commit/204ffe2d6cbaf414dad6a57e45839e823ddaf995)
- 2026-05-22T07:20:21Z: [add: Implementation ideas to RFC document](https://github.com/concourse/rfcs/commit/a1b293d5dfb377e5ecac82b1a36cca188a2bd87c)
- 2026-06-10T14:57:16Z: [Remove inline scripts and styles to enable strict CSP](https://github.com/concourse/concourse/commit/5741d8ee548509f7c7b9835711754756ec74f65b)
- 2026-06-10T15:02:12Z: [Remove inline scripts and styles to enable strict CSP](https://github.com/concourse/concourse/commit/5741d8ee548509f7c7b9835711754756ec74f65b)
- 2026-06-11T12:12:10Z: [fix: Add missed inline script during login of the skymarshal dex](https://github.com/concourse/concourse/commit/e08aeb94a0a872bae5bf8f6d8a819389076351fd)
- 2026-06-13T14:25:56Z: [Execute DB migrations at pre_start](https://github.com/concourse/concourse-bosh-release/commit/496e2a3929c40a97d2e551462cfa0772de7ffe1e)
- 2026-06-13T14:30:29Z: [Run ./scripts/generate-job-templates](https://github.com/concourse/concourse-bosh-release/commit/bb2ca6777edb4ebf50bbd8ac2431e9ee02ca3b16)
- 2026-06-15T10:16:26Z: [Merge branch 'master' into db-mig-pre-start](https://github.com/concourse/concourse-bosh-release/commit/75552a2d2afbee5058213db1f9e4f7bce50c0808)
- 2026-06-15T10:18:05Z: [Merge branch 'master' into db-mig-pre-start](https://github.com/concourse/concourse-bosh-release/commit/75552a2d2afbee5058213db1f9e4f7bce50c0808)
- 2026-06-22T10:10:24Z: [feat: add setns, keyctl, sethostname to fuse-only seccomp profile to support oci-build-task](https://github.com/concourse/concourse/commit/a478beaa8b68986a9d8d9ccb813b74379804b061)
- 2026-06-26T07:43:08Z: [fix: Resource cache cleanup errors with Postgresql 18](https://github.com/concourse/concourse/commit/d3a2f635d7b63e93a075b7041034af1d3f270b4a)
- 2026-06-26T07:51:27Z: [fix: Resource cache cleanup errors with Postgresql 18](https://github.com/concourse/concourse/commit/d3a2f635d7b63e93a075b7041034af1d3f270b4a)

