### PR TITLE
Add explicit branch protection for cloudfoundry/stratos (develop + main)

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -371,6 +371,33 @@ branch-protection:
               teams: ["wg-app-runtime-interfaces-autoscaler-bots"]
           include: [ "^main$" ]
 
+        # Stratos
+        stratos:
+          protect: true
+          enforce_admins: false
+          allow_force_pushes: false
+          allow_deletions: false
+          allow_disabled_policies: true
+          required_status_checks:
+            contexts:
+            - "EasyCLA"
+            - "Lint Check"
+            - "Frontend Tests (core)"
+            - "Frontend Tests (store)"
+            - "Frontend Tests (cloud-foundry)"
+            - "Frontend Tests (kubernetes)"
+            - "Frontend Tests (git)"
+            - "Frontend Tests (shared)"
+            - "Frontend Tests (extension)"
+            - "Backend Tests"
+            - "Build Check"
+            - "STB Tests"
+          required_pull_request_reviews:
+            dismiss_stale_reviews: false
+            require_code_owner_reviews: true
+            required_approving_review_count: 1
+          include: [ "^develop$" ]
+
         # Cloud Controller / CAPI related repos to skip branch protection on
         cf-performance-tests-pipeline:
           protect: false

--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -396,7 +396,10 @@ branch-protection:
             dismiss_stale_reviews: false
             require_code_owner_reviews: true
             required_approving_review_count: 1
-          include: [ "^develop$" ]
+          # develop = dev integration (default); main = release line (rc + stable).
+          # main is pre-staged here; allow_disabled_policies tolerates it until the
+          # master->main rename lands. See cloudfoundry/stratos#5507.
+          include: [ "^develop$", "^main$" ]
 
         # Cloud Controller / CAPI related repos to skip branch protection on
         cf-performance-tests-pipeline:


### PR DESCRIPTION
## What

Adds an explicit `stratos` entry to `orgs/branchprotection.yml`, replacing the
Working-Group-generated default with a pinned policy that gates both long-lived
branches:

- **`develop`** — dev integration branch (current default; where PRs merge).
- **`main`** — the upcoming release line (rc + stable). Pre-staged here;
  `allow_disabled_policies` tolerates it until `master` is renamed to `main`
  (cloudfoundry/stratos#5507). `master` is dormant (~1404 commits behind develop)
  and is being retired in that rename.

Owned by the **App Runtime Interfaces** WG, **Stratos Console for Cloud Foundry**
area.

## Why

The Stratos repo recently added a dedicated CI gate, **STB Tests** (a
path-filtered workflow for the standalone `tools/stb` Theme Builder project that
the frontend/backend suites don't exercise). For that gate to actually block
merges, its check name must be in the required-status-checks list — which is
managed here, not in the stratos repo. This entry also pins the existing PR
checks explicitly so the enforced set is visible and reviewable in-repo.

## Required status checks

- EasyCLA
- Lint Check
- Frontend Tests (core | store | cloud-foundry | kubernetes | git | shared | extension)
- Backend Tests
- Build Check
- **STB Tests**  ← new

## Notes / for reviewers

- **STB Tests** has reported successfully on `develop` (stratos PR #5506 is
  merged), so branchprotector can require it.
- Please confirm this explicit set matches (or intentionally tightens) the
  current WG-generated enforcement for stratos — I couldn't read the live
  branch-protection settings to diff against.
- Review settings mirror the WG convention (code-owner reviews, dismiss stale,
  1 approval). No `bypass_pull_request_allowances` added (matches sibling
  explicit entries); add an ARI stratos bots-team bypass if the WG wants one.
- Related: the `master` → `main` rename + release-branch setup is tracked in
  cloudfoundry/stratos#5507.
