### PR TITLE
Add Bart Kuijper as a reviewer for the Stratos Console area

### DIFF
--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -384,6 +384,8 @@ areas:
     github: patzeltj
   - name: Matthias Folz
     github: mafolz
+  - name: Bart Kuijper
+    github: Bartan89
 
   repositories:
   - cloudfoundry/stratos


### PR DESCRIPTION
Adds **Bart Kuijper** (@Bartan89) to the `reviewers` list of the **App Runtime
Interfaces** WG, **Stratos Console for Cloud Foundry** area.

## Why

Per `toc/ROLES.md`, the Reviewer requirement is *"actively contributing to the
relevant Working Group Area(s)."* Bart is actively contributing to Stratos
(e.g. issue cloudfoundry/stratos#5505 and ongoing tech-debt work). The Reviewer
role gives him PR review assignments within the area; no merge rights.

## Process notes (per ROLES.md)

- Submitted on Bart's behalf by @norman-abramovitz (a Stratos-area approver).
  By the promotion rules, the submitting approver **does not** serve as an
  attester.
- The Stratos area has 4 approvers, so **two** existing Stratos-area approvers
  (of krutten / wayneeseguin / itsouvalas) must attest, and a WG Lead merges.
