### PR TITLE
Add concourse github org to org automation

### DIFF
--- a/.github/workflows/org-management-peribolos-dump.yml
+++ b/.github/workflows/org-management-peribolos-dump.yml
@@ -40,10 +40,8 @@ jobs:
         uses: docker://gcr.io/k8s-prow/peribolos
         with:
           entrypoint: /bin/sh
-          # Switch back to app auth once following PR gets merged: https://github.com/kubernetes/test-infra/pull/24882
-          # args: --dump-full --dump cloudfoundry --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key > orgs/orgs.yml
-          # args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-token-path=token > community/orgs/orgs.yml"
-          args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --confirm=true > community/orgs/orgs.yml"
+          # args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --confirm=true > community/orgs/orgs.yml"
+          args: -c "/ko-app/peribolos --dump-full --dump concourse --github-endpoint http://ghproxy:8888 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --confirm=true > community/orgs/orgs.yml"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/org-management-peribolos-dump.yml
+++ b/.github/workflows/org-management-peribolos-dump.yml
@@ -42,7 +42,8 @@ jobs:
           entrypoint: /bin/sh
           # Switch back to app auth once following PR gets merged: https://github.com/kubernetes/test-infra/pull/24882
           # args: --dump-full --dump cloudfoundry --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key > orgs/orgs.yml
-          args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-token-path=token > community/orgs/orgs.yml"
+          # args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-token-path=token > community/orgs/orgs.yml"
+          args: -c "/ko-app/peribolos --dump-full --dump cloudfoundry --github-endpoint http://ghproxy:8888 --github-app-id=${{ secrets.GH_APP_ID }} --github-app-private-key-path=private_key --confirm=true > community/orgs/orgs.yml"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "python.testing.unittestArgs": [
         "-v",
         "-s",
-        "./orgs",
+        "./org_management",
         "-p",
         "test_*.py"
     ],

--- a/ORGS.md
+++ b/ORGS.md
@@ -13,5 +13,6 @@ This document describes the set of Github Organizations that are overseen by the
 | Github Organization Name                                  | Is it Managed? |
 |-----------------------------------------------------------|----------------|
 | [cloudfoundry](https://github.com/cloudfoundry)           | Yes            |
+| [concourse](https://github.com/concourse)                 | Yes            |
 | [openservicebrokerapi](https://github.com/openservicebrokerapi)| No        |
 | [paketo-buildpacks](https://github.com/paketo-buildpacks) | No             |

--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -787,5 +787,170 @@ branch-protection:
             - "AWS S3 Public Read Integration"
             - "AWS S3 US Integration"
             - "S3 Compatible Integration"
+
     concourse:
-      repos: {}
+      protect: true
+      enforce_admins: false
+      allow_force_pushes: false
+      allow_deletions: false
+      allow_disabled_policies: true # needed to allow branches w/o branch protection
+
+      repos:
+        .github:
+          include:
+            - "^main$"
+
+        examples:
+          include:
+            - "^main$"
+
+        houdini:
+          include:
+            - "^master$"
+
+        ci:
+          include:
+            - "^master$"
+
+        infrastructure:
+          include:
+            - "^master$"
+
+        retryhttp:
+          include:
+            - "^master$"
+
+        rfcs:
+          include:
+            - "^master$"
+
+        dex:
+          include:
+            - "^master$"
+            - "^maintenance$"
+            - "^upstream$"
+            - "^pr\/.*$"
+
+        docs:
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          include:
+            - "^master$"
+
+        oci-build-task:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            required_approving_review_count: 1
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          include:
+            - "^master$"
+          branches:
+            version:
+              protect: true
+
+        concourse:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            required_approving_review_count: 1
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+              - "CodeQL"
+              - "Analyze (go)"
+              - "concourse-ci/compile-check"
+              - "concourse-ci/containerd-integration"
+              - "concourse-ci/go-format-check"
+              - "concourse-ci/integration"
+              - "concourse-ci/testflight"
+              - "concourse-ci/unit"
+              - "concourse-ci/validate-labels"
+              - "concourse-ci/watsjs"
+          include:
+            - "^master$"
+            - "^release\/.*$"
+
+        concourse-chart:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+              - "concourse-ci/lint-and-install-test"
+              - "concourse-ci/unit-tests"
+          include:
+            - "^master$"
+            - "^dev$"
+            - "^release\/.*$"
+
+        concourse-docker:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          include:
+            - "^master$"
+            - "^release\/.*$"
+
+        concourse-bosh-release:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          include:
+            - "^master$"
+            - "^release\/.*$"
+
+        concourse-bosh-deployment:
+          required_pull_request_reviews:
+            dismiss_stale_reviews: true
+            bypass_pull_request_allowances:
+              teams: ["wg-concourse-bots"]
+          required_status_checks:
+            contexts:
+              - "EasyCLA"
+          include:
+            - "^master$"
+            - "^release\/.*$"
+
+        git-resource: &concourse-resource-repo
+          protect: false
+          branches:
+            master:
+              protect: true
+              required_pull_request_reviews:
+                dismiss_stale_reviews: true
+                bypass_pull_request_allowances:
+                  teams: ["wg-concourse-bots"]
+              required_status_checks:
+                contexts:
+                  - "EasyCLA"
+                  - "Build and Test"
+            version:
+              protect: true
+
+        bosh-io-stemcell-resource: *concourse-resource-repo
+        bosh-io-release-resource: *concourse-resource-repo
+        docker-image-resource: *concourse-resource-repo
+        github-release-resource: *concourse-resource-repo
+        hg-resource: *concourse-resource-repo
+        mock-resource: *concourse-resource-repo
+        pool-resource: *concourse-resource-repo
+        registry-image-resource: *concourse-resource-repo
+        s3-resource: *concourse-resource-repo
+        semver-resource: *concourse-resource-repo
+        time-resource: *concourse-resource-repo

--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -787,3 +787,5 @@ branch-protection:
             - "AWS S3 Public Read Integration"
             - "AWS S3 US Integration"
             - "S3 Compatible Integration"
+    concourse:
+      repos: {}

--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -200,3 +200,15 @@ orgs:
     - ivo1116
     - t-schoell
     - rashedkvm
+  concourse:
+    contributors:
+    - IvanChalukov
+    - Kump3r
+    - Spimtav
+    - concourse-bot
+    - concourse-otto
+    - drich10
+    - ichandrabhatta
+    - taylorsilva
+    - wayneadams
+    - yharish991

--- a/orgs/org_management/org_management.py
+++ b/orgs/org_management/org_management.py
@@ -35,7 +35,7 @@ class UniqueKeyLoader(yaml.SafeLoader):
 @final
 class OrgGenerator:
     # list of managed orgs, should match ./ORGS.md
-    _MANAGED_ORGS = ["cloudfoundry"]
+    _MANAGED_ORGS = ["cloudfoundry", "concourse"]
     _DEFAULT_ORG = "cloudfoundry"
 
     # parameters intended for testing only, all params are yaml docs

--- a/orgs/org_management/test_org_management.py
+++ b/orgs/org_management/test_org_management.py
@@ -359,7 +359,12 @@ branch-protection:
 class TestOrgGenerator(unittest.TestCase):
     @override
     def setUp(self) -> None:
+        self._original_managed_orgs = OrgGenerator._MANAGED_ORGS  # pyright: ignore[reportUninitializedInstanceVariable]
         OrgGenerator._MANAGED_ORGS = ["cloudfoundry"]
+
+    @override
+    def tearDown(self) -> None:
+        OrgGenerator._MANAGED_ORGS = self._original_managed_orgs
 
     def test_empty_org(self):
         o = OrgGenerator()
@@ -869,14 +874,18 @@ class TestOrgGenerator(unittest.TestCase):
 # integration test, depends on data in this repo which may change
 class TestOrgGeneratorIntegrationTest(unittest.TestCase):
     def test_cf_org(self):
-        self.assertEqual(["cloudfoundry"], OrgGenerator._MANAGED_ORGS)
+        self.assertEqual(["cloudfoundry", "concourse"], OrgGenerator._MANAGED_ORGS)
 
         o = OrgGenerator()
         o.load_from_project()
-        self.assertEqual(1, len(o.org_cfg["orgs"]))
+        self.assertEqual(2, len(o.org_cfg["orgs"]))
         self.assertEqual("cloudfoundry", o.toc_org)
         self.assertEqual("Technical Oversight Committee", o.toc["name"])
+
         self.assertGreater(len(o.contributors["cloudfoundry"]), 100)
+        self.assertGreater(len(o.contributors["concourse"]), 9)
+
+        # cloudfoundry WGs
         cf_wgs = o.working_groups["cloudfoundry"]
         self.assertGreater(len(cf_wgs), 5)
         self.assertEqual(1, len([wg for wg in cf_wgs if "Admin" in wg["name"]]))
@@ -888,29 +897,61 @@ class TestOrgGeneratorIntegrationTest(unittest.TestCase):
         # branch protection
         self.assertIn("cloudfoundry", o.branch_protection["branch-protection"]["orgs"])
 
+        # concourse WGs
+        concourse_wgs = o.working_groups["concourse"]
+        self.assertEqual(len(concourse_wgs), 1)
+        self.assertEqual(1, len([wg for wg in concourse_wgs if "Concourse" in wg["name"]]))
+        # no WGs without execution leads
+        self.assertEqual(0, len([wg for wg in concourse_wgs if len(wg["execution_leads"]) == 0]))
+        # branch protection
+        self.assertIn("concourse", o.branch_protection["branch-protection"]["orgs"])
+
         self.assertTrue(o.validate_repo_ownership())
 
         o.generate_org_members()
-        members = o.org_cfg["orgs"]["cloudfoundry"]["members"]
-        admins = o.org_cfg["orgs"]["cloudfoundry"]["admins"]
-        self.assertGreater(len(members), 100)
-        self.assertGreater(len(admins), 7)  # 5 toc members + CFF technical staff
-        self.assertIn("cf-bosh-ci-bot", members)
+        # cloudfoundry
+        cf_members = o.org_cfg["orgs"]["cloudfoundry"]["members"]
+        cf_admins = o.org_cfg["orgs"]["cloudfoundry"]["admins"]
+        self.assertGreater(len(cf_members), 100)
+        self.assertGreater(len(cf_admins), 7)  # 5 toc members + CFF technical staff
+        self.assertIn("cf-bosh-ci-bot", cf_members)
+        # concourse
+        concourse_members = o.org_cfg["orgs"]["concourse"]["members"]
+        concourse_admins = o.org_cfg["orgs"]["concourse"]["admins"]
+        self.assertGreater(len(concourse_members), 9)
+        self.assertGreater(len(concourse_admins), 7)  # 5 toc members + CFF technical staff
+        self.assertIn("concourse-bot", concourse_members)
 
         o.generate_teams()
-        teams = o.org_cfg["orgs"]["cloudfoundry"]["teams"]
-        self.assertIn("wg-app-runtime-deployments", teams)
+        # cloudfoundry
+        cf_teams = o.org_cfg["orgs"]["cloudfoundry"]["teams"]
+        self.assertIn("wg-app-runtime-deployments", cf_teams)
         self.assertIn(
-            "cf-deployment", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-cf-deployment-approvers"]["repos"]
+            "cf-deployment", cf_teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-cf-deployment-approvers"]["repos"]
         )
-        self.assertIn("cf-deployment", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["repos"])
-        self.assertIn("ard-wg-gitbot", teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["members"])
-        self.assertIn("toc", teams)
-        self.assertEqual(5, len(teams["toc"]["maintainers"]))
-        self.assertIn("community", teams["toc"]["repos"])
-        self.assertIn("wg-leads", teams)
-        self.assertIn("community", teams["wg-leads"]["repos"])
+        self.assertIn("cf-deployment", cf_teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["repos"])
+        self.assertIn("ard-wg-gitbot", cf_teams["wg-app-runtime-deployments"]["teams"]["wg-app-runtime-deployments-bots"]["members"])
+        self.assertIn("toc", cf_teams)
+        self.assertEqual(5, len(cf_teams["toc"]["maintainers"]))
+        self.assertIn("community", cf_teams["toc"]["repos"])
+        self.assertIn("wg-leads", cf_teams)
+        self.assertIn("community", cf_teams["wg-leads"]["repos"])
+
+        # concourse
+        concourse_teams = o.org_cfg["orgs"]["concourse"]["teams"]
+        self.assertIn("wg-concourse", concourse_teams)
+        self.assertIn("concourse-bosh-deployment", concourse_teams["wg-concourse"]["teams"]["wg-concourse-core-approvers"]["repos"])
+        self.assertIn("concourse-bosh-deployment", concourse_teams["wg-concourse"]["teams"]["wg-concourse-bots"]["repos"])
+        self.assertIn("concourse-bot", concourse_teams["wg-concourse"]["teams"]["wg-concourse-bots"]["members"])
+        self.assertIn("wg-leads", concourse_teams)
+        self.assertEqual(2, len(concourse_teams["wg-leads"]["members"]))
+        # concourse wg leads are also in cloudfoundry wg-leads to grant access to the community repo
+        self.assertIn("wg-leads-concourse", cf_teams)
+        self.assertEqual(2, len(cf_teams["wg-leads-concourse"]["members"]))
+        self.assertIn("community", cf_teams["wg-leads-concourse"]["repos"])
 
         o.generate_branch_protection()
-        bp_repos = o.branch_protection["branch-protection"]["orgs"]["cloudfoundry"]["repos"]
-        self.assertGreaterEqual(len(bp_repos), 3)
+        cf_bp_repos = o.branch_protection["branch-protection"]["orgs"]["cloudfoundry"]["repos"]
+        self.assertGreaterEqual(len(cf_bp_repos), 300)
+        concourse_bp_repos = o.branch_protection["branch-protection"]["orgs"]["concourse"]["repos"]
+        self.assertGreaterEqual(len(concourse_bp_repos), 30)

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2971,7 +2971,8 @@ orgs:
         homepage: https://hush-house.pivotal.io
       infrastructure:
         description: Automation stack for the Concourse project's infrastructure.
-        has_projects: true
+        has_projects: false
+        has_wiki: false        
       mock-resource:
         description: A resource for testing the resource interface. It reflects the
           version it's told, and is able to mirror its own container image

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2838,7 +2838,7 @@ orgs:
           terraform-provider-cloudfoundry: admin
   concourse:
     admins: [] # shall be empty, maintained in TOC.md
-    billing_email: ap@cloudfoundry.org
+    billing_email: team@concourse-ci.org
     company: ""
     default_repository_permission: none
     description: An open-source continuous thing-doer, mostly used for CI/CD
@@ -2849,5 +2849,199 @@ orgs:
     members: [] # shall be empty, org members are maintained in contributors.yml and WG charters
     members_can_create_repositories: false
     name: Concourse
-    repos: {}
+    repos:
+      .github:
+        default_branch: main
+        has_issues: false
+        has_projects: false
+        has_wiki: false
+      baggageclaim:
+        archived: true
+        description: stateless volume manager for Concourse builds and resource caches
+        has_issues: false
+        has_projects: false
+        has_wiki: false
+      blog:
+        archived: true
+        default_branch: main
+        has_projects: true
+        has_wiki: false
+        homepage: https://concourse-ci.org/blog/
+      bosh-io-release-resource:
+        description: Tracks BOSH releases published on https://bosh.io
+        has_projects: false
+        has_wiki: false
+      bosh-io-stemcell-resource:
+        description: Tracks BOSH stemcells published on https://bosh.io
+        has_projects: false
+        has_wiki: false
+      buildroot-images:
+        archived: true
+        description: (outdated/no longer used) BuildRoot-based toolchain for building
+          tiny images for our core resource types.
+        has_issues: false
+        has_projects: true
+      ci:
+        description: Configuration files used to automate the testing and release
+          of various versions of Concourse.
+        has_projects: false
+        has_wiki: false
+      concourse:
+        description: Concourse is a container-based automation system written in Go.
+          It's mostly used for CI/CD.
+        has_projects: false
+        homepage: https://concourse-ci.org
+      concourse-bosh-deployment:
+        description: A toolchain for deploying Concourse with BOSH.
+        has_projects: false
+        has_wiki: false
+      concourse-bosh-release:
+        description: Concourse BOSH release
+        has_projects: false
+        has_wiki: false
+      concourse-chart:
+        description: Helm chart to install Concourse
+        has_projects: false
+        has_wiki: false
+      concourse-docker:
+        description: Offical concourse/concourse Docker image.
+        has_projects: false
+        has_wiki: false
+      concourse-pipeline-resource:
+        archived: true
+        description: '!!! use the `set_pipeline` step instead !!!'
+        has_projects: true
+        homepage: https://concourse-ci.org/jobs.html#schema.step.set-pipeline-step.set_pipeline
+      datadog-event-resource:
+        archived: true
+        has_projects: true
+        has_wiki: false
+      dex:
+        description: A fork of dexidp/dex with changes necessary for Concourse. See
+          the "maintenance" branch for details.
+        has_projects: false
+        has_wiki: false
+      docker-image-resource:
+        description: A resource for docker images
+        has_projects: false
+        has_wiki: false
+      docs:
+        description: concourse documentation and website
+        has_projects: false
+        has_wiki: false
+        homepage: https://concourse-ci.org
+      examples:
+        default_branch: main
+        description: Examples of Concourse workflows
+        has_projects: false
+        has_wiki: false
+      flag:
+        archived: true
+        description: 'ARCHIVED: merged into main concourse/concourse repo. flag types
+          for use with jessevdk/go-flags'
+        has_projects: false
+        has_wiki: false
+      git-resource:
+        description: Tracks commits in a branch of a Git repository
+        has_projects: false
+        has_wiki: false
+      github-release-resource:
+        description: A resource for GitHub releases
+        has_projects: false
+        has_wiki: false
+      governance:
+        archived: true
+        description: Documentation and automation for the Concourse project governance
+          model.
+        has_projects: false
+        has_wiki: false
+      hg-resource:
+        description: Mercurial resource for Concourse
+        has_projects: false
+        has_wiki: false
+      houdini:
+        description: a no-op Garden backend
+        has_projects: false
+        has_wiki: false
+      hush-house:
+        archived: true
+        description: Concourse k8s-based environment
+        has_projects: false
+        has_wiki: false
+        homepage: https://hush-house.pivotal.io
+      infrastructure:
+        description: Automation stack for the Concourse project's infrastructure.
+        has_projects: true
+      mock-resource:
+        description: A resource for testing the resource interface. It reflects the
+          version it's told, and is able to mirror its own container image
+        has_projects: false
+        has_wiki: false
+      oci-build-task:
+        description: a Concourse task for building OCI images
+        has_projects: false
+        has_wiki: false
+      office-hours:
+        archived: true
+        default_branch: main
+        description: Office hours is a community live stream that Concourse hosts
+          every so often
+        has_projects: false
+        has_wiki: false
+        homepage: https://www.youtube.com/channel/UCf5gRGP0pYASo1YwoBkaCGw
+      oxygen-mask:
+        archived: true
+        has_projects: false
+        has_wiki: false
+      pool-resource:
+        description: Atomically manages the state of the world (e.g. external environments)
+        has_projects: false
+        has_wiki: false
+      prod:
+        archived: true
+        description: bosh/terraform config for our deployments
+        has_issues: false
+        has_projects: false
+        has_wiki: false
+      registry-image-resource:
+        description: A resource for images in an OCI/Docker registry
+        has_projects: false
+        has_wiki: false
+      resource-types:
+        archived: true
+        description: A place where the concourse resource types live.
+        has_projects: false
+        has_wiki: false
+      resource-types-website:
+        archived: true
+        description: Website for Concourse resource types (Beta)
+        has_projects: false
+        has_wiki: false
+        homepage: https://resource-types.concourse-ci.org
+      retryhttp:
+        description: Retryable http transport used by baggageclaim client and garden
+          client in ATC
+        has_projects: false
+        has_wiki: false
+      rfcs:
+        description: An open process for designing substantial changes to Concourse.
+        has_issues: false
+        has_projects: false
+        has_wiki: false
+      s3-resource:
+        description: Concourse resource for interacting with AWS S3
+        has_projects: false
+        has_wiki: false
+      semver-resource:
+        description: Automated semantic version bumping
+        has_projects: false
+        has_wiki: false
+      time-resource:
+        description: A resource for triggering on an interval
+        has_projects: false
+        has_wiki: false
+      tracker-resource:
+        archived: true
+        description: pivotal tracker output resource
+        has_projects: true    
     teams: {}

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2836,3 +2836,18 @@ orgs:
         privacy: closed
         repos:
           terraform-provider-cloudfoundry: admin
+  concourse:
+    admins: [] # shall be empty, maintained in TOC.md
+    billing_email: ap@cloudfoundry.org
+    company: ""
+    default_repository_permission: none
+    description: An open-source continuous thing-doer, mostly used for CI/CD
+    email: contact@concourse-ci.org
+    has_organization_projects: true
+    has_repository_projects: true
+    location: Worldwide
+    members: [] # shall be empty, org members are maintained in contributors.yml and WG charters
+    members_can_create_repositories: false
+    name: Concourse
+    repos: {}
+    teams: {}

--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -24,8 +24,9 @@ Technical assets for the Concourse working group are contained in the following 
 
 * [github.com/concourse](https://github.com/concourse)
 
-```
+```yaml
 name: Concourse
+org: concourse
 execution_leads:
 - name: Derek Richard
   github: drich10
@@ -36,6 +37,11 @@ technical_leads:
   github: drich10
 - name: Taylor Silva
   github: taylorsilva
+bots:
+- name: concourse-otto
+  github: concourse-otto
+- name: concourse-bot
+  github: concourse-bot
 areas:
 - name: Core
   approvers:
@@ -52,43 +58,43 @@ areas:
   - name: Kump3r
     github: Kump3r
   repositories:
-  - concourse/concourse
-  - concourse/concourse-bosh-release
-  - concourse/ci
-  - concourse/docs
-  - concourse/dex
-  - concourse/semver-resource
-  - concourse/houdini
-  - concourse/concourse-bosh-deployment
-  - concourse/registry-image-resource
-  - concourse/hg-resource
-  - concourse/github-release-resource
-  - concourse/bosh-io-stemcell-resource
-  - concourse/docker-image-resource
-  - concourse/rfcs
-  - concourse/blog
-  - concourse/concourse-chart
-  - concourse/mock-resource
-  - concourse/infrastructure
-  - concourse/concourse-docker
-  - concourse/git-resource
-  - concourse/examples
-  - concourse/flag
-  - concourse/s3-resource
-  - concourse/pool-resource
-  - concourse/resource-types-website
-  - concourse/resource-types
-  - concourse/oci-build-task
-  - concourse/time-resource
   - concourse/bosh-io-release-resource
+  - concourse/bosh-io-stemcell-resource
+  - concourse/ci
+  - concourse/concourse
+  - concourse/concourse-bosh-deployment
+  - concourse/concourse-bosh-release
+  - concourse/concourse-chart
+  - concourse/concourse-docker
+  - concourse/dex
+  - concourse/docker-image-resource
+  - concourse/docs
+  - concourse/examples
+  - concourse/git-resource
+  - concourse/github-release-resource
+  - concourse/hg-resource
+  - concourse/houdini
+  - concourse/infrastructure
+  - concourse/mock-resource
+  - concourse/oci-build-task
+  - concourse/pool-resource
+  - concourse/registry-image-resource
+  - concourse/resource-types
+  - concourse/resource-types-website
   - concourse/retryhttp
-  - concourse/prod
-  - concourse/booklit
-  - concourse/oxygen-mask
-  - concourse/datadog-event-resource
-  - concourse/office-hours #here and below is either archived, or we expect to archive in near the future
-  - concourse/governance
+  - concourse/rfcs
+  - concourse/s3-resource
+  - concourse/semver-resource
+  - concourse/time-resource
   - concourse/.github
+  # Repositories below this line are archived
+  - concourse/blog
+  - concourse/flag
+  - concourse/prod
+  - concourse/oxygen-mask
+  - concourse/office-hours
+  - concourse/governance
+  - concourse/datadog-event-resource
   - concourse/hush-house
   - concourse/tracker-resource
   - concourse/baggage-claim


### PR DESCRIPTION
Concourse wg definition taken from #1540

TODOs:
- [x] fill concourse repos in orgs.yml, ideally with a peribolos dump
- [x] grant org automation workflow sufficient access in concourse org to manage repos and teams, hopefully this works with the CF org automation github app
- [x] review concourse sections in generated org.out.yml and branchprotection.out.yml