### PR TITLE
Require the stratos PR aggregate check instead of each suite job

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -381,16 +381,13 @@ branch-protection:
           required_status_checks:
             contexts:
             - "EasyCLA"
-            - "Lint Check"
-            - "Frontend Tests (core)"
-            - "Frontend Tests (store)"
-            - "Frontend Tests (cloud-foundry)"
-            - "Frontend Tests (kubernetes)"
-            - "Frontend Tests (git)"
-            - "Frontend Tests (shared)"
-            - "Frontend Tests (extension)"
-            - "Backend Tests"
-            - "Build Check"
+            # PR Quality Gate is the in-repo aggregate (runs on every PR via
+            # `if: always()` and fails on any failed/cancelled suite job).
+            # Requiring it instead of each suite job lets docs-only PRs skip
+            # the suite without the skipped matrix shards blocking merges as
+            # forever-"expected" contexts. STB Tests runs from its own
+            # workflow and is not covered by the aggregate, so it stays.
+            - "PR Quality Gate"
             - "STB Tests"
           required_pull_request_reviews:
             dismiss_stale_reviews: false


### PR DESCRIPTION
## Change

For `cloudfoundry/stratos` (`develop`/`main`), replace the ten per-job required status checks with the repo's aggregate check:

- `EasyCLA` (unchanged)
- `PR Quality Gate` (new — replaces Lint Check, the seven `Frontend Tests (package)` matrix contexts, Backend Tests, Build Check)
- `STB Tests` (unchanged — runs from a separate workflow not covered by the aggregate)

## Why

Stratos recently added a docs-only fast path to its PR workflow (cloudfoundry/stratos#5564, #5566): PRs touching only `docs/`/`website/` skip the heavy test suite via job-level `if:` gates. Single skipped jobs report a `skipped` conclusion and satisfy branch protection, but a skipped **matrix** job never expands — its per-package contexts never report, and the merge blocks with `7 of 12 required status checks are expected` (observed on cloudfoundry/stratos#5563, a one-file docs change).

`PR Quality Gate` is stratos' aggregate job: it runs on every PR (`if: always()`), inspects the result of lint, all frontend matrix shards, backend tests, build check, and website build, and fails on any `failure` or `cancelled` result while accepting `skipped` (the deliberate fast-path outcome). Requiring the aggregate instead of each job is the standard resolution for required-check + conditional-matrix workflows, and lets stratos revert an interim workaround (cloudfoundry/stratos#5567) that spins up no-op matrix shards purely so their contexts report.

## Risk

Low. Enforcement is equivalent: any suite failure fails the aggregate and blocks the merge; the only behavioral change is that legitimately-skipped paths no longer deadlock. Same config mechanism as #1537.