### PR TITLE
Archive inlined more diego components that are no longer submodules

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -474,6 +474,7 @@ orgs:
         has_projects: false
         has_wiki: false
       buildpackapplifecycle:
+        archived: true
         description: The bit that takes some bits, mashes them together with other
           bits, and produces a new bit
         has_projects: false
@@ -507,6 +508,7 @@ orgs:
         has_issues: false
         has_projects: true
       cacheddownloader:
+        archived: true
         description: A cached HTTP blob downloader
         has_issues: false
         has_projects: true
@@ -1312,6 +1314,7 @@ orgs:
       example-sidecar-buildpack:
         has_projects: true
       executor:
+        archived: true
         description: thy will be done
         has_issues: false
         has_projects: true
@@ -2146,6 +2149,7 @@ orgs:
         has_projects: true
         private: true
       rep:
+        archived: true
         description: Representative bids on tasks and schedules them on an associated
           Executor
         has_issues: false


### PR DESCRIPTION
These repositories have been inlined into diego-release under src/code.cloudfoundry.org/ and are no longer maintained as standalone repos.