### PR TITLE
Move go-fetcher into the same group as homebrew-tap

### DIFF
--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -51,7 +51,6 @@ areas:
   - cloudfoundry/developer-training-course
   - cloudfoundry/developer-training-hugo-parser
   - cloudfoundry/foundation
-  - cloudfoundry/go-fetcher
   - cloudfoundry/lf-elearning
   - cloudfoundry/logos
   - cloudfoundry/oss-summit-class
@@ -61,7 +60,7 @@ areas:
   - cloudfoundry/summit-training-classes
   - cloudfoundry/training-cert-admin
 
-- name: CF Homebrew TAP
+- name: CF Code Packaging and Publication
   approvers:
   - name: Al Berez
     github: a-b
@@ -99,12 +98,14 @@ areas:
   - name: cf-uaa-ci-bot
     github: cf-identity
   repositories:
-  - cloudfoundry/homebrew-tap
+    - cloudfoundry/go-fetcher
+    - cloudfoundry/homebrew-tap
 config:
   github_project_sync:
     mapping:
       cloudfoundry: 31
   deploy_keys:
     repositories:
-    - cloudfoundry/homebrew-tap
+      - cloudfoundry/go-fetcher
+      - cloudfoundry/homebrew-tap
 ```


### PR DESCRIPTION
This PR renames the group "CF Homebrew TAP" to "CF Code Packagin and Publication" since it now includes more than just the homebrew tap.