### PR TITLE
Add tas-ecosystem-bot to Metric Store area bots

### DIFF
--- a/toc/working-groups/app-runtime-platform.md
+++ b/toc/working-groups/app-runtime-platform.md
@@ -243,6 +243,9 @@ areas:
   reviewers:
   - name: Wei Li
     github: weili-broadcom
+  bots:
+  - name: TAS Ecosystem Bot (GPP)
+    github: tas-ecosystem-bot
   repositories:
   - cloudfoundry/metric-store-ci
   - cloudfoundry/metric-store-release


### PR DESCRIPTION
Adds tas-ecosystem-bot (Broadcom's GPP/TAS Ecosystem automation) as a scoped bot for the Metric Store area, granting it write access to metric-store-ci, metric-store-release, and metric-store-dotfiles only. This is needed so GPP can push automated Kilnfile.lock version-bump commits as part of onboarding metric-store's tile to the Golden Path to Publish pipeline.