### PR TITLE
Bot user for storage-cli area

### DIFF
--- a/toc/working-groups/foundational-infrastructure.md
+++ b/toc/working-groups/foundational-infrastructure.md
@@ -394,6 +394,9 @@ areas:
       github: cf-prometheus-ci-bot
 
 - name: Storage CLI
+  bots:
+  - name: ARI WG Git Bot
+    github: ari-wg-gitbot
   approvers:
   - name: Long Nguyen
     github: lnguyen


### PR DESCRIPTION
The bot user is needed to auto-merge validated dependabot PRs for storage-cli and for implementing a workflow that allows approvers to trigger integration tests for PRs from forks (which fail normally due to missing secrets).

- bot will approve dependabot PRs - they get auto-merged once they pass the integration tests, see [dependabot-auto-merge.yml](https://github.com/cloudfoundry/storage-cli/blob/main/.github/workflows/dependabot-auto-merge.yml), approval step is not yet implemented
- bot shall be used to trigger integration tests, see [fork-integration-trigger.yml](https://github.com/cloudfoundry/storage-cli/blob/main/.github/workflows/fork-integration-trigger.yml)
  - w/o bot user, the follow-up workflow [fork-integration-status-reporter.yml](https://github.com/cloudfoundry/storage-cli/blob/main/.github/workflows/fork-integration-status-reporter.yml) won't trigger to report the test status on the PR