### PR TITLE
Create Docs area in Concourse

### DIFF
--- a/toc/working-groups/concourse.md
+++ b/toc/working-groups/concourse.md
@@ -100,4 +100,14 @@ areas:
   - concourse/baggage-claim
   - concourse/buildroot-images
   - concourse/concourse-pipeline-resource
+
+- name: Docs
+  approvers:
+  - name: Kevin Bimonte
+    github: kcbimonte
+  - name: Josh Ghiloni
+    github: jghiloni
+  repositories:
+  - concourse/docs
+  - concourse/examples
 ```


### PR DESCRIPTION
I'd like to add a new area to Concourse for users that contribute to Concourse's documentation. I'd like to add the following users as approvers because they've recently made significant contributions to the docs repository:

@kcbimonte
- https://github.com/concourse/docs/pull/572
- https://github.com/concourse/docs/pull/578
- https://github.com/concourse/docs/pull/579
- https://github.com/concourse/docs/pull/581
- https://github.com/concourse/docs/pull/586
- https://github.com/concourse/docs/pull/603

@jghiloni
- https://github.com/concourse/docs/pull/606
- https://github.com/concourse/docs/pull/607
- https://github.com/concourse/docs/pull/82

If either of you, Kevin or Josh, don't want approver status, leave a comment stating so and I'll remove you. I think both of you have earned it though.