### PR TITLE
Add frequent Concourse contributors

### DIFF
--- a/orgs/contributors.yml
+++ b/orgs/contributors.yml
@@ -212,3 +212,9 @@ orgs:
     - taylorsilva
     - wayneadams
     - yharish991
+    - aliculPix4D
+    - marco-m-pix4d
+    - ceco556
+    - AtanasNikov
+    - jghiloni
+    - kcbimonte


### PR DESCRIPTION
I'd like to give the following users `contributor` role within the Concourse org. They are all active members of the community that do one or more of the following:

- Submit PR's to one or more repos
- Review PR's
- Contributors to community discussion

If any of you don't want contributor status, leave a comment stating so and I'll remove you from this PR.

@aliculPix4D
@marco-m-pix4d
@ceco556
@AtanasNikov
@jghiloni
@kcbimonte