### PR TITLE
Run org management per github org

### DIFF
--- a/.github/workflows/org-management.yml
+++ b/.github/workflows/org-management.yml
@@ -12,7 +12,26 @@ on:
     - cron: '0 */12 * * *'
 
 jobs:
-  peribolos:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: community
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "community/orgs/pyproject.toml"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Validate github org configuration
+        working-directory: ./community/orgs
+        run: |
+          uv run --no-dev python -m org_management -o /tmp/orgs-validate.yml -b /tmp/bp-validate.yml
+
+  peribolos-cloudfoundry:
+    needs: validate
     runs-on: ubuntu-latest
     concurrency:
       group: peribolos
@@ -47,7 +66,7 @@ jobs:
       - name: Generate github org configuration
         working-directory: ./community/orgs
         run: |
-          uv run --no-dev python -m org_management -o ../../orgs.out.yml -b ../../branchprotection.out.yml
+          uv run --no-dev python -m org_management --org cloudfoundry -o ../../orgs.out.yml -b ../../branchprotection.out.yml
       - name: write github private key
         run: |
           echo "${GH_PRIVATE_KEY}" > private_key
@@ -76,9 +95,9 @@ jobs:
             --fix-team-members
             --fix-team-repos
             --allow-repo-archival
-            --maximum-removal-delta=1
-  branchprotector:
-    needs: peribolos
+
+  branchprotector-cloudfoundry:
+    needs: peribolos-cloudfoundry
     runs-on: ubuntu-latest
     concurrency:
       group: peribolos
@@ -113,7 +132,128 @@ jobs:
       - name: Generate github org configuration
         working-directory: ./community/orgs
         run: |
-          uv run --no-dev python -m org_management -o ../../orgs.out.yml -b ../../branchprotection.out.yml
+          uv run --no-dev python -m org_management --org cloudfoundry -o ../../orgs.out.yml -b ../../branchprotection.out.yml
+      - name: write github private key
+        run: |
+          echo "${GH_PRIVATE_KEY}" > private_key
+          echo "${GH_TOKEN}" > token
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
+      - name: branchprotector
+        id: branchprotector
+        uses: docker://gcr.io/k8s-prow/branchprotector
+        with:
+          args: >-
+            --confirm=true
+            --github-endpoint http://ghproxy:8888
+            --github-app-id=${{ secrets.GH_APP_ID }}
+            --github-app-private-key-path=private_key
+            --config-path=branchprotection.out.yml
+
+  peribolos-concourse:
+    needs: validate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: peribolos
+    services:
+      ghproxy:
+        image: rkoster/ghproxy
+        options: >-
+          --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly
+          --mount type=bind,source=/etc/group,target=/etc/group,readonly
+        ports:
+          - 8888:8888
+        volumes:
+          - ${{ github.workspace }}/ghproxy-cache:/cache
+    steps:
+      - name: ghproxy-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ghproxy-cache
+          key: ghproxy-cache-${{ github.run_number }}
+          restore-keys: |
+            ghproxy-cache-
+      - uses: actions/checkout@v5
+        with:
+          path: community
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "community/orgs/pyproject.toml"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Generate github org configuration
+        working-directory: ./community/orgs
+        run: |
+          uv run --no-dev python -m org_management --org concourse -o ../../orgs.out.yml -b ../../branchprotection.out.yml
+      - name: write github private key
+        run: |
+          echo "${GH_PRIVATE_KEY}" > private_key
+          echo "${GH_TOKEN}" > token
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}
+      - name: peribolos
+        id: peribolos
+        uses: docker://gcr.io/k8s-prow/peribolos
+        with:
+          entrypoint: /ko-app/peribolos
+          args: >-
+            --confirm=true
+            --github-endpoint http://ghproxy:8888
+            --required-admins=thelinuxfoundation
+            --min-admins=5
+            --github-app-id=${{ secrets.GH_APP_ID }}
+            --github-app-private-key-path=private_key
+            --require-self=false
+            --config-path=orgs.out.yml
+            --fix-org
+            --fix-org-members
+            --fix-repos
+            --fix-teams
+            --fix-team-members
+            --fix-team-repos
+            --allow-repo-archival
+
+  branchprotector-concourse:
+    needs: peribolos-concourse
+    runs-on: ubuntu-latest
+    concurrency:
+      group: peribolos
+    services:
+      ghproxy:
+        image: rkoster/ghproxy
+        options: >-
+          --mount type=bind,source=/etc/passwd,target=/etc/passwd,readonly
+          --mount type=bind,source=/etc/group,target=/etc/group,readonly
+        ports:
+          - 8888:8888
+        volumes:
+          - ${{ github.workspace }}/ghproxy-cache:/cache
+    steps:
+      - name: ghproxy-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/ghproxy-cache
+          key: ghproxy-cache-${{ github.run_number }}
+          restore-keys: |
+            ghproxy-cache-
+      - uses: actions/checkout@v5
+        with:
+          path: community
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "community/orgs/pyproject.toml"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Generate github org configuration
+        working-directory: ./community/orgs
+        run: |
+          uv run --no-dev python -m org_management --org concourse -o ../../orgs.out.yml -b ../../branchprotection.out.yml
       - name: write github private key
         run: |
           echo "${GH_PRIVATE_KEY}" > private_key

--- a/orgs/org_management/__main__.py
+++ b/orgs/org_management/__main__.py
@@ -8,7 +8,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "-b", "--branchprotection", default="branchprotection.out.yml", help="output file for generated branch protection rules"
     )
+    parser.add_argument(
+        "--org",
+        dest="orgs",
+        action="append",
+        metavar="ORG",
+        help="limit output to this org (repeatable); default: all orgs",
+    )
     args = parser.parse_args()
+
+    if args.orgs:
+        invalid = set(args.orgs) - set(OrgGenerator.MANAGED_ORGS)
+        if invalid:
+            print(f"ERROR: Unknown org(s): {invalid}. Expected one of {OrgGenerator.MANAGED_ORGS}")
+            exit(1)
 
     print("Generating CFF Managed Github Org configuration.")
     generator = OrgGenerator()
@@ -19,5 +32,5 @@ if __name__ == "__main__":
     generator.generate_org_members()
     generator.generate_teams()
     generator.generate_branch_protection()
-    generator.write_org_config(args.out)
-    generator.write_branch_protection(args.branchprotection)
+    generator.write_org_config(args.out, args.orgs)
+    generator.write_branch_protection(args.branchprotection, args.orgs)

--- a/orgs/org_management/org_management.py
+++ b/orgs/org_management/org_management.py
@@ -35,7 +35,7 @@ class UniqueKeyLoader(yaml.SafeLoader):
 @final
 class OrgGenerator:
     # list of managed orgs, should match ./ORGS.md
-    _MANAGED_ORGS = ["cloudfoundry", "concourse"]
+    MANAGED_ORGS = ["cloudfoundry", "concourse"]
     _DEFAULT_ORG = "cloudfoundry"
 
     # parameters intended for testing only, all params are yaml docs
@@ -57,7 +57,7 @@ class OrgGenerator:
             if branch_protection
             else {"branch-protection": {"orgs": {}}}
         )
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             if org not in self.org_cfg["orgs"]:
                 self.org_cfg["orgs"][org] = {"admins": [], "members": [], "teams": {}, "repos": {}}
             self.contributors[org] = set()
@@ -76,15 +76,15 @@ class OrgGenerator:
         wgs = [OrgGenerator._validate_wg(OrgGenerator._yaml_load(wg)) for wg in working_groups] if working_groups else []
         for wg in wgs:
             org = wg["org"]
-            if org not in OrgGenerator._MANAGED_ORGS:
-                raise ValueError(f"Invalid org {org} in WG {wg['name']}, expected one of {OrgGenerator._MANAGED_ORGS}")
+            if org not in OrgGenerator.MANAGED_ORGS:
+                raise ValueError(f"Invalid org {org} in WG {wg['name']}, expected one of {OrgGenerator.MANAGED_ORGS}")
             self.working_groups[org].append(wg)
 
     def load_from_project(self):
         path = f"{_SCRIPT_PATH}/orgs.yml"
         print(f"Reading static org configuration from {path}")
         self.org_cfg = OrgGenerator._validate_github_org_cfg(OrgGenerator._read_yml_file(path))
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             if org not in self.org_cfg["orgs"]:
                 self.org_cfg["orgs"][org] = {"admins": [], "members": [], "teams": {}, "repos": {}}
 
@@ -99,7 +99,7 @@ class OrgGenerator:
         path = f"{_SCRIPT_PATH}/branchprotection.yml"
         print(f"Reading branch protection configuration from {path}")
         self.branch_protection = OrgGenerator._validate_branch_protection(OrgGenerator._read_yml_file(path))
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             if org not in self.branch_protection["branch-protection"]["orgs"]:
                 self.branch_protection["branch-protection"]["orgs"][org] = {"repos": {}}
 
@@ -116,26 +116,26 @@ class OrgGenerator:
                 wg = OrgGenerator._read_wg_charter(wg_file)
                 if wg:
                     org = wg["org"]
-                    if org not in OrgGenerator._MANAGED_ORGS:
-                        raise ValueError(f"Invalid org {org} in WG {wg['name']}, expected one of {OrgGenerator._MANAGED_ORGS}")
+                    if org not in OrgGenerator.MANAGED_ORGS:
+                        raise ValueError(f"Invalid org {org} in WG {wg['name']}, expected one of {OrgGenerator.MANAGED_ORGS}")
                     self.working_groups[org].append(wg)
 
     def validate_repo_ownership(self) -> bool:
         valid = True
 
         # repos in WG areas must be listed in orgs.yml (managed orgs only)
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             for wg in self.working_groups[org]:
                 wg_name = wg["name"]
                 for area in wg["areas"]:
                     for repo in area["repositories"]:
                         repo_org, repo_name = repo.split("/", 1)
-                        if repo_org in OrgGenerator._MANAGED_ORGS and repo_name not in self.org_cfg["orgs"][repo_org]["repos"]:
+                        if repo_org in OrgGenerator.MANAGED_ORGS and repo_name not in self.org_cfg["orgs"][repo_org]["repos"]:
                             print(f"ERROR: Working Group '{wg_name}' references repository '{repo}' which is not listed in orgs.yml")
                             valid = False
 
         # rfc-0007-repository-ownership: a repo can't be owned by multiple WGs, scope is github org
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             repo_owners = {}
             for wg in self.working_groups[org]:
                 wg_name = wg["name"]
@@ -154,14 +154,14 @@ class OrgGenerator:
                 wg_repos = set(r for a in wg["areas"] for r in a["repositories"])
                 for repo in wg_repos:
                     repo_org = repo.split("/")[0]
-                    if repo_org != org and repo_org in OrgGenerator._MANAGED_ORGS:
+                    if repo_org != org and repo_org in OrgGenerator.MANAGED_ORGS:
                         print(
                             f"ERROR: Working Group '{wg_name}' assigned to Github org '{org}' contains repository '{repo}' from a different managed org."
                         )
                         valid = False
 
         # validate deploy_keys repos exist in WG areas
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             for wg in self.working_groups[org]:
                 wg_name = wg["name"]
                 wg_repos = {r for a in wg["areas"] for r in a["repositories"]}
@@ -184,14 +184,14 @@ class OrgGenerator:
         return result
 
     def generate_org_members(self):
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             org_members = set(self.org_cfg["orgs"][org]["members"])  # just in case, should be empty list
             org_members |= self.get_contributors(org)
             for wg in self.working_groups[org]:
                 org_members |= OrgGenerator._wg_github_users(wg)
             # wg-leads of all WGs shall be members in cloudfoundy org for access to community repo
             if org == self.toc_org:
-                for _org in OrgGenerator._MANAGED_ORGS:
+                for _org in OrgGenerator.MANAGED_ORGS:
                     for wg in self.working_groups[_org]:
                         org_members |= OrgGenerator._wg_github_users_leads(wg)
             org_admins = set(self.org_cfg["orgs"][org]["admins"])
@@ -207,7 +207,7 @@ class OrgGenerator:
         (name, team) = OrgGenerator._generate_toc_team(self.toc)
         self.org_cfg["orgs"][self.toc["org"]]["teams"][name] = team
         # wg teams for all orgs
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             # working group teams
             for wg in self.working_groups[org]:
                 if wg["org"] == org:
@@ -221,7 +221,7 @@ class OrgGenerator:
         # RFC-0005 lists community repo explicitly (not all TOC repos)
         self.org_cfg["orgs"][self.toc_org]["teams"]["wg-leads"]["repos"] = {"community": "write"}
         # wg leads of other orgs -> create extra wg-leads-<org> team in cloudfoundry org
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             if org != self.toc_org:
                 wg_leads_other_org = self.org_cfg["orgs"][org]["teams"]["wg-leads"]
                 team = {
@@ -235,7 +235,7 @@ class OrgGenerator:
     def generate_branch_protection(self):
         # basis is static config in self.branch_protection which is never overwritten
         # generate RFC0015 branch protection rules for every WG+TOC by default
-        for org in OrgGenerator._MANAGED_ORGS:
+        for org in OrgGenerator.MANAGED_ORGS:
             branch_protection_repos = self.branch_protection["branch-protection"]["orgs"][org]["repos"]
             wgs = self.working_groups[org]
             if org == self.toc["org"]:
@@ -246,17 +246,23 @@ class OrgGenerator:
                     if repo not in branch_protection_repos:
                         branch_protection_repos[repo] = repo_rules[repo]
 
-    def write_org_config(self, path: str):
+    def write_org_config(self, path: str, orgs: list[str] | None = None):
         p = Path(path)
         print(f"Writing org configuration to {p.absolute()}")
+        cfg = self.org_cfg if orgs is None else {"orgs": {org: self.org_cfg["orgs"][org] for org in orgs}}
         with open(p, "w") as stream:
-            return yaml.safe_dump(self.org_cfg, stream)
+            return yaml.safe_dump(cfg, stream)
 
-    def write_branch_protection(self, path: str):
+    def write_branch_protection(self, path: str, orgs: list[str] | None = None):
         p = Path(path)
         print(f"Writing branch protection to {p.absolute()}")
+        bp = (
+            self.branch_protection
+            if orgs is None
+            else {"branch-protection": {"orgs": {org: self.branch_protection["branch-protection"]["orgs"][org] for org in orgs}}}
+        )
         with open(p, "w") as stream:
-            return yaml.safe_dump(self.branch_protection, stream)
+            return yaml.safe_dump(bp, stream)
 
     @staticmethod
     def _yaml_load(stream: TextIO | str) -> dict[str, Any]:
@@ -342,8 +348,8 @@ class OrgGenerator:
         jsonschema.validate(contributors, OrgGenerator._CONTRIBUTORS_SCHEMA)
         # check that orgs are in _ORGS
         for org in contributors["orgs"]:
-            if org not in OrgGenerator._MANAGED_ORGS:
-                raise ValueError(f"Invalid org {org} in orgs.yml, expected one of {OrgGenerator._MANAGED_ORGS}")
+            if org not in OrgGenerator.MANAGED_ORGS:
+                raise ValueError(f"Invalid org {org} in orgs.yml, expected one of {OrgGenerator.MANAGED_ORGS}")
         return contributors
 
     _WG_SCHEMA = {
@@ -405,8 +411,8 @@ class OrgGenerator:
         # validate org and use 'cloudfoundry' if missing
         if "org" not in wg:
             wg["org"] = OrgGenerator._DEFAULT_ORG
-        if wg["org"] not in OrgGenerator._MANAGED_ORGS:
-            raise ValueError(f"Invalid org {wg['org']} in {wg['name']}, expected one of {OrgGenerator._MANAGED_ORGS}")
+        if wg["org"] not in OrgGenerator.MANAGED_ORGS:
+            raise ValueError(f"Invalid org {wg['org']} in {wg['name']}, expected one of {OrgGenerator.MANAGED_ORGS}")
         return wg
 
     # schema for referenced fields only, not for complete config
@@ -436,8 +442,8 @@ class OrgGenerator:
         jsonschema.validate(cfg, OrgGenerator._GITHUB_ORG_CFG_SCHEMA)
         # check that orgs are in _ORGS
         for org in cfg["orgs"]:
-            if org not in OrgGenerator._MANAGED_ORGS:
-                raise ValueError(f"Invalid org {org} in orgs.yml, expected one of {OrgGenerator._MANAGED_ORGS}")
+            if org not in OrgGenerator.MANAGED_ORGS:
+                raise ValueError(f"Invalid org {org} in orgs.yml, expected one of {OrgGenerator.MANAGED_ORGS}")
         return cfg
 
     # schema for referenced fields only, not for complete config
@@ -471,8 +477,8 @@ class OrgGenerator:
         jsonschema.validate(cfg, OrgGenerator._BRANCH_PROTECTION_SCHEMA)
         # check that orgs are in _ORGS
         for org in cfg["branch-protection"]["orgs"]:
-            if org not in OrgGenerator._MANAGED_ORGS:
-                raise ValueError(f"Invalid org {org} in branchprotection.yml, expected one of {OrgGenerator._MANAGED_ORGS}")
+            if org not in OrgGenerator.MANAGED_ORGS:
+                raise ValueError(f"Invalid org {org} in branchprotection.yml, expected one of {OrgGenerator.MANAGED_ORGS}")
         return cfg
 
     # https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0005-github-teams-and-access.md

--- a/orgs/org_management/test_org_management.py
+++ b/orgs/org_management/test_org_management.py
@@ -408,12 +408,12 @@ branch-protection:
 class TestOrgGenerator(unittest.TestCase):
     @override
     def setUp(self) -> None:
-        self._original_managed_orgs = OrgGenerator._MANAGED_ORGS  # pyright: ignore[reportUninitializedInstanceVariable]
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry"]
+        self._originalMANAGED_ORGS = OrgGenerator.MANAGED_ORGS  # pyright: ignore[reportUninitializedInstanceVariable]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry"]
 
     @override
     def tearDown(self) -> None:
-        OrgGenerator._MANAGED_ORGS = self._original_managed_orgs
+        OrgGenerator.MANAGED_ORGS = self._originalMANAGED_ORGS
 
     def test_empty_org(self):
         o = OrgGenerator()
@@ -469,7 +469,7 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertListEqual(["Contributor2", "contributor1"], o.org_cfg["orgs"]["cloudfoundry"]["members"])
 
     def test_org_members_multiple_orgs(self):
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         o = OrgGenerator(contributors=contributors_multiple_orgs, toc=toc, working_groups=[wg1, wg2, wg4_other_org])
         o.generate_org_members()
         # 2 contributors, 8 wg1, 3 wg2, 2 wg-leads of cloudfoundry2
@@ -523,7 +523,7 @@ class TestOrgGenerator(unittest.TestCase):
         # multiple orgs
         with self.assertRaises(ValueError):
             OrgGenerator._validate_contributors(OrgGenerator._yaml_load(contributors_multiple_orgs))
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         OrgGenerator._validate_contributors(OrgGenerator._yaml_load(contributors_multiple_orgs))
 
     def test_validate_wg(self):
@@ -563,7 +563,7 @@ class TestOrgGenerator(unittest.TestCase):
         # multiple orgs
         with self.assertRaises(ValueError):
             OrgGenerator._validate_wg(OrgGenerator._yaml_load(wg4_other_org))
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         wg = OrgGenerator._validate_wg(OrgGenerator._yaml_load(wg4_other_org))
         self.assertEqual("cloudfoundry2", wg["org"])
 
@@ -575,7 +575,7 @@ class TestOrgGenerator(unittest.TestCase):
         # multiple orgs
         with self.assertRaises(ValueError):
             OrgGenerator._validate_github_org_cfg(OrgGenerator._yaml_load(org_cfg_multiple))
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         OrgGenerator._validate_github_org_cfg(OrgGenerator._yaml_load(org_cfg_multiple))
 
     def test_kebab_case(self):
@@ -603,7 +603,7 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertFalse(o.validate_repo_ownership())
 
     def test_validate_repo_ownership_multiple_orgs(self):
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         o = OrgGenerator(static_org_cfg=org_cfg_multiple, toc=toc, working_groups=[wg1, wg4_other_org])
         self.assertTrue(o.validate_repo_ownership())
         # includes non-managed orgs
@@ -683,7 +683,7 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertNotIn("wg-wg2-name-area-1-bots", wg_team["teams"])
 
     def test_generate_wg_teams_multiple_orgs(self):
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         _wg4 = OrgGenerator._yaml_load(wg4_other_org)
         OrgGenerator._validate_wg(_wg4)
 
@@ -757,7 +757,7 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertIn("community", teams["wg-leads"]["repos"])
 
     def test_generate_teams_multiple_orgs(self):
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         o = OrgGenerator(
             static_org_cfg=org_cfg_multiple, contributors=contributors_multiple_orgs, toc=toc, working_groups=[wg1, wg2, wg4_other_org]
         )
@@ -835,7 +835,7 @@ class TestOrgGenerator(unittest.TestCase):
         # multiple orgs
         with self.assertRaises(ValueError):
             OrgGenerator._validate_branch_protection(OrgGenerator._yaml_load(branch_protection_multiple_orgs))
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         OrgGenerator._validate_branch_protection(OrgGenerator._yaml_load(branch_protection_multiple_orgs))
 
     def test_get_default_branch(self):
@@ -908,7 +908,7 @@ class TestOrgGenerator(unittest.TestCase):
         self.assertNotIn("required_pull_request_reviews", bp_repos["repo1"])
 
     def test_generate_branch_protection_multiple_orgs(self):
-        OrgGenerator._MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
+        OrgGenerator.MANAGED_ORGS = ["cloudfoundry", "cloudfoundry2"]
         o = OrgGenerator(
             static_org_cfg=org_cfg_multiple,
             toc=toc,
@@ -935,7 +935,7 @@ class TestOrgGenerator(unittest.TestCase):
 # integration test, depends on data in this repo which may change
 class TestOrgGeneratorIntegrationTest(unittest.TestCase):
     def test_cf_org(self):
-        self.assertEqual(["cloudfoundry", "concourse"], OrgGenerator._MANAGED_ORGS)
+        self.assertEqual(["cloudfoundry", "concourse"], OrgGenerator.MANAGED_ORGS)
 
         o = OrgGenerator()
         o.load_from_project()

--- a/orgs/readme.md
+++ b/orgs/readme.md
@@ -1,7 +1,5 @@
 # CFF Managed Github Orgs
 
-:construction: Multiple CFF Managed Github Orgs is work-in-progress. Currently, only the `cloudfoundry` org is supported as CFF Managed Github Org.
-
 The projects, teams and org membership in CFF Managed Github Orgs are maintained according to a number of [RFCs](https://github.com/cloudfoundry/community/tree/main/toc/rfc). The RFCs require PRs to one of the following files:
 
 - [orgs.yml](https://github.com/cloudfoundry/community/blob/main/orgs/orgs.yml) - static org configuration and projects
@@ -115,15 +113,16 @@ uv run python -m org_management.org_user_management --help
 Usage:
 ```
 $ uv run python -m org_management --help
-usage: org_management.py [-h] [-o OUT] [-b BRANCHPROTECTION]
+usage: python3 -m org_management [-h] [-o OUT] [-b BRANCHPROTECTION] [--org ORG]
 
-Cloud Foundry Org Generator
+CFF Managed Github Orgs Generator
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  -o OUT, --out OUT     output file for generated org configuration
-  -b BRANCHPROTECTION, --branchprotection BRANCHPROTECTION
+  -o, --out OUT         output file for generated org configuration
+  -b, --branchprotection BRANCHPROTECTION
                         output file for generated branch protection rules
+  --org ORG             limit output to this org (repeatable); default: all orgs
 ```
 
 ```


### PR DESCRIPTION
- work around the 6h job timeout for github actinos
- --org option for org_management (write out files for specified org only)
- org-management workflow split into org specific jobs
- jobs are serialized by a concurrency group to avoid github rate limits