### PR TITLE
Allow disabled policies for concourse resource repos

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -929,6 +929,7 @@ branch-protection:
 
         git-resource: &concourse-resource-repo
           protect: false
+          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           branches:
             master:
               protect: true


### PR DESCRIPTION
- branchprotector complains about missing allow_disabled_policies (should get inherited from org setting)