### PR TITLE
Requesting approval as a Docs Approver

### DIFF
--- a/toc/working-groups/docs.md
+++ b/toc/working-groups/docs.md
@@ -40,6 +40,8 @@ areas:
   approvers:
   - name: Anita Flegg
     github: anita-flegg
+  - name: Norman Abramovitz
+    github: norman-abramovitz
   repositories:
   - cloudfoundry/docs-book-cloudfoundry
   - cloudfoundry/docs-cf-admin


### PR DESCRIPTION
 @anita-flegg was looking for a new docs approver, since she is the last one left in the approvers group.  

Since August 2015, I have been involved with Cloud Foundry. I have been using the open source Cloud Foundry documentation all these years. Writing specifications and user documentation is a necessity for any project.

The Linux Foundation also allowed me, along with others, to create an introductory course about Cloud Foundry on the EDX platform around 2018 or 2019, which further reflects my experience with Cloud Foundry documentation and learning resources.

My goal is to ensure the documentation is clear, concise, and consistent by using writing assistants. This background supports my ability to serve as an approver.