### PR TITLE
Move allow_disabled_policies to global scope

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -1,6 +1,7 @@
 # doc: https://docs.prow.k8s.io/docs/components/optional/branchprotector/
 # https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0015-branch-protection.md
 branch-protection:
+  allow_disabled_policies: true  # needed to allow branches w/o branch protection
   orgs:
     cloudfoundry:
       repos:
@@ -11,7 +12,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: true
@@ -21,7 +21,6 @@ branch-protection:
           include: [ "^main$", "^v[0-9]*$"]
         cf-k8s-releases:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include: ["^main$"]
@@ -99,7 +98,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -112,7 +110,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -125,7 +122,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -138,7 +134,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -151,7 +146,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -164,7 +158,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           include: ["^master$"]
           required_status_checks:
             contexts: ["concourse-ci/unit-tests","concourse-ci/acceptance-tests"]
@@ -179,7 +172,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -192,7 +184,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -205,7 +196,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -218,7 +208,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           include: ["^main$"]
           required_status_checks:
             contexts: ["concourse-ci/unit-tests","concourse-ci/acceptance-tests"]
@@ -232,7 +221,6 @@ branch-protection:
         # CF-on-K8s
         k8s-garden-client:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include: ["^main$"]
@@ -250,7 +238,6 @@ branch-protection:
             required_approving_review_count: 1
         k8s-policy-agent:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include: ["^main$"]
@@ -268,7 +255,6 @@ branch-protection:
             required_approving_review_count: 1
         kind-deployment:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include: ["^main$"]
@@ -292,7 +278,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           include: ["^main$"]
           required_status_checks:
             contexts:
@@ -317,7 +302,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_status_checks:
             contexts:
             - "EasyCLA"
@@ -336,7 +320,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_status_checks:
             contexts:
             - "EasyCLA"
@@ -358,7 +341,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_status_checks:
             contexts:
             - "EasyCLA"
@@ -377,7 +359,6 @@ branch-protection:
           enforce_admins: false
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_status_checks:
             contexts:
             - "EasyCLA"
@@ -483,7 +464,6 @@ branch-protection:
 
         cnbapplifecycle:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include: ["^main$"]
@@ -506,7 +486,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: false
@@ -517,7 +496,6 @@ branch-protection:
 
         bosh-linux-stemcell-builder:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: false
           include:
@@ -537,7 +515,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -556,7 +533,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -575,7 +551,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -594,7 +569,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -613,7 +587,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -632,7 +605,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -651,7 +623,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -670,7 +641,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -689,7 +659,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -708,7 +677,6 @@ branch-protection:
           required_linear_history: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_status_checks:
             strict: true
             contexts:
@@ -724,7 +692,6 @@ branch-protection:
         uaa:
          protect: true
          allow_deletions: false
-         allow_disabled_policies: true
          allow_force_pushes: false
          enforce_admins: false
          include:
@@ -741,7 +708,6 @@ branch-protection:
         uaa-release:
          protect: true
          allow_deletions: false
-         allow_disabled_policies: true
          allow_force_pushes: false
          enforce_admins: false
          include:
@@ -757,7 +723,6 @@ branch-protection:
 
         storage-cli:
           allow_deletions: false
-          allow_disabled_policies: true
           allow_force_pushes: false
           enforce_admins: true
           include:
@@ -793,7 +758,6 @@ branch-protection:
       enforce_admins: false
       allow_force_pushes: false
       allow_deletions: false
-      allow_disabled_policies: true # needed to allow branches w/o branch protection
 
       repos:
         .github:
@@ -929,7 +893,6 @@ branch-protection:
 
         git-resource: &concourse-resource-repo
           protect: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           branches:
             master:
               protect: true

--- a/orgs/org_management/org_management.py
+++ b/orgs/org_management/org_management.py
@@ -595,7 +595,6 @@ class OrgGenerator:
                 "enforce_admins": repo not in deploy_key_repos,
                 "allow_force_pushes": False,
                 "allow_deletions": False,
-                "allow_disabled_policies": True,  # needed to allow branches w/o branch protection
                 "include": [f"^{self._get_default_branch(org, repo)}$", "^v[0-9]*$"],
                 "required_pull_request_reviews": {
                     "dismiss_stale_reviews": True,

--- a/orgs/readme.md
+++ b/orgs/readme.md
@@ -54,7 +54,6 @@ branch-protection:
           enforce_admins: true
           allow_force_pushes: false
           allow_deletions: false
-          allow_disabled_policies: true  # needed to allow branches w/o branch protection
           required_pull_request_reviews:
             dismiss_stale_reviews: true
             require_code_owner_reviews: true


### PR DESCRIPTION
prow branchprotector only reads allow_disabled_policies from the top-level BranchProtection struct; the field is not part of Policy and is silently ignored at org/repo level. Remove all per-org and per-repo occurrences and keep a single global entry so the branchprotector no longer rejects branches that have protect: false but inherit policy fields from a parent.