### PR TITLE
Add me as an approver

### DIFF
--- a/toc/ADMIN.md
+++ b/toc/ADMIN.md
@@ -90,6 +90,8 @@ areas:
     github: ragaskar
   - name: Duane May
     github: duanemay
+  - name: Amin Jamali
+    github: winkingturtle-vmw
   bots:
   - name: CF CLI Eng
     github: cf-cli-eng


### PR DESCRIPTION
I would like to become an approver for `github.com/cloudfoundry/go-fetcher`. We use `code.cloudfoundry.org` as part of CloudFoundry runtime team, but no one on our team has the ability to approve PRs. 