### PR TITLE
Add cf-mgmt to Stratos area in ARI WG

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2444,6 +2444,9 @@ orgs:
         description: Custom buildpack Stratos (UI for Cloud Foundry)
         default_branch: develop
         has_projects: true
+      cf-mgmt:
+        description: A tool to manage Cloud Foundry orgs and spaces
+        has_projects: true
       summit-hands-on-labs:
         description: Hands-on Labs for CF Summit Boston '18 and beyond
         has_projects: true

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -380,6 +380,8 @@ areas:
     github: norman-abramovitz
   - name: Ioannis Tsouvalas
     github: itsouvalas
+  - name: Ruben Koster
+    github: rkoster
   reviewers:
   - name: Tristan Poland
     github: tristanpoland
@@ -393,4 +395,5 @@ areas:
   repositories:
   - cloudfoundry/stratos
   - cloudfoundry/stratos-buildpack
+  - cloudfoundry/cf-mgmt
 ```


### PR DESCRIPTION
Adds `cloudfoundry/cf-mgmt` to the Stratos Console for Cloud Foundry area in the App Runtime Interfaces working group, and adds `rkoster` as an approver.

The repo will be forked/transferred to the `cloudfoundry` org after this PR is merged.

Closes #1603