### PR TITLE
Archive cf-openapi repo

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -390,8 +390,6 @@ branch-protection:
           protect: false
         capi-env-pool:
           protect: false
-        cf-openapi:
-          protect: false
 
         # CLI
         CLAW:

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -669,6 +669,7 @@ orgs:
         has_projects: true
         private: true
       cf-openapi:
+        archived: true
         default_branch: main
         description: OpenAPI specification for the Cloud Foundry API.
         has_projects: true

--- a/toc/working-groups/app-runtime-interfaces.md
+++ b/toc/working-groups/app-runtime-interfaces.md
@@ -229,7 +229,6 @@ areas:
   - cloudfoundry/app-runtime-interfaces-infrastructure
   - cloudfoundry/servicebroker
   - cloudfoundry/osb-checker
-  - cloudfoundry/cf-openapi
 
 - name: CLI
   approvers:


### PR DESCRIPTION
CF API openapi spec is now maintained in the cloud_controller_ng repo.