### PR TITLE
Add temp-ari-stratos-admins team

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2837,6 +2837,16 @@ orgs:
         privacy: closed
         repos:
           terraform-provider-cloudfoundry: admin
+      temp-ari-stratos-admins:
+        description: "Temporary team for managing Stratos secrets and packages until we have a permanent plan."
+        maintainers:
+          - norman-abramovitz
+          - krutten
+          - wayneeseguin
+        members: []
+        privacy: closed
+        repos:
+          stratos: admin
   concourse:
     admins: [] # shall be empty, maintained in TOC.md
     billing_email: team@concourse-ci.org


### PR DESCRIPTION
Follows up #1602, which asked for workflows in `cloudfoundry/stratos` to be able to write the `ghcr.io/cloudfoundry/stratos` package.

Per @stephanme's proposal in https://github.com/cloudfoundry/community/issues/1602#issuecomment-5254809622, confirmed by @beyhan after the TOC meeting on 2026-09-01, this adds a temporary admin team for the area rather than granting package permissions directly. It follows the `temp-ari-buildpacks-admins` pattern already in this file.

Maintainers are approvers for the Stratos area.

### Why this is needed

The **Build All-in-One Image** job in the Stratos release workflow has failed with `denied: permission_denied: write_package` on every release since v5.1.0 — five consecutive releases, most recently v5.5.2 today. The release itself completes and its 9 assets publish correctly, so the only symptom is that each run's conclusion reads `failure` and the AIO image never reaches the registry. Repo admin lets the area configure the package's write permissions and clear that.

Tracked on the Stratos side as cloudfoundry/stratos#5763.