### PR TITLE
Archive Korifi repositories

### DIFF
--- a/orgs/branchprotection.yml
+++ b/orgs/branchprotection.yml
@@ -274,27 +274,7 @@ branch-protection:
         cf-k8s-secrets:
           protect: false
         korifi:
-          protect: true
-          enforce_admins: true
-          allow_force_pushes: false
-          allow_deletions: false
-          include: ["^main$"]
-          required_status_checks:
-            contexts:
-              - "api-tests"
-              - "controllers-tests"
-              - "linter"
-              - "job-task-runner-tests"
-              - "kpack-image-builder-tests"
-              - "statefulset-runner-tests"
-              - "tools-tests"
-              - "Concourse / e2e-tests (pull_request)"
-              - "Concourse / e2e-eks-tests (pull_request)"
-              - "EasyCLA"
-          required_pull_request_reviews:
-            dismiss_stale_reviews: true
-            require_code_owner_reviews: true
-            required_approving_review_count: 1
+          protect: false
 
         # App-Autoscaler
         app-autoscaler-release:

--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -665,6 +665,7 @@ orgs:
         has_projects: false
         has_wiki: false
       cf-k8s-secrets:
+        archived: true
         default_branch: main
         has_projects: true
         private: true
@@ -1606,6 +1607,7 @@ orgs:
         has_projects: true
         archived: true
       intro-to-korifi:
+        archived: true
         default_branch: main
         description: An introduction to the Korifi project
         has_projects: false
@@ -1720,16 +1722,20 @@ orgs:
         has_projects: false
         has_wiki: false
       korifi:
+        archived: true
         default_branch: main
         description: Cloud Foundry on Kubernetes
         has_projects: true
       korifi-ci:
+        archived: true
         default_branch: main
         has_projects: true
       korifi-website:
+        archived: true
         default_branch: main
         has_projects: false
       korifi-sample-app:
+        archived: true
         default_branch: main
         description: A sample application used in the Korifi tutorial
         has_projects: false


### PR DESCRIPTION
The CF-on-K8S WG is being archived, see [RFC-0060](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0060-archive-cf-on-k8s-wg.md)

As part of this activity, korifi repositories should be archived.