### PR TITLE
Use GitHub App token and matrix per org in remove-individual-access w…

### DIFF
--- a/.github/workflows/remove-individual-access.yml
+++ b/.github/workflows/remove-individual-access.yml
@@ -5,24 +5,35 @@ on:
       - main
   schedule:
   - cron: '0 */1 * * *'
+  workflow_dispatch:
 
 jobs:
   remove-individual-access-to-repos:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        org: [cloudfoundry, concourse]
     steps:
       - uses: actions/checkout@v7
         with:
           path: community
       - name: Install yq
         run: sudo wget https://oauth2:${{ secrets.GITHUB_TOKEN }}@github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq -q && sudo chmod +x /usr/bin/yq
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_PRIVATE_KEY }}
+          owner: ${{ matrix.org }}
       - name: Remove individual access to repos
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           set -o pipefail
 
-          ./community/toc/working-groups/parsable-working-groups.sh | jq -r '.[].areas[].repositories[]' | grep -E '^(cloudfoundry|concourse)/' | while read -r repo; do
+          ./community/toc/working-groups/parsable-working-groups.sh | jq -r '.[].areas[].repositories[]' | grep -E '^${{ matrix.org }}/' | while read -r repo; do
               gh api "repos/${repo}/collaborators?affiliation=direct" | jq -r '.[].login' | while read -r user; do
                   echo "remove ${user} from ${repo}"
                   gh api -X delete "/repos/${repo}/collaborators/${user}"


### PR DESCRIPTION
…orkflow

- secrets.GH_TOKEN is only good for cloudfoundry org -> cleanup fails on first concourse repo
- GH_APP_ID is registered for concourse org as well (used by org-management workflow)