### PR TITLE
Add Cloud Foundry skills repository to Agentic Runtime

### DIFF
--- a/orgs/orgs.yml
+++ b/orgs/orgs.yml
@@ -2376,6 +2376,10 @@ orgs:
       sipid:
         archived: true
         has_projects: true
+      skills:
+        description: Portable Agent Skills for Cloud Foundry AI coding agents
+        default_branch: main
+        has_projects: false
       slack-interrupt-bot:
         has_projects: false
         has_wiki: false

--- a/toc/working-groups/agentic-runtime.md
+++ b/toc/working-groups/agentic-runtime.md
@@ -77,4 +77,5 @@ areas:
     github: al-gerd
   repositories:
   - cloudfoundry/agentic-runtime-notes
+  - cloudfoundry/skills
 ```


### PR DESCRIPTION
Create `cloudfoundry/skills` for portable Agent Skills used with Cloud Foundry AI coding agents.

The initial skill, `cf-kind-verify`, verifies a Cloud Foundry component change against a local cf-on-kind cluster. Skills use the Agent Skills `SKILL.md` standard and support multiple harnesses, including OpenCode, Claude Code, GitHub Copilot, Cursor, and Codex.

The Agentic Runtime working group will own the repository.